### PR TITLE
Add dart code builder

### DIFF
--- a/packages/compiler_dart/lib/src/builtins.dart
+++ b/packages/compiler_dart/lib/src/builtins.dart
@@ -162,20 +162,20 @@ class DartBuiltinCompiler extends BuiltinCompiler<dart.Spec> {
         ..body = compileBody(context, id).value);
     });
 
-    final t = dart.refer('T');
-    final arrayT = dart.refer('Array<T>');
-    final listT = dart.TypeReference((b) => b
+    final item = dart.refer('Item');
+    final arrayItem = dart.refer('Array<Item>');
+    final listItem = dart.TypeReference((b) => b
       ..symbol = 'List'
       ..url = dartCoreUrl
-      ..types.add(t));
+      ..types.add(item));
     return [
       dart.Class((b) => b
         ..annotations.add(dart.refer('sealed', packageMetaUrl))
         ..name = 'Array'
-        ..types.add(t)
+        ..types.add(item)
         ..fields.add(dart.Field((b) => b
           ..name = 'value'
-          ..type = listT))
+          ..type = listItem))
         ..mixins.addAll(traits.map((it) {
           final type = compileType(context, it);
           return dart.TypeReference((b) => b
@@ -191,8 +191,8 @@ class DartBuiltinCompiler extends BuiltinCompiler<dart.Spec> {
           dart.Method((b) => b
             ..name = 'generate'
             ..static = true
-            ..types.add(t)
-            ..returns = arrayT
+            ..types.add(item)
+            ..returns = arrayItem
             ..requiredParameters.addAll([
               dart.Parameter((b) => b
                 ..name = 'length'
@@ -201,10 +201,10 @@ class DartBuiltinCompiler extends BuiltinCompiler<dart.Spec> {
                 ..name = 'generator'
                 ..type = dart.FunctionType((b) => b
                   ..requiredParameters.add(compileType(context, CandyType.int))
-                  ..returnType = t)),
+                  ..returnType = item)),
             ])
-            ..body = arrayT.call([
-              listT.property('generate').call([
+            ..body = arrayItem.call([
+              listItem.property('generate').call([
                 dart.refer('length.value'),
                 // The Dart code generator doesn't support lambdas, so we do an ugly workaround.
                 dart.Method((b) => b
@@ -224,7 +224,7 @@ class DartBuiltinCompiler extends BuiltinCompiler<dart.Spec> {
             ..requiredParameters.add(dart.Parameter((b) => b
               ..name = 'index'
               ..type = compileType(context, CandyType.int)))
-            ..returns = t
+            ..returns = item
             ..body = dart.refer('value').index(dart.refer('index.value')).code),
           dart.Method((b) => b
             ..name = 'set'
@@ -234,9 +234,9 @@ class DartBuiltinCompiler extends BuiltinCompiler<dart.Spec> {
                 ..type = compileType(context, CandyType.int)),
               dart.Parameter((b) => b
                 ..name = 'item'
-                ..type = t),
+                ..type = item),
             ])
-            ..returns = t
+            ..returns = item
             ..body = dart
                 .refer('value')
                 .index(dart.refer('index.value'))

--- a/packages/core/src/collections/array.candy
+++ b/packages/core/src/collections/array.candy
@@ -1,5 +1,6 @@
 use ...numbers
 use ..iterable
+use ..list
 
 public builtin class Array<Item> {
   /// A structure that holds a fixed number of `Item`s.
@@ -19,6 +20,16 @@ public builtin class Array<Item> {
 
   public fun get(index: Int /* UInt */): Item
   public fun set(index: Int /* UInt */, item: Item)
+
+  public fun toList(): List<Item> {
+    let list = MutableList.empty<Item>()
+    mut let i = 0
+    while i < length() {
+      list.append(get(i))
+      i = i + 1
+    }
+    list
+  }
 }
 
 // TODO(marcelgarus): Make `Array` `Iterable`, this clashes with `Iterable.get`, which should return

--- a/packages/core/src/collections/iterable.candy
+++ b/packages/core/src/collections/iterable.candy
@@ -248,8 +248,12 @@ public trait Iterable<Item> {
 
   fun join(separator: String): String {
     mut let s = ""
+    mut let isFirst = true
+
     for item in this {
-      if !(s == "") {
+      if isFirst {
+        isFirst = false
+      } else {
         s = "{s}{separator}"
       }
       s = "{s}{item}"

--- a/packages/core/src/collections/iterable.candy
+++ b/packages/core/src/collections/iterable.candy
@@ -2,6 +2,7 @@ use ...bool
 use ...operators
 use ...maybe
 use ...numbers
+use ...string
 use ...todo
 use ..list
 
@@ -209,6 +210,10 @@ public trait Iterable<Item> {
   // TODO(marcelgarus): reversed
   // TODO(marcelgarus): zip
 
+  fun followedBy(other: Iterable<Item>): Iterable<Item> {
+    FollowedByIterable<Item>(this, other)
+  }
+
   // Conversions.
 
   fun toList(): List<Item> {
@@ -240,6 +245,17 @@ public trait Iterable<Item> {
   // TODO(marcelgarus): for Iterable<Iterable<T>>: flatten
   // TODO(marcelgarus): for Iterable<Number>: average, sum, min, max, minBy, maxBy
   // TODO(marcelgarus): for Iterable<Maybe<T>>: whereSome, unwrapAll
+
+  fun join(separator: String): String {
+    mut let s = ""
+    for item in this {
+      if !(s == "") {
+        s = "{s}{separator}"
+      }
+      s = "{s}{item}"
+    }
+    s
+  }
 }
 
 class MappedIterable<In, Out> {
@@ -288,6 +304,29 @@ impl<Item> WhereIterator<Item>: Iterator<Item> {
         }
       }
     }
+  }
+}
+
+class FollowedByIterable<Item> {
+  let parent: Iterable<Item>
+  let following: Iterable<Item>
+}
+impl<Item> FollowedByIterable<Item>: Iterable<Item> {
+  fun iterator(): Iterator<Item> {
+    FollowedByIterator<Item>(parent.iterator(), following.iterator())
+  }
+}
+class FollowedByIterator<Item> {
+  let parent: Iterator<Item>
+  let following: Iterator<Item>
+}
+impl<Item> FollowedByIterator<Item>: Iterator<Item> {
+  fun next(): Maybe<Item> {
+    let a = parent.next()
+    if a is Some {
+      return a
+    }
+    following.next()
   }
 }
 

--- a/packages/core/src/collections/list/module.candy
+++ b/packages/core/src/collections/list/module.candy
@@ -47,24 +47,6 @@ public trait List<Item>: Iterable<Item> {
     }
     result
   }
-
-  fun followedBy(other: List<Item>): List<Item> {
-    let resultLength = length() + (other as Iterable<Item>).length()
-    let result = ArrayList.create<Item>(resultLength)
-
-    mut let index = 0
-    while index < length() {
-      (result as MutableList<Item>).append(get(index).unwrap() as Item)
-      index = index + 1
-    }
-
-    mut let index = 0
-    while index < (other as Iterable<Item>).length() {
-      (result as MutableList<Item>).append((other as Iterable<Item>).get(index).unwrap() as Item)
-      index = index + 1
-    }
-    result
-  }
 }
 
 public trait MutableList<Item>: List<Item> {

--- a/packages/core/src/collections/list/module.candy
+++ b/packages/core/src/collections/list/module.candy
@@ -48,7 +48,7 @@ public trait List<Item>: Iterable<Item> {
     result
   }
 
-  fun followedBy(other: List<Item>): List<Item> {
+  fun followedByList(other: List<Item>): List<Item> {
     let resultLength = length() + (other as Iterable<Item>).length()
     let result = ArrayList.create<Item>(resultLength)
 

--- a/packages/core/src/collections/list/module.candy
+++ b/packages/core/src/collections/list/module.candy
@@ -47,6 +47,24 @@ public trait List<Item>: Iterable<Item> {
     }
     result
   }
+
+  fun followedBy(other: List<Item>): List<Item> {
+    let resultLength = length() + (other as Iterable<Item>).length()
+    let result = ArrayList.create<Item>(resultLength)
+
+    mut let index = 0
+    while index < length() {
+      (result as MutableList<Item>).append(get(index).unwrap() as Item)
+      index = index + 1
+    }
+
+    mut let index = 0
+    while index < (other as Iterable<Item>).length() {
+      (result as MutableList<Item>).append((other as Iterable<Item>).get(index).unwrap() as Item)
+      index = index + 1
+    }
+    result
+  }
 }
 
 public trait MutableList<Item>: List<Item> {

--- a/packages/core/src/collections/map/bucket_map.candy
+++ b/packages/core/src/collections/map/bucket_map.candy
@@ -6,6 +6,7 @@ use ....operators
 use ....todo
 use ...array
 use ...iterable
+use ...list
 use ...map
 use ..linked_hash_map
 
@@ -32,7 +33,13 @@ impl<Key: Equals & Hash, Value> BucketMap<Key, Value>: Map<Key, Value> {
   fun get(key: Key): Maybe<Value> { bucketByKey(key).get(key) }
 
   fun entries(): Iterable<(Key, Value)> {
-    todo("Implement BucketMap.entries")
+    let list = MutableList.empty<(Key, Value)>()
+    for bucket in buckets.toList() {
+      for entry in bucket.entries() {
+        list.append(entry)
+      }
+    }
+    list as Iterable<(Key, Value)>
   }
 }
 impl<Key: Equals & Hash, Value> BucketMap<Key, Value>: MutableMap<Key, Value> {

--- a/packages/core/src/collections/map/linked_hash_map.candy
+++ b/packages/core/src/collections/map/linked_hash_map.candy
@@ -17,9 +17,11 @@ class LinkedHashMap<Key: Equals & Hash, Value> {
   /// An inefficient "mini-map" (it's typically pretty small).
 
   static fun empty<Key: Equals & Hash, Value>(): LinkedHashMap<Key, Value> {
-    LinkedHashMap<Key, Value>(MutableList.empty<MapEntry<Key, Value>>())
+    LinkedHashMap<Key, Value>(
+      MutableList.empty<MapEntry<Key, Value>>()
+    )
   }
-  
+
   let entries_: MutableList<MapEntry<Key, Value>>
 
   fun entryForKey(key: Key): Maybe<MapEntry<Key, Value>> {

--- a/packages/dart_code_builder/candyspec.yml
+++ b/packages/dart_code_builder/candyspec.yml
@@ -1,0 +1,1 @@
+name: dart_code_builder

--- a/packages/dart_code_builder/src/example.candy
+++ b/packages/dart_code_builder/src/example.candy
@@ -102,15 +102,15 @@ fun main() {
             Identifier("value", None<String>()),
             then = List.of1<Statement>(
               ExpressionStatement(Assignment(
-                Identifier("left", None<String>()),
+                Identifier("length", None<String>()),
                 Literal(0),
               )),
             ),
             else_ = List.of1<Statement>(
-              ExpressionStatement(Identifier("left", None<String>()).call(
-                List.of1<Expression>(Literal(1)),
+              ExpressionStatement(Identifier("length", None<String>()).dot("someCall").call(
+                List.of2<Expression>(Literal(1), Literal(2)),
                 Map.empty<String, Expression>(),
-                List.empty<DartType>(),
+                List.of1<DartType>(UserType("bool", List.empty<DartType>(), None<String>())),
               )),
             ),
           ),

--- a/packages/dart_code_builder/src/example.candy
+++ b/packages/dart_code_builder/src/example.candy
@@ -20,7 +20,7 @@ fun main() {
     "main",
     annotations = List.of1<Annotation>(
       Annotation(
-        (UserType(
+        (NamedType(
           "Cached",
           parameters = List.empty<DartType>(),
           prefix = None<String>(),
@@ -31,7 +31,7 @@ fun main() {
         )
       )
     ),
-    _returns = Some<DartType>(UserType(
+    _returns = Some<DartType>(NamedType(
       "Foo",
       parameters = List.empty<DartType>(),
       prefix = Some<String>("foo"),
@@ -39,10 +39,10 @@ fun main() {
     requiredParameters = List.of1<Parameter>(
       Parameter(
         "args",
-        type = Some<DartType>(UserType(
+        type = Some<DartType>(NamedType(
           "List",
           parameters = List.of1<DartType>(
-            UserType("String", parameters = List.empty<DartType>(), prefix = None<String>())
+            NamedType("String", parameters = List.empty<DartType>(), prefix = None<String>())
           ),
           prefix = None<String>(),
         )),
@@ -52,7 +52,7 @@ fun main() {
     positionalParameters = List.of1<Parameter>(
       Parameter(
         "number",
-        type = Some<DartType>(UserType("int", List.empty<DartType>(), None<String>())),
+        type = Some<DartType>(NamedType("int", List.empty<DartType>(), None<String>())),
         default = Some<Expression>(Literal(123)),
       ),
     ),
@@ -68,15 +68,15 @@ fun main() {
   list.append(Class(
     "Foo",
     annotations = List.of1<Annotation>(Annotation(Identifier("data", prefix = None<String>()))),
-    extends_ = Some<DartType>(UserType("Bar", List.empty<DartType>(), None<String>())),
+    extends_ = Some<DartType>(NamedType("Bar", List.empty<DartType>(), None<String>())),
     implements_ = List.of3<DartType>(
-      UserType("Baz", List.empty<DartType>(), None<String>()),
-      UserType("Wheez", List.empty<DartType>(), None<String>()),
-      UserType("Fnop", List.empty<DartType>(), None<String>()),
+      NamedType("Baz", List.empty<DartType>(), None<String>()),
+      NamedType("Wheez", List.empty<DartType>(), None<String>()),
+      NamedType("Fnop", List.empty<DartType>(), None<String>()),
     ),
     with_ = List.of2<DartType>(
-      UserType("Whup", List.empty<DartType>(), None<String>()),
-      UserType("Flang", List.empty<DartType>(), None<String>()),
+      NamedType("Whup", List.empty<DartType>(), None<String>()),
+      NamedType("Flang", List.empty<DartType>(), None<String>()),
     ),
     body = List.of4<Field | Getter | Setter | Function>(
       // static const numBlubs = 123;
@@ -84,7 +84,7 @@ fun main() {
       // bool get isEmpty => this.length == 0;
       Getter(
         "isEmpty",
-        type = UserType("bool", List.empty<DartType>(), None<String>()),
+        type = NamedType("bool", List.empty<DartType>(), None<String>()),
         body = Some<Body>(InlineBody(this_.dot("length").equals(Literal(0)))),
       ),
       // set isEmpty(bool value) {
@@ -98,7 +98,7 @@ fun main() {
         "isEmpty",
         parameter = Parameter(
           "value",
-          type = Some<DartType>(UserType("bool", List.empty<DartType>(), None<String>())),
+          type = Some<DartType>(NamedType("bool", List.empty<DartType>(), None<String>())),
           defaultValue = None<Expression>(),
         ),
         body = Some<Body>(BlockBody(List.of1<Statement>(
@@ -111,7 +111,7 @@ fun main() {
               ExpressionStatement(Identifier("length", None<String>()).dot("someCall").call(
                 List.of2<Expression>(Literal(1), Literal(2)),
                 Map.empty<String, Expression>(),
-                List.of1<DartType>(UserType("bool", List.empty<DartType>(), None<String>())),
+                List.of1<DartType>(NamedType("bool", List.empty<DartType>(), None<String>())),
               )),
             ),
           ),
@@ -120,12 +120,12 @@ fun main() {
       Function(
         "blub",
         annotations = List.empty<Annotation>(),
-        _returns = Some<DartType>(UserType("Blub", List.empty<DartType>(), None<String>())),
+        _returns = Some<DartType>(NamedType("Blub", List.empty<DartType>(), None<String>())),
         requiredParameters = List.empty<Parameter>(),
         positionalParameters = List.empty<Parameter>(),
         namedParameters = List.of1<Parameter>(Parameter(
           "blub",
-          Some<DartType>(UserType("int", List.empty<DartType>(), prefix = None<String>())),
+          Some<DartType>(NamedType("int", List.empty<DartType>(), prefix = None<String>())),
           defaultValue = None<Expression>(),
         )),
         body = None<Body>(),

--- a/packages/dart_code_builder/src/example.candy
+++ b/packages/dart_code_builder/src/example.candy
@@ -1,137 +1,186 @@
 use ..nodes
+use ..to_code
 
 fun main() {
-  let list = MutableList.empty<Directive | Declaration>()
-  list.append(Import(
-    "package:foo/foo.dart",
-    prefix = Some<String>("foo"),
-    show = List.empty<String>(),
-    hide = List.of1<String>("bar"),
-  ))
-  list.append(Import(
-    "dart:blub",
-    prefix = None<String>(),
-    show = List.of1<String>("blubber"),
-    hide = List.empty<String>(),
-  ))
-  list.append(Part("test.dart"))
-  list.append(PartOf("meow.dart"))
-  list.append(Function(
-    "main",
-    annotations = List.of1<Annotation>(
-      Annotation(
-        (NamedType(
-          "Cached",
-          typeArguments = List.empty<DartType>(),
-          prefix = None<String>(),
-        ) as Expression).call(
-          positionalArguments = List.empty<Expression>(),
-          namedArguments = Map.empty<String, Expression>(),
-          typeArguments = List.empty<DartType>(),
-        )
-      )
-    ),
-    _returns = Some<DartType>(NamedType(
-      "Foo",
-      typeArguments = List.empty<DartType>(),
-      prefix = Some<String>("foo"),
-    )),
-    requiredParameters = List.of1<Parameter>(
-      Parameter(
-        "args",
-        type = Some<DartType>(NamedType(
-          "List",
-          typeArguments = List.of1<DartType>(
-            NamedType("String", typeArguments = List.empty<DartType>(), prefix = None<String>())
-          ),
-          prefix = None<String>(),
-        )),
-        defaultValue = None<Expression>(),
+  let compilationUnit = CompilationUnit(
+    directives = List.of4<Directive>(
+      Import(
+        "package:foo/foo.dart",
+        prefix = Some<String>("foo"),
+        show = List.empty<String>(),
+        hide = List.of1<String>("bar"),
       ),
-    ),
-    positionalParameters = List.of1<Parameter>(
-      Parameter(
-        "number",
-        type = Some<DartType>(NamedType("int", List.empty<DartType>(), None<String>())),
-        default = Some<Expression>(Literal(123)),
+      Import(
+        "dart:blub",
+        prefix = None<String>(),
+        show = List.of1<String>("blubber"),
+        hide = List.empty<String>(),
       ),
+      Part("test.dart"),
+      PartOf("meow.dart"),
     ),
-    namedParameters = List.empty<Parameter>(),
-    body = Some<Body>(BlockBody(List.of1<Statement>(
-      While(
-        condition = Literal(true),
-        label = Some<String>("foo"),
-        body = List.of1<Statement>(Break(label = Some<String>("foo"))),
-      ),
-    ))),
-  ))
-  list.append(Class(
-    "Foo",
-    annotations = List.of1<Annotation>(Annotation(Identifier("data", prefix = None<String>()))),
-    extends_ = Some<DartType>(NamedType("Bar", List.empty<DartType>(), None<String>())),
-    implements_ = List.of3<DartType>(
-      NamedType("Baz", List.empty<DartType>(), None<String>()),
-      NamedType("Wheez", List.empty<DartType>(), None<String>()),
-      NamedType("Fnop", List.empty<DartType>(), None<String>()),
-    ),
-    with_ = List.of2<DartType>(
-      NamedType("Whup", List.empty<DartType>(), None<String>()),
-      NamedType("Flang", List.empty<DartType>(), None<String>()),
-    ),
-    body = List.of4<Field | Getter | Setter | Function>(
-      // static const numBlubs = 123;
-      Field("numBlubs", isStatic = true, mutability = Const(), Some<Expression>(Literal(123))),
-      // bool get isEmpty => this.length == 0;
-      Getter(
-        "isEmpty",
-        type = NamedType("bool", List.empty<DartType>(), None<String>()),
-        body = Some<Body>(InlineBody(this_.dot("length").equals(Literal(0)))),
-      ),
-      // set isEmpty(bool value) {
-      //   if (value) {
-      //     length = 0;
-      //   } else {
-      //     add(1);
-      //   }
-      // }
-      Setter(
-        "isEmpty",
-        parameter = Parameter(
-          "value",
-          type = Some<DartType>(NamedType("bool", List.empty<DartType>(), None<String>())),
-          defaultValue = None<Expression>(),
-        ),
-        body = Some<Body>(BlockBody(List.of1<Statement>(
-          If(
-            Identifier("value", None<String>()),
-            then = List.of1<Statement>(
-              ExpressionStatement(Assignment(Identifier("length", None<String>()), Literal(0))),
-            ),
-            else_ = List.of1<Statement>(
-              ExpressionStatement(Identifier("length", None<String>()).dot("someCall").call(
-                List.of2<Expression>(Literal(1), Literal(2)),
-                Map.empty<String, Expression>(),
-                List.of1<DartType>(NamedType("bool", List.empty<DartType>(), None<String>())),
-              )),
-            ),
-          ),
-        ))),
-      ),
+    declarations = List.of2<Declaration>(
       Function(
-        "blub",
-        annotations = List.empty<Annotation>(),
-        _returns = Some<DartType>(NamedType("Blub", List.empty<DartType>(), None<String>())),
-        requiredParameters = List.empty<Parameter>(),
-        positionalParameters = List.empty<Parameter>(),
-        namedParameters = List.of1<Parameter>(Parameter(
-          "blub",
-          Some<DartType>(NamedType("int", List.empty<DartType>(), prefix = None<String>())),
-          defaultValue = None<Expression>(),
-        )),
-        body = None<Body>(),
+        "main",
+        annotations = List.of1<Annotation>(
+          Annotation(
+            (NamedType(
+              Identifier("Cached", prefix = None<String>()),
+              typeArguments = List.empty<DartType>(),
+            ) as Expression).call(
+              positionalArguments = List.empty<Expression>(),
+              namedArguments = Map.empty<String, Expression>(),
+              typeArguments = List.empty<DartType>(),
+            ),
+          ),
+        ),
+        _returns = Some<DartType>(
+          NamedType(
+            Identifier("Foo", prefix = Some<String>("foo")),
+            typeArguments = List.empty<DartType>(),
+          ),
+        ),
+        requiredParameters = List.of1<Parameter>(
+          Parameter(
+            "args",
+            type = Some<DartType>(
+              NamedType(
+                Identifier("List", prefix = None<String>()),
+                typeArguments = List.of1<DartType>(
+                  NamedType(
+                    Identifier("String", prefix = None<String>()),
+                    typeArguments = List.empty<DartType>(),
+                  )
+                ),
+              ),
+            ),
+            defaultValue = None<Expression>(),
+          ),
+        ),
+        positionalParameters = List.of1<Parameter>(
+          Parameter(
+            "number",
+            type = Some<DartType>(
+              NamedType(Identifier("int", None<String>()), List.empty<DartType>()),
+            ),
+            default = Some<Expression>(IntLiteral(123)),
+          ),
+        ),
+        namedParameters = List.empty<Parameter>(),
+        body = Some<Body>(
+          Block(
+            List.of1<Statement>(
+              While(
+                condition = BoolLiteral(true),
+                label = Some<String>("foo"),
+                body = Block(List.of1<Statement>(Break(label = Some<String>("foo")))),
+              ),
+            ),
+          ),
+        ),
+      ),
+      Class(
+        "Foo",
+        annotations = List.of1<Annotation>(Annotation(Identifier("data", prefix = None<String>()))),
+        extends_ = Some<DartType>(
+          NamedType(Identifier("Bar", None<String>()), List.empty<DartType>()),
+        ),
+        implements_ = List.of3<DartType>(
+          NamedType(Identifier("Baz", None<String>()), List.empty<DartType>()),
+          NamedType(Identifier("Wheez", None<String>()), List.empty<DartType>()),
+          NamedType(Identifier("Fnop", None<String>()), List.empty<DartType>()),
+        ),
+        with_ = List.of2<DartType>(
+          NamedType(Identifier("Whup", None<String>()), List.empty<DartType>()),
+          NamedType(Identifier("Flang", None<String>()), List.empty<DartType>()),
+        ),
+        body = List.of4<Field | Getter | Setter | Function>(
+          // static const numBlubs = 123;
+          Field(
+            "numBlubs",
+            isStatic = true,
+            mutability = Const(),
+            initialValue = Some<Expression>(IntLiteral(123)),
+          ),
+          // bool get isEmpty => this.length == 0;
+          Getter(
+            "isEmpty",
+            type = NamedType(Identifier("bool", None<String>()), List.empty<DartType>()),
+            body = Some<Body>(InlineBody(this_.dot("length").equals(IntLiteral(0)))),
+          ),
+          // set isEmpty(bool value) {
+          //   if (value) {
+          //     length = 0;
+          //   } else {
+          //     add(1);
+          //   }
+          // }
+          Setter(
+            "isEmpty",
+            parameter = Parameter(
+              "value",
+              type = Some<DartType>(
+                NamedType(Identifier("bool", None<String>()), List.empty<DartType>()),
+              ),
+              defaultValue = None<Expression>(),
+            ),
+            body = Some<Body>(
+              Block(
+                List.of1<Statement>(
+                  If(
+                    Identifier("value", None<String>()),
+                    then = Block(
+                      List.of1<Statement>(
+                        ExpressionStatement(
+                          Assignment(Identifier("length", None<String>()), IntLiteral(0)),
+                        ),
+                      ),
+                    ),
+                    else_ = Some<Statement>(
+                      Block(
+                        List.of1<Statement>(
+                          ExpressionStatement(
+                            Identifier("length", None<String>()).dot("someCall").call(
+                              List.of2<Expression>(IntLiteral(1), IntLiteral(2)),
+                              Map.empty<String, Expression>(),
+                              List.of1<DartType>(
+                                NamedType(
+                                  Identifier("bool", None<String>()),
+                                  List.empty<DartType>(),
+                                ),
+                              ),
+                            ),
+                          ),
+                        ),
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+            ),
+          ),
+          Function(
+            "blub",
+            annotations = List.empty<Annotation>(),
+            _returns = Some<DartType>(
+              NamedType(Identifier("Blub", None<String>()), List.empty<DartType>()),
+            ),
+            requiredParameters = List.empty<Parameter>(),
+            positionalParameters = List.empty<Parameter>(),
+            namedParameters = List.of1<Parameter>(
+              Parameter(
+                "blub",
+                Some<DartType>(
+                  NamedType(Identifier("int", None<String>()), List.empty<DartType>()),
+                ),
+                defaultValue = None<Expression>(),
+              ),
+            ),
+            body = None<Body>(),
+          ),
+        ),
       ),
     ),
-  ))
-  let compilationUnit = CompilationUnit(list)
-  print(compilationUnit.toCode())
+  )
+  print((compilationUnit as ToCode).toCode())
 }

--- a/packages/dart_code_builder/src/example.candy
+++ b/packages/dart_code_builder/src/example.candy
@@ -6,7 +6,7 @@ fun main() {
     "package:foo/foo.dart",
     alias = Some<String>("foo"),
     show = List.empty<String>(),
-    hide = List.of1<String>("bar")
+    hide = List.of1<String>("bar"),
   ))
   list.append(Import(
     "dart:blub",
@@ -41,11 +41,9 @@ fun main() {
         "args",
         type = Some<DartType>(UserType(
           "List",
-          parameters = List.of1<DartType>(UserType(
-            "String",
-            parameters = List.empty<DartType>(),
-            prefix = None<String>(),
-          )),
+          parameters = List.of1<DartType>(
+            UserType("String", parameters = List.empty<DartType>(), prefix = None<String>())
+          ),
           prefix = None<String>(),
         )),
         defaultValue = None<Expression>(),
@@ -59,7 +57,13 @@ fun main() {
       ),
     ),
     namedParameters = List.empty<Parameter>(),
-    body = None<Body>(),
+    body = Some<Body>(BlockBody(List.of1<Statement>(
+      While(
+        condition = Literal(true),
+        label = Some<String>("foo"),
+        body = List.of1<Statement>(Break(label = Some<String>("foo"))),
+      ),
+    ))),
   ))
   list.append(Class(
     "Foo",
@@ -101,10 +105,7 @@ fun main() {
           If(
             Identifier("value", None<String>()),
             then = List.of1<Statement>(
-              ExpressionStatement(Assignment(
-                Identifier("length", None<String>()),
-                Literal(0),
-              )),
+              ExpressionStatement(Assignment(Identifier("length", None<String>()), Literal(0))),
             ),
             else_ = List.of1<Statement>(
               ExpressionStatement(Identifier("length", None<String>()).dot("someCall").call(
@@ -119,11 +120,7 @@ fun main() {
       Function(
         "blub",
         annotations = List.empty<Annotation>(),
-        _returns = Some<DartType>(UserType(
-          "Blub",
-          List.empty<DartType>(),
-          None<String>(),
-        )),
+        _returns = Some<DartType>(UserType("Blub", List.empty<DartType>(), None<String>())),
         requiredParameters = List.empty<Parameter>(),
         positionalParameters = List.empty<Parameter>(),
         namedParameters = List.of1<Parameter>(Parameter(

--- a/packages/dart_code_builder/src/example.candy
+++ b/packages/dart_code_builder/src/example.candy
@@ -19,7 +19,7 @@ fun main() {
       Part("test.dart"),
       PartOf("meow.dart"),
     ),
-    declarations = List.of2<Declaration>(
+    declarations = List.of3<Declaration>(
       Function(
         "main",
         annotations = List.of1<Annotation>(
@@ -94,13 +94,25 @@ fun main() {
           NamedType(Identifier("Whup", None<String>()), List.empty<DartType>()),
           NamedType(Identifier("Flang", None<String>()), List.empty<DartType>()),
         ),
-        body = List.of4<Field | Getter | Setter | Function>(
+        body = List.of5<Constructor | Field | Getter | Setter | Function>(
           // static const numBlubs = 123;
           Field(
             "numBlubs",
             isStatic = true,
             mutability = Const(),
             initialValue = Some<Expression>(IntLiteral(123)),
+          ),
+          // Foo()
+          Constructor(
+            className = "Foo",
+            name = None<String>(),
+            annotations = List.empty<Annotation>(),
+            requiredParameters = List.of1<Parameter | InitializingFormal>(
+              InitializingFormal("blub", defaultValue = None<Expression>()),
+            ),
+            positionalParameters = List.empty<Parameter | InitializingFormal>(),
+            namedParameters = List.empty<Parameter | InitializingFormal>(),
+            body = None<Body>(),
           ),
           // bool get isEmpty => this.length == 0;
           Getter(
@@ -179,6 +191,14 @@ fun main() {
             body = None<Body>(),
           ),
         ),
+      ),
+      Mixin(
+        "MyMixin",
+        annotations = List.of1<Annotation>(Annotation(Identifier("data", prefix = None<String>()))),
+        on_ = Some<DartType>(
+          NamedType(Identifier("Foo", prefix = None<String>()), List.empty<DartType>()),
+        ),
+        body = List.empty<Getter | Setter | Function>(),
       ),
     ),
   )

--- a/packages/dart_code_builder/src/example.candy
+++ b/packages/dart_code_builder/src/example.candy
@@ -4,13 +4,13 @@ fun main() {
   let list = MutableList.empty<Directive | Declaration>()
   list.append(Import(
     "package:foo/foo.dart",
-    alias = Some<String>("foo"),
+    prefix = Some<String>("foo"),
     show = List.empty<String>(),
     hide = List.of1<String>("bar"),
   ))
   list.append(Import(
     "dart:blub",
-    alias = None<String>(),
+    prefix = None<String>(),
     show = List.of1<String>("blubber"),
     hide = List.empty<String>(),
   ))

--- a/packages/dart_code_builder/src/example.candy
+++ b/packages/dart_code_builder/src/example.candy
@@ -132,6 +132,6 @@ fun main() {
       ),
     ),
   ))
-  let file = File(list)
-  print(file.toCode())
+  let compilationUnit = CompilationUnit(list)
+  print(compilationUnit.toCode())
 }

--- a/packages/dart_code_builder/src/example.candy
+++ b/packages/dart_code_builder/src/example.candy
@@ -1,0 +1,147 @@
+use ..nodes
+
+fun main() {
+  let list = MutableList.empty<Directive | Declaration>()
+  list.append(Import(
+    "package:foo/foo.dart",
+    alias = Some<String>("foo"),
+    show = List.empty<String>(),
+    hide = List.of1<String>("bar")
+  ))
+  list.append(Import(
+    "dart:blub",
+    alias = None<String>(),
+    show = List.of1<String>("blubber"),
+    hide = List.empty<String>(),
+  ))
+  list.append(Part("test.dart"))
+  list.append(PartOf("meow.dart"))
+  list.append(Function(
+    "main",
+    annotations = List.of1<Annotation>(
+      Annotation(
+        (UserType(
+          "Cached",
+          parameters = List.empty<DartType>(),
+          prefix = None<String>(),
+        ) as Expression).call(
+          positionalArguments = List.empty<Expression>(),
+          namedArguments = Map.empty<String, Expression>(),
+          typeArguments = List.empty<DartType>(),
+        )
+      )
+    ),
+    returns = Some<DartType>(UserType(
+      "Foo",
+      parameters = List.empty<DartType>(),
+      prefix = Some<String>("foo"),
+    )),
+    requiredParameters = List.of1<Parameter>(
+      Parameter(
+        "args",
+        type = Some<DartType>(UserType(
+          "List",
+          parameters = List.of1<DartType>(UserType(
+            "String",
+            parameters = List.empty<DartType>(),
+            prefix = None<String>(),
+          )),
+          prefix = None<String>(),
+        )),
+        defaultValue = None<Expression>(),
+      ),
+    ),
+    positionalParameters = List.of1<Parameter>(
+      Parameter(
+        "number",
+        type = Some<DartType>(UserType("int", List.empty<DartType>(), None<String>())),
+        default = Some<Expression>(Literal(123)),
+      ),
+    ),
+    namedParameters = List.empty<Parameter>(),
+    body = None<Body>(),
+  ))
+  list.append(Class(
+    "Foo",
+    annotations = List.of1<Annotation>(Annotation(Identifier("data", prefix = None<String>()))),
+    extends = Some<DartType>(UserType("Bar", List.empty<DartType>(), None<String>())),
+    implements = List.of3<DartType>(
+      UserType("Baz", List.empty<DartType>(), None<String>()),
+      UserType("Wheez", List.empty<DartType>(), None<String>()),
+      UserType("Fnop", List.empty<DartType>(), None<String>()),
+    ),
+    with = List.of2<DartType>(
+      UserType("Whup", List.empty<DartType>(), None<String>()),
+      UserType("Flang", List.empty<DartType>(), None<String>()),
+    ),
+    body = List.of4<Field | Getter | Setter | Function>(
+      // static const numBlubs = 123;
+      Field(
+        "numBlubs",
+        isStatic = true,
+        mutability = Const(),
+        value = Some<Expression>(Literal(123)),
+      ),
+      // bool get isEmpty => this.length == 0;
+      Getter(
+        "isEmpty",
+        type = UserType("bool", List.empty<DartType>(), None<String>()),
+        body = Some<Body>(InlineBody(
+          this_.dot("length").equals(Literal(0))
+        )),
+      ),
+      // set isEmpty(bool value) {
+      //   if (value) {
+      //     length = 0;
+      //   } else {
+      //     add(1);
+      //   }
+      // }
+      Setter(
+        "isEmpty",
+        parameter = Parameter(
+          "value",
+          type = Some<DartType>(UserType("bool", List.empty<DartType>(), None<String>())),
+          defaultValue = None<Expression>(),
+        ),
+        body = Some<Body>(BlockBody(List.of1<Statement>(
+          If(
+            Identifier("value", None<String>()),
+            then = List.of1<Statement>(
+              Assignment(
+                Identifier("left", None<String>()),
+                Literal(0),
+              ),
+            ),
+            else = List.of1<Statement>(
+              Identifier("left", None<String>()).call(
+                List.of1<Expression>(Literal(1)),
+                Map.empty<String, Expression>(),
+                List.empty<DartType>(),
+              ) as Statement,
+            ),
+          ),
+        ))),
+      ),
+      Function(
+        "blub",
+        annotations = List.empty<Annotation>(),
+        returns = Some<DartType>(UserType(
+          "Foo",
+          List.empty<DartType>(),
+          Some<String>("foo"),
+        )),
+        requiredParameters = List.empty<Parameter>(),
+        positionalParameters = List.empty<Parameter>(),
+        namedParameters = List.of1<Parameter>(Parameter(
+          "blub",
+          Some<DartType>(UserType("int", List.empty<DartType>(), prefix = None<String>())),
+          defaultValue = None<Expression>(),
+        )),
+        body = None<Body>(),
+      ),
+    ),
+  ))
+  let code = File(list)
+  print(code)
+}

--- a/packages/dart_code_builder/src/example.candy
+++ b/packages/dart_code_builder/src/example.candy
@@ -22,7 +22,7 @@ fun main() {
       Annotation(
         (NamedType(
           "Cached",
-          parameters = List.empty<DartType>(),
+          typeArguments = List.empty<DartType>(),
           prefix = None<String>(),
         ) as Expression).call(
           positionalArguments = List.empty<Expression>(),
@@ -33,7 +33,7 @@ fun main() {
     ),
     _returns = Some<DartType>(NamedType(
       "Foo",
-      parameters = List.empty<DartType>(),
+      typeArguments = List.empty<DartType>(),
       prefix = Some<String>("foo"),
     )),
     requiredParameters = List.of1<Parameter>(
@@ -41,8 +41,8 @@ fun main() {
         "args",
         type = Some<DartType>(NamedType(
           "List",
-          parameters = List.of1<DartType>(
-            NamedType("String", parameters = List.empty<DartType>(), prefix = None<String>())
+          typeArguments = List.of1<DartType>(
+            NamedType("String", typeArguments = List.empty<DartType>(), prefix = None<String>())
           ),
           prefix = None<String>(),
         )),

--- a/packages/dart_code_builder/src/example.candy
+++ b/packages/dart_code_builder/src/example.candy
@@ -31,7 +31,7 @@ fun main() {
         )
       )
     ),
-    returns = Some<DartType>(UserType(
+    _returns = Some<DartType>(UserType(
       "Foo",
       parameters = List.empty<DartType>(),
       prefix = Some<String>("foo"),
@@ -64,31 +64,24 @@ fun main() {
   list.append(Class(
     "Foo",
     annotations = List.of1<Annotation>(Annotation(Identifier("data", prefix = None<String>()))),
-    extends = Some<DartType>(UserType("Bar", List.empty<DartType>(), None<String>())),
-    implements = List.of3<DartType>(
+    extends_ = Some<DartType>(UserType("Bar", List.empty<DartType>(), None<String>())),
+    implements_ = List.of3<DartType>(
       UserType("Baz", List.empty<DartType>(), None<String>()),
       UserType("Wheez", List.empty<DartType>(), None<String>()),
       UserType("Fnop", List.empty<DartType>(), None<String>()),
     ),
-    with = List.of2<DartType>(
+    with_ = List.of2<DartType>(
       UserType("Whup", List.empty<DartType>(), None<String>()),
       UserType("Flang", List.empty<DartType>(), None<String>()),
     ),
     body = List.of4<Field | Getter | Setter | Function>(
       // static const numBlubs = 123;
-      Field(
-        "numBlubs",
-        isStatic = true,
-        mutability = Const(),
-        value = Some<Expression>(Literal(123)),
-      ),
+      Field("numBlubs", isStatic = true, mutability = Const(), Some<Expression>(Literal(123))),
       // bool get isEmpty => this.length == 0;
       Getter(
         "isEmpty",
         type = UserType("bool", List.empty<DartType>(), None<String>()),
-        body = Some<Body>(InlineBody(
-          this_.dot("length").equals(Literal(0))
-        )),
+        body = Some<Body>(InlineBody(this_.dot("length").equals(Literal(0)))),
       ),
       // set isEmpty(bool value) {
       //   if (value) {
@@ -108,17 +101,17 @@ fun main() {
           If(
             Identifier("value", None<String>()),
             then = List.of1<Statement>(
-              Assignment(
+              ExpressionStatement(Assignment(
                 Identifier("left", None<String>()),
                 Literal(0),
-              ),
+              )),
             ),
-            else = List.of1<Statement>(
-              Identifier("left", None<String>()).call(
+            else_ = List.of1<Statement>(
+              ExpressionStatement(Identifier("left", None<String>()).call(
                 List.of1<Expression>(Literal(1)),
                 Map.empty<String, Expression>(),
                 List.empty<DartType>(),
-              ) as Statement,
+              )),
             ),
           ),
         ))),
@@ -126,10 +119,10 @@ fun main() {
       Function(
         "blub",
         annotations = List.empty<Annotation>(),
-        returns = Some<DartType>(UserType(
-          "Foo",
+        _returns = Some<DartType>(UserType(
+          "Blub",
           List.empty<DartType>(),
-          Some<String>("foo"),
+          None<String>(),
         )),
         requiredParameters = List.empty<Parameter>(),
         positionalParameters = List.empty<Parameter>(),
@@ -142,6 +135,6 @@ fun main() {
       ),
     ),
   ))
-  let code = File(list)
-  print(code)
+  let file = File(list)
+  print(file.toCode())
 }

--- a/packages/dart_code_builder/src/module.candy
+++ b/packages/dart_code_builder/src/module.candy
@@ -1,0 +1,2 @@
+public use nodes
+public use to_code

--- a/packages/dart_code_builder/src/nodes.candy
+++ b/packages/dart_code_builder/src/nodes.candy
@@ -54,9 +54,9 @@ class Class {
   
   let name: String
   let annotations: List<Annotation> = List.empty<Annotation>()
-  let extends: Maybe<DartType> = None<DartType>()
-  let implements: List<DartType> = List.empty<DartType>()
-  let with: List<DartType> = List.empty<DartType>()
+  let extends_: Maybe<DartType> = None<DartType>()
+  let implements_: List<DartType> = List.empty<DartType>()
+  let with_: List<DartType> = List.empty<DartType>()
   let body: List<Field | Getter | Setter | Function> = List.empty<Field | Getter | Setter | Function>()
 }
 impl Class: Declaration {}
@@ -75,7 +75,7 @@ class Function {
 
   let name: String
   let annotations: List<Annotation> = List.empty<Annotation>()
-  let returns: Maybe<DartType> = None<DartType>()
+  let _returns: Maybe<DartType> = None<DartType>()
   let requiredParameters: List<Parameter> = List.empty<Parameter>()
   let positionalParameters: List<Parameter> = List.empty<Parameter>()
   let namedParameters: List<Parameter> = List.empty<Parameter>()
@@ -103,7 +103,6 @@ class Final {}
 impl Final: Mutability
 class Const {}
 impl Const: Mutability
-
 
 class Getter {
   let name: String
@@ -139,6 +138,8 @@ class UserType {
   let prefix: Maybe<String> = None<String>()
 }
 impl UserType: DartType
+impl UserType: Expression
+/// TODO(marcelgarus): Remove once the compiler realizes DartType implements Expression.
 
 class FunctionType {
   let parameters: List<Parameter> = List.empty<Parameter>()
@@ -147,7 +148,8 @@ class FunctionType {
   let returns: Maybe<DartType> = None<DartType>()
 }
 impl FunctionType: DartType
-
+impl FunctionType: Expression
+/// TODO(marcelgarus): Remove once the compiler realizes DartType implements Expression.
 
 // Expressions.
 
@@ -249,7 +251,7 @@ impl ExpressionStatement: Statement
 class If {
   let condition: Expression
   let then: List<Statement>
-  let else: List<Statement> = List.empty<Statement>()
+  let else_: List<Statement> = List.empty<Statement>()
 }
 impl If: Statement
 

--- a/packages/dart_code_builder/src/nodes.candy
+++ b/packages/dart_code_builder/src/nodes.candy
@@ -297,6 +297,11 @@ class Break {
 }
 impl Break: Statement
 
+class Continue {
+  let label: Maybe<String>
+}
+impl Continue: Statement
+
 class If {
   let condition: Expression
   let then: Statement

--- a/packages/dart_code_builder/src/nodes.candy
+++ b/packages/dart_code_builder/src/nodes.candy
@@ -20,7 +20,7 @@ class Import {
   /// import 'foo.dart' hide secretFoo;
 
   let path: String
-  let alias: Maybe<String> = None<String>()
+  let prefix: Maybe<String> = None<String>()
   let show: List<String> = List.empty<String>()
   let hide: List<String> = List.empty<String>()
 }

--- a/packages/dart_code_builder/src/nodes.candy
+++ b/packages/dart_code_builder/src/nodes.candy
@@ -135,7 +135,7 @@ trait DartType {}
 
 class NamedType {
   let name: String
-  let parameters: List<DartType> = List.empty<DartType>()
+  let typeArguments: List<DartType> = List.empty<DartType>()
   let prefix: Maybe<String> = None<String>()
 }
 impl NamedType: DartType

--- a/packages/dart_code_builder/src/nodes.candy
+++ b/packages/dart_code_builder/src/nodes.candy
@@ -170,7 +170,7 @@ class FunctionType {
   let parameters: List<Parameter> = List.empty<Parameter>()
   let positionalParameters: List<Parameter> = List.empty<Parameter>()
   let namedParameters: List<Parameter> = List.empty<Parameter>()
-  let returns: Maybe<DartType> = None<DartType>()
+  let _returns: Maybe<DartType> = None<DartType>()
 }
 impl FunctionType: DartType
 impl FunctionType: Expression
@@ -204,9 +204,8 @@ trait Expression {
   fun divide(other: Expression): BinaryOperator { BinaryOperator(this, "/", other) }
   fun divideTruncate(other: Expression): BinaryOperator { BinaryOperator(this, "~/", other) }
   fun modulo(other: Expression): BinaryOperator { BinaryOperator(other, "%", other) }
-  fun as(other: DartType): BinaryOperator { BinaryOperator(this, "as", other as Expression) }
-  fun is(other: DartType): BinaryOperator { BinaryOperator(this, "is", other as Expression) }
-
+  fun as_(other: DartType): BinaryOperator { BinaryOperator(this, "as", other as Expression) }
+  fun is_(other: DartType): BinaryOperator { BinaryOperator(this, "is", other as Expression) }
 }
 
 impl DartType: Expression

--- a/packages/dart_code_builder/src/nodes.candy
+++ b/packages/dart_code_builder/src/nodes.candy
@@ -133,13 +133,13 @@ impl BlockBody: Body
 
 trait DartType {}
 
-class UserType {
+class NamedType {
   let name: String
   let parameters: List<DartType> = List.empty<DartType>()
   let prefix: Maybe<String> = None<String>()
 }
-impl UserType: DartType
-impl UserType: Expression
+impl NamedType: DartType
+impl NamedType: Expression
 /// TODO(marcelgarus): Remove once the compiler realizes DartType implements Expression.
 
 class FunctionType {

--- a/packages/dart_code_builder/src/nodes.candy
+++ b/packages/dart_code_builder/src/nodes.candy
@@ -249,9 +249,14 @@ class ExpressionStatement {
 impl ExpressionStatement: Statement
 
 class Return {
-  let expression: Expression
+  let expression: Maybe<Expression>
 }
 impl Return: Statement
+
+class Break {
+  let label: Maybe<String>
+}
+impl Break: Statement
 
 class If {
   let condition: Expression
@@ -262,6 +267,7 @@ impl If: Statement
 
 class While {
   let condition: Expression
+  let label: Maybe<String>
   let body: List<Statement> = List.empty<Statement>()
 }
 impl While: Statement

--- a/packages/dart_code_builder/src/nodes.candy
+++ b/packages/dart_code_builder/src/nodes.candy
@@ -124,19 +124,18 @@ class InlineBody {
 }
 impl InlineBody: Body
 
-class BlockBody {
+class Block {
   let statements: List<Statement>
 }
-impl BlockBody: Body
+impl Block: Body
 
 // Types.
 
 trait DartType {}
 
 class NamedType {
-  let name: String
+  let name: Identifier
   let typeArguments: List<DartType> = List.empty<DartType>()
-  let prefix: Maybe<String> = None<String>()
 }
 impl NamedType: DartType
 impl NamedType: Expression
@@ -192,11 +191,20 @@ impl Identifier: Expression
 
 let this_ = Identifier("this", None<String>())
 
-class Literal {
-  // TODO: Support Map, List, and Set literals.
-  let value: String | Int | Bool
+class NullLiteral {}
+impl NullLiteral: Expression
+class StringLiteral {
+  let value: String
 }
-impl Literal: Expression
+impl StringLiteral: Expression
+class IntLiteral {
+  let value: Int
+}
+impl IntLiteral: Expression
+class BoolLiteral {
+  let value: Bool
+}
+impl BoolLiteral: Expression
 
 class Call {
   let target: Expression
@@ -244,6 +252,8 @@ impl Closure: Expression
 
 trait Statement {}
 
+impl Block: Statement
+
 class ExpressionStatement {
   let expression: Expression
 }
@@ -261,14 +271,14 @@ impl Break: Statement
 
 class If {
   let condition: Expression
-  let then: List<Statement>
-  let else_: List<Statement> = List.empty<Statement>()
+  let then: Statement
+  let else_: Maybe<Statement> = None<Statement>()
 }
 impl If: Statement
 
 class While {
   let condition: Expression
   let label: Maybe<String>
-  let body: List<Statement> = List.empty<Statement>()
+  let body: Statement
 }
 impl While: Statement

--- a/packages/dart_code_builder/src/nodes.candy
+++ b/packages/dart_code_builder/src/nodes.candy
@@ -58,9 +58,34 @@ class Class {
   let extends_: Maybe<DartType> = None<DartType>()
   let implements_: List<DartType> = List.empty<DartType>()
   let with_: List<DartType> = List.empty<DartType>()
-  let body: List<Field | Getter | Setter | Function> = List.empty<Field | Getter | Setter | Function>()
+  let body: List<Constructor | Field | Getter | Setter | Function> = List.empty<Constructor | Field | Getter | Setter | Function>()
 }
-impl Class: Declaration {}
+impl Class: Declaration
+
+class Constructor {
+  let className: String
+  let name: Maybe<String>
+  let annotations: List<Annotation> = List.empty<Annotation>()
+  let requiredParameters: List<Parameter | InitializingFormal> = List.empty<Parameter | InitializingFormal>()
+  let positionalParameters: List<Parameter | InitializingFormal> = List.empty<Parameter | InitializingFormal>()
+  let namedParameters: List<Parameter | InitializingFormal> = List.empty<Parameter | InitializingFormal>()
+  let body: Maybe<Body> = None<Body>()
+}
+class InitializingFormal {
+  /// this.foo
+  /// this.bar
+
+  let name: String
+  let defaultValue: Maybe<Expression> = None<Expression>()
+}
+
+class Mixin {
+  let name: String
+  let annotations: List<Annotation> = List.empty<Annotation>()
+  let on_: Maybe<DartType> = None<DartType>()
+  let body: List<Getter | Setter | Function> = List.empty<Getter | Setter | Function>()
+}
+impl Mixin: Declaration
 
 class Function {
   /// void foo();
@@ -82,7 +107,7 @@ class Function {
   let namedParameters: List<Parameter> = List.empty<Parameter>()
   let body: Maybe<Body> = None<Body>()
 }
-impl Function: Declaration {}
+impl Function: Declaration
 
 class Parameter {
   let name: String

--- a/packages/dart_code_builder/src/nodes.candy
+++ b/packages/dart_code_builder/src/nodes.candy
@@ -1,0 +1,231 @@
+class File {
+  let parts: List<Directive | Declaration>
+}
+
+class Annotation {
+  let expression: Expression
+}
+
+// Directives.
+
+trait Directive {}
+
+class Import {
+  let path: String
+  let alias: Maybe<String> = None
+  let show: List<String> = []
+  let hide: List<String> = []
+}
+impl Import: Directive
+
+class Part {
+  let path: String
+}
+impl Part: Directive
+
+class PartOf {
+  let path: String
+}
+impl PartOf: Directive
+
+// Declarations.
+
+trait Declaration {}
+
+class Class {
+  let name: String
+  let annotations: List<Annotation> = []
+  let extends: Maybe<Type> = None
+  let implements: List<Type> = []
+  let with: List<Type> = []
+  let body: List<Field | Getter | Setter | Function> = []
+}
+impl Class: Declaration {}
+
+class Function {
+  let name: String
+  let annotations: List<Annotation> = []
+  let returns: Maybe<Type> = None
+  let requiredParameters: List<Parameter> = []
+  let positionalParameters: List<Parameter> = []
+  let namedParameters: List<Parameter> = []
+  let body: Maybe<Body> = None
+}
+impl Function: Declaration {}
+
+class Parameter {
+  let name: String
+  let type: Maybe<Type> = None
+  let defaultValue: Maybe<Expression> = None
+}
+
+class Field {
+  let name: String
+  let isStatic: Bool = false
+  let mutability: Mutability = var
+  let initialValue: Maybe<Expression> = None
+}
+
+trait Mutability {}
+class Var {}
+impl Var: Mutability
+class Final {}
+impl Final: Mutability
+class Const {}
+impl Const: Mutability
+
+class Getter {
+  let name: String
+  let type: Type
+  let body: Maybe<Body> = None
+}
+
+class Setter {
+  let name: String
+  let parameter: Parameter
+  let body: Maybe<Body> = None
+}
+
+trait Body {}
+
+class InlineBody {
+  let expression: Expression
+}
+impl InlineBody: Body {}
+
+class BlockBody {
+  let statements: List<Statement>
+}
+impl BlockBody: Body
+
+// Types.
+
+trait Type {}
+
+class UserType {
+  let name: String
+  let parameters: List<Type> = []
+  let prefix: Maybe<String> = None
+}
+impl UserType: Type
+
+class FunctionType {
+  let parameters: List<Parameter> = []
+  let positionalParameters: List<Parameter> = []
+  let namedParameters: List<Parameter> = []
+  let returns: Maybe<Type> = None
+}
+impl FunctionType: Type
+
+// Expressions.
+
+trait Expression {}
+
+impl Type: Expression
+
+class Identifier {
+  let name: String
+  let prefix: Maybe<String> = None
+}
+impl Identifier: Expression
+
+let this_ = Identifier("this")
+
+class Literal {
+  // TODO: Support Map, List, and Set literals.
+  let value: String | Int | Bool
+}
+impl Literal: Expression
+
+class Call {
+  let target: Expression
+  let positionalArguments: List<Expression> = []
+  let namedArguments: Map<String, Expression> = {}
+  let typeArguments: List<Type> = []
+}
+impl Call: Expression
+
+class Navigation {
+  let target: Expression
+  let property: String
+}
+impl Navigation: Expression
+
+class BinaryOperator {
+  let left: Expression
+  let operator: String
+  let right: Expression
+}
+impl BinaryOperator: Expression
+
+class PrefixOperator {
+  let operator: String
+  let target: Expression
+}
+impl PrefixOperator: Expression {}
+
+class Closure {
+  let returns: Maybe<Type> = None
+  let requiredParameters: List<Parameter> = []
+  let positionalParameters: List<Parameter> = []
+  let namedParameters: List<Parameter> = []
+  let body: Body
+}
+impl Closure: Expression {}
+
+impl Expression {
+  /*public fun call(
+    positionalArguments: List<Expression>,
+    namedArguments: List<Expression>,
+    typeArguments: List<Type>,
+  ): Call {
+    Call(this, positionalArguments, namedArguments, typeArguments)
+  }*/
+  fun dot(property: String): Navigation {
+    
+  }
+  /*fun equals(other: Expression): BinaryOperator { BinaryOperator(this, "==", other) }
+  fun notEquals(other: Expression): BinaryOperator { BinaryOperator(this, "!=", other) }
+  fun opposite(): PrefixOperator { PrefixOperator(this, "!") }
+  fun and(other: Expression): BinaryOperator { BinaryOperator(this, "&&", other) }
+  fun or(other: Expression): BinaryOperator { BinaryOperator(this, "||", other) }
+  fun lessThan(other: Expression): BinaryOperator { BinaryOperator(this, "<", other) }
+  fun greaterThan(other: Expression): BinaryOperator { BinaryOperator(this, ">", other) }
+  fun lessThanOrEqualTo(other: Expression): BinaryOperator { BinaryOperator(this, "<=", other) }
+  fun greaterThanOrEqualTo(other: Expression): BinaryOperator { BinaryOperator(this, ">=", other) }
+  fun bitwiseAnd(other: Expression): BinaryOperator { BinaryOperator(this, "&", other) }
+  fun bitwiseOr(other: Expression): BinaryOperator { BinaryOperator(this, "|", other) }
+  fun plus(other: Expression): BinaryOperator { BinaryOperator(this, "+", other) }
+  fun minus(other: Expression): BinaryOperator { BinaryOperator(this, "-", other) }
+  fun times(other: Expression): BinaryOperator { BinaryOperator(this, "*", other) }
+  fun divide(other: Expression): BinaryOperator { BinaryOperator(this, "/", other) }
+  fun divideTruncate(other: Expression): BinaryOperator { BinaryOperator(this, "~/", other) }*/
+  /*fun modulo(other: Expression): BinaryOperator {
+    // return BinaryOperator(other, "%", other)
+  }*/
+}
+
+// Statements.
+
+trait Statement {}
+
+impl Expression: Statement
+
+class If {
+  let condition: Expression
+  let then: List<Statement>
+  let else: List<Statement> = []
+}
+impl If: Statement
+
+class While {
+  let condition: Expression
+  let body: List<Statement> = []
+}
+impl While: Statement
+
+class Assignment {
+  let left: Expression
+  let right: Expression
+}
+impl Assignment: Statement

--- a/packages/dart_code_builder/src/nodes.candy
+++ b/packages/dart_code_builder/src/nodes.candy
@@ -1,5 +1,6 @@
-class File {
-  let parts: List<Directive | Declaration>
+class CompilationUnit {
+  let directives: List<Directive>
+  let declarations: List<Declaration>
 }
 
 class Annotation {

--- a/packages/dart_code_builder/src/nodes.candy
+++ b/packages/dart_code_builder/src/nodes.candy
@@ -204,6 +204,9 @@ trait Expression {
   fun divide(other: Expression): BinaryOperator { BinaryOperator(this, "/", other) }
   fun divideTruncate(other: Expression): BinaryOperator { BinaryOperator(this, "~/", other) }
   fun modulo(other: Expression): BinaryOperator { BinaryOperator(other, "%", other) }
+  fun as(other: DartType): BinaryOperator { BinaryOperator(this, "as", other as Expression) }
+  fun is(other: DartType): BinaryOperator { BinaryOperator(this, "is", other as Expression) }
+
 }
 
 impl DartType: Expression

--- a/packages/dart_code_builder/src/nodes.candy
+++ b/packages/dart_code_builder/src/nodes.candy
@@ -3,6 +3,9 @@ class File {
 }
 
 class Annotation {
+  /// @override
+  /// @sealed
+  
   let expression: Expression
 }
 
@@ -11,19 +14,27 @@ class Annotation {
 trait Directive {}
 
 class Import {
+  /// import 'package:blub/blub.dart' as blub;
+  /// import 'blub.dart' show Foo, Bar;
+  /// import 'foo.dart' hide secretFoo;
+
   let path: String
-  let alias: Maybe<String> = None
-  let show: List<String> = []
-  let hide: List<String> = []
+  let alias: Maybe<String> = None<String>()
+  let show: List<String> = List.empty<String>()
+  let hide: List<String> = List.empty<String>()
 }
 impl Import: Directive
 
 class Part {
+  /// part 'foo.dart';
+  
   let path: String
 }
 impl Part: Directive
 
 class PartOf {
+  /// part of 'bar.dart';
+  
   let path: String
 }
 impl PartOf: Directive
@@ -33,37 +44,56 @@ impl PartOf: Directive
 trait Declaration {}
 
 class Class {
+  /// @immutable
+  /// class Foo extends Bar implements Baz with Whop {
+  ///   final String flub;
+  ///   final int flop;
+  ///
+  ///   void foo(bool value);
+  /// }
+  
   let name: String
-  let annotations: List<Annotation> = []
-  let extends: Maybe<Type> = None
-  let implements: List<Type> = []
-  let with: List<Type> = []
-  let body: List<Field | Getter | Setter | Function> = []
+  let annotations: List<Annotation> = List.empty<Annotation>()
+  let extends: Maybe<DartType> = None<DartType>()
+  let implements: List<DartType> = List.empty<DartType>()
+  let with: List<DartType> = List.empty<DartType>()
+  let body: List<Field | Getter | Setter | Function> = List.empty<Field | Getter | Setter | Function>()
 }
 impl Class: Declaration {}
 
 class Function {
+  /// void foo();
+  ///
+  /// @override
+  /// String toString() => 'Foo';
+  ///
+  /// int blub(int a, [int b, int c]) => ...;
+  ///
+  /// String bar(int a, {int b = 0, int c}) {
+  ///   print('a=$a, b=$b, c=$c');
+  /// }
+
   let name: String
-  let annotations: List<Annotation> = []
-  let returns: Maybe<Type> = None
-  let requiredParameters: List<Parameter> = []
-  let positionalParameters: List<Parameter> = []
-  let namedParameters: List<Parameter> = []
-  let body: Maybe<Body> = None
+  let annotations: List<Annotation> = List.empty<Annotation>()
+  let returns: Maybe<DartType> = None<DartType>()
+  let requiredParameters: List<Parameter> = List.empty<Parameter>()
+  let positionalParameters: List<Parameter> = List.empty<Parameter>()
+  let namedParameters: List<Parameter> = List.empty<Parameter>()
+  let body: Maybe<Body> = None<Body>()
 }
 impl Function: Declaration {}
 
 class Parameter {
   let name: String
-  let type: Maybe<Type> = None
-  let defaultValue: Maybe<Expression> = None
+  let type: Maybe<DartType> = None<DartType>()
+  let defaultValue: Maybe<Expression> = None<Expression>()
 }
 
 class Field {
   let name: String
   let isStatic: Bool = false
-  let mutability: Mutability = var
-  let initialValue: Maybe<Expression> = None
+  let mutability: Mutability = Var()
+  let initialValue: Maybe<Expression> = None<Expression>()
 }
 
 trait Mutability {}
@@ -74,16 +104,17 @@ impl Final: Mutability
 class Const {}
 impl Const: Mutability
 
+
 class Getter {
   let name: String
-  let type: Type
-  let body: Maybe<Body> = None
+  let type: DartType
+  let body: Maybe<Body> = None<Body>()
 }
 
 class Setter {
   let name: String
   let parameter: Parameter
-  let body: Maybe<Body> = None
+  let body: Maybe<Body> = None<Body>()
 }
 
 trait Body {}
@@ -91,7 +122,7 @@ trait Body {}
 class InlineBody {
   let expression: Expression
 }
-impl InlineBody: Body {}
+impl InlineBody: Body
 
 class BlockBody {
   let statements: List<Statement>
@@ -100,36 +131,63 @@ impl BlockBody: Body
 
 // Types.
 
-trait Type {}
+trait DartType {}
 
 class UserType {
   let name: String
-  let parameters: List<Type> = []
-  let prefix: Maybe<String> = None
+  let parameters: List<DartType> = List.empty<DartType>()
+  let prefix: Maybe<String> = None<String>()
 }
-impl UserType: Type
+impl UserType: DartType
 
 class FunctionType {
-  let parameters: List<Parameter> = []
-  let positionalParameters: List<Parameter> = []
-  let namedParameters: List<Parameter> = []
-  let returns: Maybe<Type> = None
+  let parameters: List<Parameter> = List.empty<Parameter>()
+  let positionalParameters: List<Parameter> = List.empty<Parameter>()
+  let namedParameters: List<Parameter> = List.empty<Parameter>()
+  let returns: Maybe<DartType> = None<DartType>()
 }
-impl FunctionType: Type
+impl FunctionType: DartType
+
 
 // Expressions.
 
-trait Expression {}
+trait Expression {
+  fun dot(property: String): Navigation { Navigation(this, property) }
+  public fun call(
+    positionalArguments: List<Expression>,
+    namedArguments: Map<String, Expression>,
+    typeArguments: List<DartType>,
+  ): Call {
+    Call(this, positionalArguments, namedArguments, typeArguments)
+  }
+  fun equals(other: Expression): BinaryOperator { BinaryOperator(this, "==", other) }
+  fun notEquals(other: Expression): BinaryOperator { BinaryOperator(this, "!=", other) }
+  fun opposite(): PrefixOperator { PrefixOperator("!", this) }
+  fun and(other: Expression): BinaryOperator { BinaryOperator(this, "&&", other) }
+  fun or(other: Expression): BinaryOperator { BinaryOperator(this, "||", other) }
+  fun lessThan(other: Expression): BinaryOperator { BinaryOperator(this, "<", other) }
+  fun greaterThan(other: Expression): BinaryOperator { BinaryOperator(this, ">", other) }
+  fun lessThanOrEqualTo(other: Expression): BinaryOperator { BinaryOperator(this, "<=", other) }
+  fun greaterThanOrEqualTo(other: Expression): BinaryOperator { BinaryOperator(this, ">=", other) }
+  fun bitwiseAnd(other: Expression): BinaryOperator { BinaryOperator(this, "&", other) }
+  fun bitwiseOr(other: Expression): BinaryOperator { BinaryOperator(this, "|", other) }
+  fun plus(other: Expression): BinaryOperator { BinaryOperator(this, "+", other) }
+  fun minus(other: Expression): BinaryOperator { BinaryOperator(this, "-", other) }
+  fun times(other: Expression): BinaryOperator { BinaryOperator(this, "*", other) }
+  fun divide(other: Expression): BinaryOperator { BinaryOperator(this, "/", other) }
+  fun divideTruncate(other: Expression): BinaryOperator { BinaryOperator(this, "~/", other) }
+  fun modulo(other: Expression): BinaryOperator { BinaryOperator(other, "%", other) }
+}
 
-impl Type: Expression
+impl DartType: Expression
 
 class Identifier {
   let name: String
-  let prefix: Maybe<String> = None
+  let prefix: Maybe<String> = None<String>()
 }
 impl Identifier: Expression
 
-let this_ = Identifier("this")
+let this_ = Identifier("this", None<String>())
 
 class Literal {
   // TODO: Support Map, List, and Set literals.
@@ -139,9 +197,9 @@ impl Literal: Expression
 
 class Call {
   let target: Expression
-  let positionalArguments: List<Expression> = []
-  let namedArguments: Map<String, Expression> = {}
-  let typeArguments: List<Type> = []
+  let positionalArguments: List<Expression> = List.empty<Expression>()
+  let namedArguments: Map<String, Expression> = Map.empty<String, Expression>()
+  let typeArguments: List<DartType> = List.empty<DartType>()
 }
 impl Call: Expression
 
@@ -162,70 +220,41 @@ class PrefixOperator {
   let operator: String
   let target: Expression
 }
-impl PrefixOperator: Expression {}
-
-class Closure {
-  let returns: Maybe<Type> = None
-  let requiredParameters: List<Parameter> = []
-  let positionalParameters: List<Parameter> = []
-  let namedParameters: List<Parameter> = []
-  let body: Body
-}
-impl Closure: Expression {}
-
-impl Expression {
-  /*public fun call(
-    positionalArguments: List<Expression>,
-    namedArguments: List<Expression>,
-    typeArguments: List<Type>,
-  ): Call {
-    Call(this, positionalArguments, namedArguments, typeArguments)
-  }*/
-  fun dot(property: String): Navigation {
-    
-  }
-  /*fun equals(other: Expression): BinaryOperator { BinaryOperator(this, "==", other) }
-  fun notEquals(other: Expression): BinaryOperator { BinaryOperator(this, "!=", other) }
-  fun opposite(): PrefixOperator { PrefixOperator(this, "!") }
-  fun and(other: Expression): BinaryOperator { BinaryOperator(this, "&&", other) }
-  fun or(other: Expression): BinaryOperator { BinaryOperator(this, "||", other) }
-  fun lessThan(other: Expression): BinaryOperator { BinaryOperator(this, "<", other) }
-  fun greaterThan(other: Expression): BinaryOperator { BinaryOperator(this, ">", other) }
-  fun lessThanOrEqualTo(other: Expression): BinaryOperator { BinaryOperator(this, "<=", other) }
-  fun greaterThanOrEqualTo(other: Expression): BinaryOperator { BinaryOperator(this, ">=", other) }
-  fun bitwiseAnd(other: Expression): BinaryOperator { BinaryOperator(this, "&", other) }
-  fun bitwiseOr(other: Expression): BinaryOperator { BinaryOperator(this, "|", other) }
-  fun plus(other: Expression): BinaryOperator { BinaryOperator(this, "+", other) }
-  fun minus(other: Expression): BinaryOperator { BinaryOperator(this, "-", other) }
-  fun times(other: Expression): BinaryOperator { BinaryOperator(this, "*", other) }
-  fun divide(other: Expression): BinaryOperator { BinaryOperator(this, "/", other) }
-  fun divideTruncate(other: Expression): BinaryOperator { BinaryOperator(this, "~/", other) }*/
-  /*fun modulo(other: Expression): BinaryOperator {
-    // return BinaryOperator(other, "%", other)
-  }*/
-}
-
-// Statements.
-
-trait Statement {}
-
-impl Expression: Statement
-
-class If {
-  let condition: Expression
-  let then: List<Statement>
-  let else: List<Statement> = []
-}
-impl If: Statement
-
-class While {
-  let condition: Expression
-  let body: List<Statement> = []
-}
-impl While: Statement
+impl PrefixOperator: Expression
 
 class Assignment {
   let left: Expression
   let right: Expression
 }
-impl Assignment: Statement
+impl Assignment: Expression
+
+class Closure {
+  let returns: Maybe<DartType> = None<DartType>()
+  let requiredParameters: List<Parameter> = List.empty<Parameter>()
+  let positionalParameters: List<Parameter> = List.empty<Parameter>()
+  let namedParameters: List<Parameter> = List.empty<Parameter>()
+  let body: Body
+}
+impl Closure: Expression
+
+// Statements.
+
+trait Statement {}
+
+class ExpressionStatement {
+  let expression: Expression
+}
+impl ExpressionStatement: Statement
+
+class If {
+  let condition: Expression
+  let then: List<Statement>
+  let else: List<Statement> = List.empty<Statement>()
+}
+impl If: Statement
+
+class While {
+  let condition: Expression
+  let body: List<Statement> = List.empty<Statement>()
+}
+impl While: Statement

--- a/packages/dart_code_builder/src/nodes.candy
+++ b/packages/dart_code_builder/src/nodes.candy
@@ -248,6 +248,11 @@ class ExpressionStatement {
 }
 impl ExpressionStatement: Statement
 
+class Return {
+  let expression: Expression
+}
+impl Return: Statement
+
 class If {
   let condition: Expression
   let then: List<Statement>

--- a/packages/dart_code_builder/src/to_code.candy
+++ b/packages/dart_code_builder/src/to_code.candy
@@ -1,0 +1,179 @@
+use ..nodes
+
+trait ToCode {
+  fun toCode(indention: Int): String
+}
+
+impl File: ToCode {
+  fun toCode(indention: Int): String {
+    mut let s = ""
+    for part in parts {
+      s = "{s}{(part as ToCode).toCode(indention)}"
+    }
+    s
+  }
+}
+
+impl Annotation: ToCode {
+  fun toCode(indention: Int): String {
+    "@{(expression as ToCode).toCode(indention)}"
+  }
+}
+
+impl Directive: ToCode
+
+impl Import: ToCode {
+  fun toCode(indention: Int): String {
+    mut let s = "import '{path}'"
+    if alias is Some {
+      s = "{s} as {alias.unwrap()}"
+    }
+    if (show as Iterable).isNotEmpty() {
+      s = "{s} show {(show as Iterable).join(", ")}"
+    }
+    // TODO(marcelgarus): Use hide
+    s
+  }
+}
+
+impl Part: ToCode {
+  fun toCode(indention: Int): String {
+    "part '{path}';"
+  }
+}
+
+impl PartOf: ToCode {
+  fun toCode(indention: Int): String {
+    "part of '{path}';"
+  }
+}
+
+let a = 3
+
+impl Declaration: ToCode
+
+// TODO: Class
+// TODO: Function
+// TODO: Parameter
+// TODO: Field
+
+impl Mutability: ToCode
+impl Var: ToCode {
+  fun toCode(indention: Int): String { "var" }
+}
+impl Final: ToCode {
+  fun toCode(indention: Int): String { "final" }
+}
+impl Const: ToCode {
+  fun toCode(indention: Int): String { "const" }
+}
+
+// TOOD: Getter
+// TOOD: Setter
+
+impl Body: ToCode
+impl InlineBody: ToCode {
+  fun toCode(indention: Int): String {
+    "=> {expression}"
+  }
+}
+impl BlockBody: ToCode {
+  fun toCode(indention: Int): String {
+    "🦄{(statements as Iterable).join("\n")}🦄"
+  }
+}
+
+impl DartType: ToCode
+impl UserType: ToCode {
+  fun toCode(indention: Int): String {
+    mut let s = name
+    if prefix is Some {
+      s = "{prefix.unwrap()}.{s}"
+    }
+    if (parameters as Iterable).isNotEmpty() {
+      s = "{s}<{(parameters as Iterable).join(", ")}>"
+    }
+    s
+  }
+}
+impl FunctionType: ToCode {
+  fun toCode(indention: Int): String {
+    mut let s = "Function"
+    // if returns is Some {
+    //   s = "{returns} {s}"
+    // }
+    s = "{s}("
+    // s = "{s}{(parameters as Iterable).map<String>({ "{it}," }).join("")}"
+    // for parameter in parameters {
+    //   s = "{s}{parameter},"
+    // }
+    // if positionalParameters.isNotEmpty() {
+    //   s = "{"
+    // }
+    s = "{s})"
+    s
+  }
+}
+// TODO: FunctionType
+
+impl Expression: ToCode
+impl Identifier: ToCode {
+  fun toCode(indention: Int): String {
+    mut let s = name
+    if prefix is Some {
+      print("f")
+      s = "{prefix}.{s}"
+    }
+    s
+  }
+}
+impl Literal: ToCode {
+  fun toCode(indention: Int): String {
+    "{this}"
+  }
+}
+impl Call: ToCode {
+  fun toCode(indention: Int): String {
+    mut let s = (target as ToCode).toCode(indention)
+    if (typeArguments as Iterable).isNotEmpty() {
+      s = "{s}<{(typeArguments as Iterable).join(", ")}>"
+    }
+    let arguments = (positionalArguments as Iterable)
+      .map<String>({ "{it}, " })
+      .followedBy(
+        namedArguments
+          .entries()
+          .map<String>({ "{it.first}: {it.second}" })
+      )
+      .join(", ")
+    s = "{s}({arguments})"
+  }
+}
+impl Navigation: ToCode {
+  fun toCode(indention: Int): String { "{target}.{property}" }
+}
+impl BinaryOperator: ToCode {
+  fun toCode(indention: Int): String { "{left} {operator} {right}" }
+}
+impl PrefixOperator: ToCode {
+  fun toCode(indention: Int): String { "{operator}{target}" }
+}
+impl Assignment: ToCode {
+  fun toCode(indention: Int): String {
+    "{left} = {right}"
+  }
+}
+// TODO: Closure
+
+impl Statement: ToCode
+impl ExpressionStatement: ToCode {
+  fun toCode(indention: Int): String { "{expression};" }
+}
+impl If: ToCode {
+  fun toCode(indention: Int): String {
+    let thenCode = (then as Iterable).map<String>({ "{it}🦄" }).join("")
+    let elseCode = (else as Iterable).map<String>({ "{it}🦄" }).join("")
+    "if ({condition}) 🦄{thenCode}🦄 else 🦄{elseCode}🦄"
+  }
+}
+// TODO: While

--- a/packages/dart_code_builder/src/to_code.candy
+++ b/packages/dart_code_builder/src/to_code.candy
@@ -15,6 +15,32 @@ fun indent(code: String, indentFirstLine: Bool): String {
   s
 }
 
+fun parametersToCode(
+  required: Iterable<String>,
+  positional: Iterable<String>,
+  named: Iterable<String>,
+): String {
+  let required = required.join(", ")
+  let positional = positional.join(", ")
+  let named = named.join(", ")
+
+  mut let parameters = required
+  if !(required == "") && (!(positional == "") || !(named == "")) {
+    parameters = "{parameters}, "
+  }
+  if !(positional == "") {
+    parameters = "{parameters}[{positional}]"
+  }
+  if !(named == "") {
+    parameters = "{parameters}\👍{named}}"
+  }
+  parameters
+}
+
+fun annotationsToCode(annotations: Iterable<Annotation>): String {
+  (annotations as Iterable<Annotation>).map<String>({ "{(it as ToCode).toCode()}\n" }).join("")
+}
+
 trait ToCode {
   fun toCode(): String
 }
@@ -66,10 +92,7 @@ let a = 3
 impl Declaration: ToCode
 impl Class: ToCode {
   fun toCode(): String {
-    let annotationsCode = (annotations as Iterable<Annotation>)
-      .map<String>({ (it as ToCode).toCode() })
-      .join("\n")
-    mut let s = "{annotationsCode}\nclass {name}"
+    mut let s = "{annotationsToCode(annotations)}class {name}"
     if extends_ is Some {
       s = "{s} extends {(extends_.unwrap() as ToCode).toCode()}"
     }
@@ -91,37 +114,62 @@ impl Class: ToCode {
     "{s} \👍\n{indent(bodyCode, true)}\n}"
   }
 }
+impl Constructor: ToCode {
+  fun toCode(): String {
+    mut let s = className
+    if name is Some {
+      s = "{s}.{name}"
+    }
+    s = "{annotationsToCode(annotations)}{s}"
+    let parameters = parametersToCode(
+      (requiredParameters as Iterable<Parameter | InitializingFormal>)
+        .map<String>({ (it as ToCode).toCode() }),
+      (positionalParameters as Iterable<Parameter | InitializingFormal>)
+        .map<String>({ (it as ToCode).toCode() }),
+      (namedParameters as Iterable<Parameter | InitializingFormal>)
+        .map<String>({ (it as ToCode).toCode() }),
+    )
+    if body is Some {
+      s = "{s} {(body.unwrap() as ToCode).toCode()}"
+    }
+    if body.map<Bool>({ it is InlineBody }).orElse({ true }) {
+      s = "{s};"
+    }
+  }
+}
+impl InitializingFormal: ToCode {
+  fun toCode(): String {
+    mut let s = "this.{name}"
+    if defaultValue is Some {
+      s = "{s} = {(defaultValue.unwrap() as ToCode).toCode()}"
+    }
+    s
+  }
+}
+impl Mixin: ToCode {
+  fun toCode(): String {
+    mut let s = "{annotationsToCode(annotations)}mixin {name}"
+    if on_ is Some {
+      s = "{s} on {(on_.unwrap() as ToCode).toCode()}"
+    }
+    let bodyCode = (body as Iterable<Field | Getter | Setter | Function>)
+      .map<String>({ (it as ToCode).toCode() })
+      .join("\n")
+    "{s} \👍\n{indent(bodyCode, true)}\n}"
+  }
+}
 impl Function: ToCode {
   fun toCode(): String {
     mut let s = name
     if _returns is Some {
       s = "{(_returns.unwrap() as ToCode).toCode()} {s}"
     }
-    if (annotations as Iterable).isNotEmpty() {
-      let annotationsCode = (annotations as Iterable<Annotation>)
-        .map<String>({ (it as ToCode).toCode() })
-        .join("\n")
-      s = "{annotationsCode}\n{s}"
-    }
-    let required = (requiredParameters as Iterable<Parameter>)
-      .map<String>({ (it as ToCode).toCode() })
-      .join(", ")
-    let positional = (positionalParameters as Iterable<Parameter>)
-      .map<String>({ (it as ToCode).toCode() })
-      .join(", ")
-    let named = (namedParameters as Iterable<Parameter>)
-      .map<String>({ (it as ToCode).toCode() })
-      .join(", ")
-    mut let parameters = ""
-    if !(required == "") && (!(positional == "") || !(named == "")) {
-      parameters = "{required}, "
-    }
-    if !(positional == "") {
-      parameters = "{parameters}[{positional}]"
-    }
-    if !(named == "") {
-      parameters = "{parameters}\👍{named}}"
-    }
+    s = "{annotationsToCode(annotations)}{s}"
+    let parameters = parametersToCode(
+      (requiredParameters as Iterable<Parameter>).map<String>({ (it as ToCode).toCode() }),
+      (positionalParameters as Iterable<Parameter>).map<String>({ (it as ToCode).toCode() }),
+      (namedParameters as Iterable<Parameter>).map<String>({ (it as ToCode).toCode() }),
+    )
     s = "{s}({parameters})"
     if body is Some {
       s = "{s} {(body.unwrap() as ToCode).toCode()}"
@@ -314,7 +362,7 @@ impl ExpressionStatement: ToCode {
 impl Return: ToCode {
   fun toCode(): String {
     if expression is Some {
-      "return {(expression as ToCode).toCode()};"
+      "return {(expression.unwrap() as ToCode).toCode()};"
     } else {
       "return;"
     }

--- a/packages/dart_code_builder/src/to_code.candy
+++ b/packages/dart_code_builder/src/to_code.candy
@@ -203,7 +203,7 @@ impl InlineBody: ToCode {
     "=> {(expression as ToCode).toCode()}"
   }
 }
-impl BlockBody: ToCode {
+impl Block: ToCode {
   fun toCode(): String {
     let statementsCode = (statements as Iterable<Statement>)
       .map<String>({ (it as ToCode).toCode() })
@@ -215,10 +215,7 @@ impl BlockBody: ToCode {
 impl DartType: ToCode
 impl NamedType: ToCode {
   fun toCode(): String {
-    mut let s = name
-    if prefix is Some {
-      s = "{prefix.unwrap()}.{s}"
-    }
+    mut let s = (name as ToCode).toCode()
     if (typeArguments as Iterable).isNotEmpty() {
       let generics = (typeArguments as Iterable<DartType>)
         .map<String>({ (it as ToCode).toCode() })
@@ -258,10 +255,17 @@ impl Identifier: ToCode {
     s
   }
 }
-impl Literal: ToCode {
-  fun toCode(): String {
-    "{value}"
-  }
+impl NullLiteral: ToCode {
+  fun toCode(): String { "null" }
+}
+impl StringLiteral: ToCode {
+  fun toCode(): String { "\🦄{value}\🦄" }
+}
+impl IntLiteral: ToCode {
+  fun toCode(): String { "{value}" }
+}
+impl BoolLiteral: ToCode {
+  fun toCode(): String { "{value}" }
 }
 impl Call: ToCode {
   fun toCode(): String {
@@ -327,13 +331,11 @@ impl Break: ToCode {
 }
 impl If: ToCode {
   fun toCode(): String {
-    let thenCode = (then as Iterable<Statement>)
-      .map<String>({ it: Statement => "  {(it as ToCode).toCode()}" })
-      .join("\n")
-    let elseCode = (else_ as Iterable<Statement>)
-      .map<String>({ it: Statement => "  {(it as ToCode).toCode()}" })
-      .join("\n")
-    "if ({(condition as ToCode).toCode()}) \👍\n{thenCode}\n} else \👍\n{elseCode}\n}"
+    mut let s = "if ({(condition as ToCode).toCode()}) {(then as ToCode).toCode()}"
+    if else_ is Some {
+      s = "{s} else {(else_.unwrap() as ToCode).toCode()}"
+    }
+    s
   }
 }
 impl While: ToCode {
@@ -342,9 +344,6 @@ impl While: ToCode {
     if label is Some {
       s = "{label.unwrap()}:\n{s}"
     }
-    let bodyCode = (body as Iterable<Statement>)
-      .map<String>({ (it as ToCode).toCode() })
-      .join("\n")
-    "{s} \👍\n{indent(bodyCode, true)}\n}"
+    "{s} \👍\n{indent((body as ToCode).toCode(), true)}\n}"
   }
 }

--- a/packages/dart_code_builder/src/to_code.candy
+++ b/packages/dart_code_builder/src/to_code.candy
@@ -1,5 +1,20 @@
 use ..nodes
 
+fun indent(code: String, indentFirstLine: Bool): String {
+  mut let s = ""
+  if indentFirstLine {
+    s = "  "
+  }
+  for char in code.characters() {
+    if char == "\n" {
+      s = "{s}\n  "
+    } else {
+      s = "{s}{char}"
+    }
+  }
+  s
+}
+
 trait ToCode {
   fun toCode(): String
 }
@@ -67,9 +82,9 @@ impl Class: ToCode {
       s = "{s} with {withCode}"
     }
     let bodyCode = (body as Iterable<Field | Getter | Setter | Function>)
-      .map<String>({ "  {(it as ToCode).toCode()}" })
+      .map<String>({ (it as ToCode).toCode() })
       .join("\n")
-    "{s} \👍\n{bodyCode}\n}"
+    "{s} \👍\n{indent(bodyCode, true)}\n}"
   }
 }
 impl Function: ToCode {
@@ -78,28 +93,30 @@ impl Function: ToCode {
     if _returns is Some {
       s = "{(_returns.unwrap() as ToCode).toCode()} {s}"
     }
-    mut let parameters = (requiredParameters as Iterable<Parameter>)
+    let required = (requiredParameters as Iterable<Parameter>)
       .map<String>({ (it as ToCode).toCode() })
       .join(", ")
-    let positionalParameters = (positionalParameters as Iterable<Parameter>)
+    let positional = (positionalParameters as Iterable<Parameter>)
       .map<String>({ (it as ToCode).toCode() })
       .join(", ")
-    let namedParameters = (namedParameters as Iterable<Parameter>)
+    let named = (namedParameters as Iterable<Parameter>)
       .map<String>({ (it as ToCode).toCode() })
       .join(", ")
-    if !(parameters == "") && (!(positionalParameters == "") || !(namedParameters == "")) {
-      parameters = "{parameters}, "
+    mut let parameters = ""
+    if !(required == "") && (!(positional == "") || !(named == "")) {
+      parameters = "{required}, "
     }
-    if !(positionalParameters == "") {
-      parameters = "{parameters}[{positionalParameters}]"
+    if !(positional == "") {
+      parameters = "{parameters}[{positional}]"
     }
-    if !(namedParameters == "") {
-      parameters = "{parameters}\👍{namedParameters}}"
+    if !(named == "") {
+      parameters = "{parameters}\👍{named}}"
     }
     s = "{s}({parameters})"
     if body is Some {
       s = "{s} {body}"
-    } else {
+    }
+    if body.map<Bool>({ it is InlineBody }).orElse({ true }) {
       s = "{s};"
     }
     s
@@ -107,12 +124,30 @@ impl Function: ToCode {
 }
 impl Parameter: ToCode {
   fun toCode(): String {
-    "Parameter" // TODO(marcelgarus): Implement.
+    mut let s = name
+    if type is Some {
+      s = "{(type.unwrap() as ToCode).toCode()} {s}"
+    }
+    if defaultValue is Some {
+      s = "{s} = {(defaultValue.unwrap() as ToCode).toCode()}"
+    }
+    s
   }
 }
 impl Field: ToCode {
   fun toCode(): String {
-    "Field" // TODO(marcelgarus): Implement.
+    mut let s = name
+    if !(mutability is Var) {
+      s = "{(mutability as ToCode).toCode()} {s}"
+    }
+    if isStatic {
+      s = "static {s}"
+    }
+    if initialValue is Some {
+      s = "{s} = {(initialValue.unwrap() as ToCode).toCode()}"
+    }
+    s = "{s};"
+    s
   }
 }
 
@@ -129,24 +164,41 @@ impl Const: ToCode {
 
 impl Getter: ToCode {
   fun toCode(): String {
-    "Getter" // TODO(marcelgarus): Implement.
+    mut let s = "{(type as ToCode).toCode()} get {name}"
+    if body is Some {
+      s = "{s} {(body.unwrap() as ToCode).toCode()}"
+    }
+    if body.map<Bool>({ it is InlineBody }).orElse({ true }) {
+      s = "{s};"
+    }
+    s
   }
 }
 impl Setter: ToCode {
   fun toCode(): String {
-    "Setter" // TODO(marcelgarus): Implement.
+    mut let s = "set {name}({(parameter as ToCode).toCode()})"
+    if body is Some {
+      s = "{s} {(body.unwrap() as ToCode).toCode()}"
+    }
+    if body.map<Bool>({ it is InlineBody }).orElse({ true }) {
+      s = "{s};"
+    }
+    s
   }
 }
 
 impl Body: ToCode
 impl InlineBody: ToCode {
   fun toCode(): String {
-    "=> {expression}"
+    "=> {(expression as ToCode).toCode()}"
   }
 }
 impl BlockBody: ToCode {
   fun toCode(): String {
-    "🦄{(statements as Iterable).join("\n")}🦄"
+    let statementsCode = (statements as Iterable<Statement>)
+      .map<String>({ (it as ToCode).toCode() })
+      .join("\n")
+    "\👍\n{indent(statementsCode, true)}\n}"
   }
 }
 
@@ -158,7 +210,10 @@ impl UserType: ToCode {
       s = "{prefix.unwrap()}.{s}"
     }
     if (parameters as Iterable).isNotEmpty() {
-      s = "{s}<{(parameters as Iterable).join(", ")}>"
+      let generics = (parameters as Iterable<DartType>)
+        .map<String>({ (it as ToCode).toCode() })
+        .join(", ")
+      s = "{s}<{generics}>"
     }
     s
   }
@@ -195,38 +250,41 @@ impl Identifier: ToCode {
 }
 impl Literal: ToCode {
   fun toCode(): String {
-    "{this}"
+    "{value}"
   }
 }
 impl Call: ToCode {
   fun toCode(): String {
     mut let s = (target as ToCode).toCode()
-    if (typeArguments as Iterable).isNotEmpty() {
-      s = "{s}<{(typeArguments as Iterable).join(", ")}>"
+    let typeArgumentsCode = (typeArguments as Iterable<DartType>)
+      .map<String>({ (it as ToCode).toCode() })
+      .join(", ")
+    if !(typeArgumentsCode == "") {
+      s = "{s}<{typeArgumentsCode}>"
     }
     let arguments = (positionalArguments as Iterable<Expression>)
-      .map<String>({ "{it}, " })
+      .map<String>({ (it as ToCode).toCode() })
       .followedBy(
         namedArguments
           .entries()
-          .map<String>({ "{it.first}: {it.second}" })
+          .map<String>({ "{it.first}: {(it.second as ToCode).toCode()}" })
       )
       .join(", ")
     s = "{s}({arguments})"
   }
 }
 impl Navigation: ToCode {
-  fun toCode(): String { "{target}.{property}" }
+  fun toCode(): String { "{(target as ToCode).toCode()}.{property}" }
 }
 impl BinaryOperator: ToCode {
-  fun toCode(): String { "{left} {operator} {right}" }
+  fun toCode(): String { "{(left as ToCode).toCode()} {operator} {(right as ToCode).toCode()}" }
 }
 impl PrefixOperator: ToCode {
-  fun toCode(): String { "{operator}{target}" }
+  fun toCode(): String { "{operator}{(target as ToCode).toCode()}" }
 }
 impl Assignment: ToCode {
   fun toCode(): String {
-    "{left} = {right}"
+    "{(left as ToCode).toCode()} = {(right as ToCode).toCode()}"
   }
 }
 impl Closure: ToCode {
@@ -237,17 +295,17 @@ impl Closure: ToCode {
 
 impl Statement: ToCode
 impl ExpressionStatement: ToCode {
-  fun toCode(): String { "{expression};" }
+  fun toCode(): String { "{(expression as ToCode).toCode()};" }
 }
 impl If: ToCode {
   fun toCode(): String {
     let thenCode = (then as Iterable<Statement>)
-      .map<String>({ it: Statement => "{it}🦄" })
-      .join("")
+      .map<String>({ it: Statement => "  {(it as ToCode).toCode()}" })
+      .join("\n")
     let elseCode = (else_ as Iterable<Statement>)
-      .map<String>({ it: Statement => "{it}🦄" })
-      .join("")
-    "if ({condition}) 🦄{thenCode}🦄 else 🦄{elseCode}🦄"
+      .map<String>({ it: Statement => "  {(it as ToCode).toCode()}" })
+      .join("\n")
+    "if ({(condition as ToCode).toCode()}) \👍\n{thenCode}\n} else \👍\n{elseCode}\n}"
   }
 }
 impl While: ToCode {

--- a/packages/dart_code_builder/src/to_code.candy
+++ b/packages/dart_code_builder/src/to_code.candy
@@ -22,10 +22,10 @@ trait ToCode {
 impl CompilationUnit: ToCode {
   fun toCode(): String {
     let directivesCode = (directives as Iterable<Directive>)
-      .map({ (it as ToCode).toCode() })
+      .map<String>({ (it as ToCode).toCode() })
       .join("\n")
     let declarationsCode = (declarations as Iterable<Declaration>)
-      .map({ (it as ToCode).toCode() })
+      .map<String>({ (it as ToCode).toCode() })
       .join("\n")
     "{directivesCode}\n\n{declarationsCode}"
   }

--- a/packages/dart_code_builder/src/to_code.candy
+++ b/packages/dart_code_builder/src/to_code.candy
@@ -213,7 +213,7 @@ impl BlockBody: ToCode {
 }
 
 impl DartType: ToCode
-impl UserType: ToCode {
+impl NamedType: ToCode {
   fun toCode(): String {
     mut let s = name
     if prefix is Some {

--- a/packages/dart_code_builder/src/to_code.candy
+++ b/packages/dart_code_builder/src/to_code.candy
@@ -204,7 +204,7 @@ impl Call: ToCode {
     if (typeArguments as Iterable).isNotEmpty() {
       s = "{s}<{(typeArguments as Iterable).join(", ")}>"
     }
-    let arguments = (positionalArguments as Iterable)
+    let arguments = (positionalArguments as Iterable<Expression>)
       .map<String>({ "{it}, " })
       .followedBy(
         namedArguments

--- a/packages/dart_code_builder/src/to_code.candy
+++ b/packages/dart_code_builder/src/to_code.candy
@@ -40,8 +40,8 @@ impl Directive: ToCode
 impl Import: ToCode {
   fun toCode(): String {
     mut let s = "import '{path}'"
-    if alias is Some {
-      s = "{s} as {alias.unwrap()}"
+    if prefix is Some {
+      s = "{s} as {prefix.unwrap()}"
     }
     if (show as Iterable).isNotEmpty() {
       s = "{s} show {(show as Iterable).join(", ")}"

--- a/packages/dart_code_builder/src/to_code.candy
+++ b/packages/dart_code_builder/src/to_code.candy
@@ -27,8 +27,10 @@ impl Import: ToCode {
     if (show as Iterable).isNotEmpty() {
       s = "{s} show {(show as Iterable).join(", ")}"
     }
-    // TODO(marcelgarus): Use hide
-    s
+    if (hide as Iterable).isNotEmpty() {
+      s = "{s} hide {(hide as Iterable).join(", ")}"
+    }
+    "{s};"
   }
 }
 

--- a/packages/dart_code_builder/src/to_code.candy
+++ b/packages/dart_code_builder/src/to_code.candy
@@ -43,11 +43,76 @@ impl PartOf: ToCode {
 let a = 3
 
 impl Declaration: ToCode
-
-// TODO: Class
-// TODO: Function
-// TODO: Parameter
-// TODO: Field
+impl Class: ToCode {
+  fun toCode(): String {
+    let annotationsCode = (annotations as Iterable<Annotation>)
+      .map<String>({ (it as ToCode).toCode() })
+      .join("\n")
+    mut let s = "{annotationsCode}\nclass {name}"
+    if extends_ is Some {
+      s = "{s} extends {(extends_.unwrap() as ToCode).toCode()}"
+    }
+    if (implements_ as Iterable).isNotEmpty() {
+      let implementsCode = (implements_ as Iterable<DartType>)
+        .map<String>({ (it as ToCode).toCode() })
+        .join(", ")
+      s = "{s} implements {implementsCode}"
+    }
+    if (with_ as Iterable).isNotEmpty() {
+      let withCode = (with_ as Iterable<DartType>)
+        .map<String>({ (it as ToCode).toCode() })
+        .join(", ")
+      s = "{s} with {withCode}"
+    }
+    let bodyCode = (body as Iterable<Field | Getter | Setter | Function>)
+      .map<String>({ "  {(it as ToCode).toCode()}" })
+      .join("\n")
+    "{s} \👍\n{bodyCode}\n}"
+  }
+}
+impl Function: ToCode {
+  fun toCode(): String {
+    mut let s = name
+    if _returns is Some {
+      s = "{(_returns.unwrap() as ToCode).toCode()} {s}"
+    }
+    mut let parameters = (requiredParameters as Iterable<Parameter>)
+      .map<String>({ (it as ToCode).toCode() })
+      .join(", ")
+    let positionalParameters = (positionalParameters as Iterable<Parameter>)
+      .map<String>({ (it as ToCode).toCode() })
+      .join(", ")
+    let namedParameters = (namedParameters as Iterable<Parameter>)
+      .map<String>({ (it as ToCode).toCode() })
+      .join(", ")
+    if !(parameters == "") && (!(positionalParameters == "") || !(namedParameters == "")) {
+      parameters = "{parameters}, "
+    }
+    if !(positionalParameters == "") {
+      parameters = "{parameters}[{positionalParameters}]"
+    }
+    if !(namedParameters == "") {
+      parameters = "{parameters}\👍{namedParameters}}"
+    }
+    s = "{s}({parameters})"
+    if body is Some {
+      s = "{s} {body}"
+    } else {
+      s = "{s};"
+    }
+    s
+  }
+}
+impl Parameter: ToCode {
+  fun toCode(): String {
+    "Parameter" // TODO(marcelgarus): Implement.
+  }
+}
+impl Field: ToCode {
+  fun toCode(): String {
+    "Field" // TODO(marcelgarus): Implement.
+  }
+}
 
 impl Mutability: ToCode
 impl Var: ToCode {
@@ -60,8 +125,16 @@ impl Const: ToCode {
   fun toCode(): String { "const" }
 }
 
-// TOOD: Getter
-// TOOD: Setter
+impl Getter: ToCode {
+  fun toCode(): String {
+    "Getter" // TODO(marcelgarus): Implement.
+  }
+}
+impl Setter: ToCode {
+  fun toCode(): String {
+    "Setter" // TODO(marcelgarus): Implement.
+  }
+}
 
 impl Body: ToCode
 impl InlineBody: ToCode {
@@ -106,7 +179,6 @@ impl FunctionType: ToCode {
     s
   }
 }
-// TODO: FunctionType
 
 impl Expression: ToCode
 impl Identifier: ToCode {
@@ -155,7 +227,11 @@ impl Assignment: ToCode {
     "{left} = {right}"
   }
 }
-// TODO: Closure
+impl Closure: ToCode {
+  fun toCode(): String {
+    "Closure" // TODO(marcelgarus): Implement.
+  }
+}
 
 impl Statement: ToCode
 impl ExpressionStatement: ToCode {
@@ -172,4 +248,8 @@ impl If: ToCode {
     "if ({condition}) 🦄{thenCode}🦄 else 🦄{elseCode}🦄"
   }
 }
-// TODO: While
+impl While: ToCode {
+  fun toCode(): String {
+    "While" // TODO(marcelgarus): Implement.
+  }
+}

--- a/packages/dart_code_builder/src/to_code.candy
+++ b/packages/dart_code_builder/src/to_code.candy
@@ -92,7 +92,7 @@ let a = 3
 impl Declaration: ToCode
 impl Class: ToCode {
   fun toCode(): String {
-    mut let s = "{annotationsToCode(annotations)}class {name}"
+    mut let s = "{annotationsToCode(annotations)} class {name}"
     if extends_ is Some {
       s = "{s} extends {(extends_.unwrap() as ToCode).toCode()}"
     }
@@ -120,7 +120,7 @@ impl Constructor: ToCode {
     if name is Some {
       s = "{s}.{name}"
     }
-    s = "{annotationsToCode(annotations)}{s}"
+    s = "{annotationsToCode(annotations)} {s}"
     let parameters = parametersToCode(
       (requiredParameters as Iterable<Parameter | InitializingFormal>)
         .map<String>({ (it as ToCode).toCode() }),
@@ -148,7 +148,7 @@ impl InitializingFormal: ToCode {
 }
 impl Mixin: ToCode {
   fun toCode(): String {
-    mut let s = "{annotationsToCode(annotations)}mixin {name}"
+    mut let s = "{annotationsToCode(annotations)} mixin {name}"
     if on_ is Some {
       s = "{s} on {(on_.unwrap() as ToCode).toCode()}"
     }
@@ -164,7 +164,7 @@ impl Function: ToCode {
     if _returns is Some {
       s = "{(_returns.unwrap() as ToCode).toCode()} {s}"
     }
-    s = "{annotationsToCode(annotations)}{s}"
+    s = "{annotationsToCode(annotations)} {s}"
     let parameters = parametersToCode(
       (requiredParameters as Iterable<Parameter>).map<String>({ (it as ToCode).toCode() }),
       (positionalParameters as Iterable<Parameter>).map<String>({ (it as ToCode).toCode() }),

--- a/packages/dart_code_builder/src/to_code.candy
+++ b/packages/dart_code_builder/src/to_code.candy
@@ -219,8 +219,8 @@ impl NamedType: ToCode {
     if prefix is Some {
       s = "{prefix.unwrap()}.{s}"
     }
-    if (parameters as Iterable).isNotEmpty() {
-      let generics = (parameters as Iterable<DartType>)
+    if (typeArguments as Iterable).isNotEmpty() {
+      let generics = (typeArguments as Iterable<DartType>)
         .map<String>({ (it as ToCode).toCode() })
         .join(", ")
       s = "{s}<{generics}>"

--- a/packages/dart_code_builder/src/to_code.candy
+++ b/packages/dart_code_builder/src/to_code.candy
@@ -93,6 +93,12 @@ impl Function: ToCode {
     if _returns is Some {
       s = "{(_returns.unwrap() as ToCode).toCode()} {s}"
     }
+    if (annotations as Iterable).isNotEmpty() {
+      let annotationsCode = (annotations as Iterable<Annotation>)
+        .map<String>({ (it as ToCode).toCode() })
+        .join("\n")
+      s = "{annotationsCode}\n{s}"
+    }
     let required = (requiredParameters as Iterable<Parameter>)
       .map<String>({ (it as ToCode).toCode() })
       .join(", ")

--- a/packages/dart_code_builder/src/to_code.candy
+++ b/packages/dart_code_builder/src/to_code.candy
@@ -19,11 +19,15 @@ trait ToCode {
   fun toCode(): String
 }
 
-impl File: ToCode {
+impl CompilationUnit: ToCode {
   fun toCode(): String {
-    (parts as Iterable<Directive | Declaration>)
-      .map<String>({ (it as ToCode).toCode() })
+    let directivesCode = (directives as Iterable<Directive>)
+      .map({ (it as ToCode).toCode() })
       .join("\n")
+    let declarationsCode = (declarations as Iterable<Declaration>)
+      .map({ (it as ToCode).toCode() })
+      .join("\n")
+    "{directivesCode}\n\n{declarationsCode}"
   }
 }
 

--- a/packages/dart_code_builder/src/to_code.candy
+++ b/packages/dart_code_builder/src/to_code.candy
@@ -303,6 +303,9 @@ impl Statement: ToCode
 impl ExpressionStatement: ToCode {
   fun toCode(): String { "{(expression as ToCode).toCode()};" }
 }
+impl Return: ToCode {
+  fun toCode(): String { "return {(expression as ToCode).toCode()};" }
+}
 impl If: ToCode {
   fun toCode(): String {
     let thenCode = (then as Iterable<Statement>)

--- a/packages/dart_code_builder/src/to_code.candy
+++ b/packages/dart_code_builder/src/to_code.candy
@@ -406,6 +406,6 @@ impl While: ToCode {
     if label is Some {
       s = "{label.unwrap()}:\n{s}"
     }
-    "{s} \👍\n{indent((body as ToCode).toCode(), true)}\n}"
+    "{s} {indent((body as ToCode).toCode(), true)}"
   }
 }

--- a/packages/dart_code_builder/src/to_code.candy
+++ b/packages/dart_code_builder/src/to_code.candy
@@ -377,6 +377,15 @@ impl Break: ToCode {
     }
   }
 }
+impl Continue: ToCode {
+  fun toCode(): String {
+    if label is Some {
+      "continue {label.unwrap()};"
+    } else {
+      "continue;"
+    }
+  }
+}
 impl If: ToCode {
   fun toCode(): String {
     mut let s = "if ({(condition as ToCode).toCode()}) {(then as ToCode).toCode()}"

--- a/packages/dart_code_builder/src/to_code.candy
+++ b/packages/dart_code_builder/src/to_code.candy
@@ -120,7 +120,7 @@ impl Function: ToCode {
     }
     s = "{s}({parameters})"
     if body is Some {
-      s = "{s} {body}"
+      s = "{s} {(body.unwrap() as ToCode).toCode()}"
     }
     if body.map<Bool>({ it is InlineBody }).orElse({ true }) {
       s = "{s};"
@@ -304,7 +304,22 @@ impl ExpressionStatement: ToCode {
   fun toCode(): String { "{(expression as ToCode).toCode()};" }
 }
 impl Return: ToCode {
-  fun toCode(): String { "return {(expression as ToCode).toCode()};" }
+  fun toCode(): String {
+    if expression is Some {
+      "return {(expression as ToCode).toCode()};"
+    } else {
+      "return;"
+    }
+  }
+}
+impl Break: ToCode {
+  fun toCode(): String {
+    if label is Some {
+      "break {label.unwrap()};"
+    } else {
+      "break;"
+    }
+  }
 }
 impl If: ToCode {
   fun toCode(): String {
@@ -319,6 +334,13 @@ impl If: ToCode {
 }
 impl While: ToCode {
   fun toCode(): String {
-    "While" // TODO(marcelgarus): Implement.
+    mut let s = "while ({(condition as ToCode).toCode()})"
+    if label is Some {
+      s = "{label.unwrap()}:\n{s}"
+    }
+    let bodyCode = (body as Iterable<Statement>)
+      .map<String>({ (it as ToCode).toCode() })
+      .join("\n")
+    "{s} \👍\n{indent(bodyCode, true)}\n}"
   }
 }

--- a/packages/dart_code_builder/src/to_code.candy
+++ b/packages/dart_code_builder/src/to_code.candy
@@ -1,10 +1,7 @@
 use ..nodes
 
-fun indent(code: String, indentFirstLine: Bool): String {
-  mut let s = ""
-  if indentFirstLine {
-    s = "  "
-  }
+fun indent(code: String): String {
+  mut let s = " "
   for char in code.characters() {
     if char == "\n" {
       s = "{s}\n  "
@@ -87,8 +84,6 @@ impl PartOf: ToCode {
   fun toCode(): String { "part of '{path}';" }
 }
 
-let a = 3
-
 impl Declaration: ToCode
 impl Class: ToCode {
   fun toCode(): String {
@@ -108,10 +103,10 @@ impl Class: ToCode {
         .join(", ")
       s = "{s} with {withCode}"
     }
-    let bodyCode = (body as Iterable<Field | Getter | Setter | Function>)
+    let bodyCode = (body as Iterable<Constructor | Field | Getter | Setter | Function>)
       .map<String>({ (it as ToCode).toCode() })
       .join("\n")
-    "{s} \👍\n{indent(bodyCode, true)}\n}"
+    "{s} \👍\n{indent(bodyCode)}\n}"
   }
 }
 impl Constructor: ToCode {
@@ -155,7 +150,7 @@ impl Mixin: ToCode {
     let bodyCode = (body as Iterable<Field | Getter | Setter | Function>)
       .map<String>({ (it as ToCode).toCode() })
       .join("\n")
-    "{s} \👍\n{indent(bodyCode, true)}\n}"
+    "{s} \👍\n{indent(bodyCode)}\n}"
   }
 }
 impl Function: ToCode {
@@ -256,7 +251,7 @@ impl Block: ToCode {
     let statementsCode = (statements as Iterable<Statement>)
       .map<String>({ (it as ToCode).toCode() })
       .join("\n")
-    "\👍\n{indent(statementsCode, true)}\n}"
+    "\👍\n{indent(statementsCode)}\n}"
   }
 }
 
@@ -293,7 +288,6 @@ impl Identifier: ToCode {
   fun toCode(): String {
     mut let s = name
     if prefix is Some {
-      print("f")
       s = "{prefix}.{s}"
     }
     s
@@ -406,6 +400,6 @@ impl While: ToCode {
     if label is Some {
       s = "{label.unwrap()}:\n{s}"
     }
-    "{s} {indent((body as ToCode).toCode(), true)}"
+    "{s} {indent((body as ToCode).toCode())}"
   }
 }

--- a/packages/dart_code_builder/src/to_code.candy
+++ b/packages/dart_code_builder/src/to_code.candy
@@ -347,7 +347,16 @@ impl Assignment: ToCode {
 }
 impl Closure: ToCode {
   fun toCode(): String {
-    "Closure" // TODO(marcelgarus): Implement.
+    let parameters = parametersToCode(
+      (requiredParameters as Iterable<Parameter>).map<String>({ (it as ToCode).toCode() }),
+      (positionalParameters as Iterable<Parameter>).map<String>({ (it as ToCode).toCode() }),
+      (namedParameters as Iterable<Parameter>).map<String>({ (it as ToCode).toCode() }),
+    )
+    mut let s = "({parameters}) {(body as ToCode).toCode()}"
+    if body is InlineBody {
+      s = "{s};"
+    }
+    s
   }
 }
 

--- a/packages/dart_code_builder/src/to_code.candy
+++ b/packages/dart_code_builder/src/to_code.candy
@@ -276,19 +276,15 @@ impl NamedType: ToCode {
 impl FunctionType: ToCode {
   fun toCode(): String {
     mut let s = "Function"
-    // if returns is Some {
-    //   s = "{returns} {s}"
-    // }
-    s = "{s}("
-    // s = "{s}{(parameters as Iterable).map<String>({ "{it}," }).join("")}"
-    // for parameter in parameters {
-    //   s = "{s}{parameter},"
-    // }
-    // if positionalParameters.isNotEmpty() {
-    //   s = "{"
-    // }
-    s = "{s})"
-    s
+    if _returns is Some {
+      s = "{(_returns.unwrap() as ToCode).toCode()} {s}"
+    }
+    let parameters = parametersToCode(
+      (parameters as Iterable<Parameter>).map<String>({ (it as ToCode).toCode() }),
+      (positionalParameters as Iterable<Parameter>).map<String>({ (it as ToCode).toCode() }),
+      (namedParameters as Iterable<Parameter>).map<String>({ (it as ToCode).toCode() }),
+    )
+    "{s}(parameters)"
   }
 }
 

--- a/packages/dart_code_builder/src/to_code.candy
+++ b/packages/dart_code_builder/src/to_code.candy
@@ -1,29 +1,25 @@
 use ..nodes
 
 trait ToCode {
-  fun toCode(indention: Int): String
+  fun toCode(): String
 }
 
 impl File: ToCode {
-  fun toCode(indention: Int): String {
-    mut let s = ""
-    for part in parts {
-      s = "{s}{(part as ToCode).toCode(indention)}"
-    }
-    s
+  fun toCode(): String {
+    (parts as Iterable<Directive | Declaration>)
+      .map<String>({ (it as ToCode).toCode() })
+      .join("\n")
   }
 }
 
 impl Annotation: ToCode {
-  fun toCode(indention: Int): String {
-    "@{(expression as ToCode).toCode(indention)}"
-  }
+  fun toCode(): String { "@{(expression as ToCode).toCode()}" }
 }
 
 impl Directive: ToCode
 
 impl Import: ToCode {
-  fun toCode(indention: Int): String {
+  fun toCode(): String {
     mut let s = "import '{path}'"
     if alias is Some {
       s = "{s} as {alias.unwrap()}"
@@ -37,15 +33,11 @@ impl Import: ToCode {
 }
 
 impl Part: ToCode {
-  fun toCode(indention: Int): String {
-    "part '{path}';"
-  }
+  fun toCode(): String { "part '{path}';" }
 }
 
 impl PartOf: ToCode {
-  fun toCode(indention: Int): String {
-    "part of '{path}';"
-  }
+  fun toCode(): String { "part of '{path}';" }
 }
 
 let a = 3
@@ -59,13 +51,13 @@ impl Declaration: ToCode
 
 impl Mutability: ToCode
 impl Var: ToCode {
-  fun toCode(indention: Int): String { "var" }
+  fun toCode(): String { "var" }
 }
 impl Final: ToCode {
-  fun toCode(indention: Int): String { "final" }
+  fun toCode(): String { "final" }
 }
 impl Const: ToCode {
-  fun toCode(indention: Int): String { "const" }
+  fun toCode(): String { "const" }
 }
 
 // TOOD: Getter
@@ -73,19 +65,19 @@ impl Const: ToCode {
 
 impl Body: ToCode
 impl InlineBody: ToCode {
-  fun toCode(indention: Int): String {
+  fun toCode(): String {
     "=> {expression}"
   }
 }
 impl BlockBody: ToCode {
-  fun toCode(indention: Int): String {
+  fun toCode(): String {
     "🦄{(statements as Iterable).join("\n")}🦄"
   }
 }
 
 impl DartType: ToCode
 impl UserType: ToCode {
-  fun toCode(indention: Int): String {
+  fun toCode(): String {
     mut let s = name
     if prefix is Some {
       s = "{prefix.unwrap()}.{s}"
@@ -97,7 +89,7 @@ impl UserType: ToCode {
   }
 }
 impl FunctionType: ToCode {
-  fun toCode(indention: Int): String {
+  fun toCode(): String {
     mut let s = "Function"
     // if returns is Some {
     //   s = "{returns} {s}"
@@ -118,7 +110,7 @@ impl FunctionType: ToCode {
 
 impl Expression: ToCode
 impl Identifier: ToCode {
-  fun toCode(indention: Int): String {
+  fun toCode(): String {
     mut let s = name
     if prefix is Some {
       print("f")
@@ -128,13 +120,13 @@ impl Identifier: ToCode {
   }
 }
 impl Literal: ToCode {
-  fun toCode(indention: Int): String {
+  fun toCode(): String {
     "{this}"
   }
 }
 impl Call: ToCode {
-  fun toCode(indention: Int): String {
-    mut let s = (target as ToCode).toCode(indention)
+  fun toCode(): String {
+    mut let s = (target as ToCode).toCode()
     if (typeArguments as Iterable).isNotEmpty() {
       s = "{s}<{(typeArguments as Iterable).join(", ")}>"
     }
@@ -150,16 +142,16 @@ impl Call: ToCode {
   }
 }
 impl Navigation: ToCode {
-  fun toCode(indention: Int): String { "{target}.{property}" }
+  fun toCode(): String { "{target}.{property}" }
 }
 impl BinaryOperator: ToCode {
-  fun toCode(indention: Int): String { "{left} {operator} {right}" }
+  fun toCode(): String { "{left} {operator} {right}" }
 }
 impl PrefixOperator: ToCode {
-  fun toCode(indention: Int): String { "{operator}{target}" }
+  fun toCode(): String { "{operator}{target}" }
 }
 impl Assignment: ToCode {
-  fun toCode(indention: Int): String {
+  fun toCode(): String {
     "{left} = {right}"
   }
 }
@@ -167,12 +159,16 @@ impl Assignment: ToCode {
 
 impl Statement: ToCode
 impl ExpressionStatement: ToCode {
-  fun toCode(indention: Int): String { "{expression};" }
+  fun toCode(): String { "{expression};" }
 }
 impl If: ToCode {
-  fun toCode(indention: Int): String {
-    let thenCode = (then as Iterable).map<String>({ "{it}🦄" }).join("")
-    let elseCode = (else as Iterable).map<String>({ "{it}🦄" }).join("")
+  fun toCode(): String {
+    let thenCode = (then as Iterable<Statement>)
+      .map<String>({ it: Statement => "{it}🦄" })
+      .join("")
+    let elseCode = (else_ as Iterable<Statement>)
+      .map<String>({ it: Statement => "{it}🦄" })
+      .join("")
     "if ({condition}) 🦄{thenCode}🦄 else 🦄{elseCode}🦄"
   }
 }


### PR DESCRIPTION
This PR adds the dart_code_builder package and some missing functionality to core.

Of course, there's still Dart functionality missing (most importantly, utilities for common objects like the `@override` annotation etc.). Builders for files and expressions that handle allocating identifiers and dynamically adding imports would also be nice.
But since there's some changes in core and the bottom layer of the code building is already implemented, I think it's still a good time to merge.