### PR TITLE
Case-sensitive parser

### DIFF
--- a/packages/ast/src/errors/expected_identifier.candy
+++ b/packages/ast/src/errors/expected_identifier.candy
@@ -14,7 +14,7 @@ impl ExpectedIdentifierCompilerError: CompilerError {
       return node.cast<CstNavigationExpression>().child.dot.child.span
     }
     if node.child is CstValueArgument {
-      return node.cast<CstValueArgument>().child.equalsSign.child.span
+      return node.cast<CstValueArgument>().child.name.unwrap().second.child.span
     }
     throw "Unknown body: {node}."
   }

--- a/packages/ast/src/errors/expected_two_or_more_items_in_tuple.candy
+++ b/packages/ast/src/errors/expected_two_or_more_items_in_tuple.candy
@@ -1,5 +1,6 @@
 use compiler_utils
 use cst
+use petit_parser
 
 public class ExpectedTwoOrMoreItemsInTupleCompilerError {
   public let file: File
@@ -8,7 +9,16 @@ public class ExpectedTwoOrMoreItemsInTupleCompilerError {
 impl ExpectedTwoOrMoreItemsInTupleCompilerError: CompilerError {
   public fun id(): String { "expected-two-or-more-items-in-tuple" }
 
-  public fun location(): Location { Location(file, node.child.openingParenthesis.child.span) }
+  fun span(): Span {
+    if node.child is CstTupleType {
+      return node.cast<CstTupleType>().child.openingParenthesis.child.span
+    }
+    if node.child is CstTupleExpression {
+      return node.cast<CstTupleExpression>().child.openingParenthesis.child.span
+    }
+    throw "Unknown body: {node}."
+  }
+  public fun location(): Location { Location(file, span()) }
   public fun title(): String { "Expected two or more items in tuple." }
   public fun description(): String {
     /// TODO(JonasWanke): add a description

--- a/packages/ast/src/errors/missing_closing_bracket.candy
+++ b/packages/ast/src/errors/missing_closing_bracket.candy
@@ -57,7 +57,7 @@ impl MissingClosingBracketCompilerError: CompilerError {
       node.cast<CstInterpolatedStringPart>().child.openingCurlyBrace.child.span
     }
     if node.child is CstValueArguments {
-      node.cast<CstValueArguments>().child.closingParenthesis.child.span
+      node.cast<CstValueArguments>().child.openingParenthesis.child.span
     }
     throw "Unknown node: {node}."
   }

--- a/packages/ast/src/lowering.candy
+++ b/packages/ast/src/lowering.candy
@@ -1460,7 +1460,7 @@ fun lowerLambdaExpression(
 
   let expressions = (cst.child.expressions as Iterable<CstNode<CstExpression>>)
       .map<Maybe<AstExpression>>({ lowerExpression(context, id, it) })
-      .maybeMap<AstExpression>({ it.unwrap() })
+      .maybeMap<AstExpression>({ it })
       .toList()
 
   context.addIdMapping(cst.id, id)

--- a/packages/compiler_dart/bin/simplify_output.dart
+++ b/packages/compiler_dart/bin/simplify_output.dart
@@ -1,0 +1,67 @@
+import 'dart:convert';
+import 'dart:io';
+
+// A small utility to simplify `toString()` outputs of compiled Candy types.
+// Very helpful when working with large CST or AST dumps.
+//
+// Usage: dart ./bin/simplify_output.dart <output-file>
+
+Future<void> main(List<String> args) async {
+  final file = File(args.first);
+  var content = await file.readAsString();
+  content = content
+      .trim()
+      .replaceAll('\r', '')
+      .replaceAll('\n', '\\n')
+      .replaceAllMapped(
+        RegExp(
+          '("(?:path|value|name|identifier|keyword|punctuation|content)":) ([^"{\\d][^}"]*|["{](?=[,}]))',
+        ),
+        (it) => '${it[1]} "${it[2]}"',
+      )
+      .replaceAll('"""', '"\\""');
+  final dynamic json = jsonDecode(content);
+  final dynamic simplified = simplify(json);
+  await file.writeAsString(JsonEncoder.withIndent('  ').convert(simplified));
+}
+
+dynamic simplify(dynamic json) {
+  if (json is List<dynamic>) {
+    return json
+        .where(
+            (dynamic it) => it is! Map<String, dynamic> || it['name'] != 'None')
+        .map<dynamic>(simplify)
+        .toList();
+  } else if (json is Map<String, dynamic>) {
+    if (json['name'] is String) {
+      final name = json['name'] as String;
+
+      final typeParameters = json['typeParameters'] as Map<String, dynamic>;
+      final properties = json['properties'] as Map<String, dynamic>;
+      switch (name) {
+        case 'None':
+          return 'None<${typeParameters['Value']}>';
+        case 'Some':
+          return <String, dynamic>{
+            'name': 'Some<${typeParameters['Value']}>',
+            'properties': simplify(properties),
+          };
+        case 'ArrayList':
+          return simplify(properties['items']);
+        default:
+          if (name != null && name.endsWith('Id')) return '<some-id>';
+      }
+    }
+
+    return json.map<String, dynamic>(
+      (k, dynamic v) => MapEntry<String, dynamic>(k, simplify(v)),
+    )..removeWhere(
+        (key, dynamic value) =>
+            key == 'typeParameters' &&
+            value is Map<String, dynamic> &&
+            value.isEmpty,
+      );
+  } else {
+    return json;
+  }
+}

--- a/packages/compiler_dart/bin/simplify_output.dart
+++ b/packages/compiler_dart/bin/simplify_output.dart
@@ -29,27 +29,27 @@ dynamic simplify(dynamic json) {
   if (json is List<dynamic>) {
     return json
         .where(
-            (dynamic it) => it is! Map<String, dynamic> || it['name'] != 'None')
+          (dynamic it) =>
+              it is! Map<String, dynamic> ||
+              (it['_type'] as String)?.startsWith('None') != true,
+        )
         .map<dynamic>(simplify)
         .toList();
   } else if (json is Map<String, dynamic>) {
-    if (json['name'] is String) {
-      final name = json['name'] as String;
+    if (json['_type'] is String) {
+      final type = json['_type'] as String;
+      final className =
+          type.contains('<') ? type.substring(0, type.indexOf('<')) : type;
 
-      final typeParameters = json['typeParameters'] as Map<String, dynamic>;
-      final properties = json['properties'] as Map<String, dynamic>;
-      switch (name) {
+      switch (className) {
         case 'None':
-          return 'None<${typeParameters['Value']}>';
+          return type;
         case 'Some':
-          return <String, dynamic>{
-            'name': 'Some<${typeParameters['Value']}>',
-            'properties': simplify(properties),
-          };
+          return simplify(json['value']);
         case 'ArrayList':
-          return simplify(properties['items']);
+          return simplify(json['items']);
         default:
-          if (name != null && name.endsWith('Id')) return '<some-id>';
+          if (type != null && type.endsWith('Id')) return '<some-id>';
       }
     }
 

--- a/packages/compiler_dart/lib/src/builtins.dart
+++ b/packages/compiler_dart/lib/src/builtins.dart
@@ -785,13 +785,13 @@ class DartBuiltinCompiler extends BuiltinCompiler<dart.Spec> {
           ..name = 'toString'
           ..body = dart.Block((b) {
             final typeParametersString =
-                typeParameterNames.map((it) => '"$it": "\${$it}"').join(', ');
+                typeParameterNames.map((it) => '$it = \${$it}').join(', ');
             final propertiesString =
-                propertyNames.map((it) => '"$it": \${this.$it}').join(', ');
+                propertyNames.map((it) => ', "$it": \${this.$it}').join('');
             b.statements.add(dart
-                .literalString('{"name": "$name", '
-                    '"typeParameters": {$typeParametersString}, '
-                    '"properties": {$propertiesString}}')
+                .literalString(
+                  '{"_type": "$name<$typeParametersString>"$propertiesString}',
+                )
                 .returned
                 .statement);
           })))),

--- a/packages/compiler_dart/lib/src/declarations/class.dart
+++ b/packages/compiler_dart/lib/src/declarations/class.dart
@@ -91,18 +91,21 @@ final Query<DeclarationId, List<dart.Spec>> compileClass =
           ..returns = dart.refer('String', dartCoreUrl)
           ..name = 'toString'
           ..body = dart.Block((b) {
-            final typeParametersString = classHir.typeParameters
+            var typeParametersString = classHir.typeParameters
                 .map((it) => it.name)
-                .map((it) => '"$it": "\${$it}"')
+                .map((it) => '$it = \${$it}')
                 .join(', ');
+            if (typeParametersString.isNotEmpty) {
+              typeParametersString = '<$typeParametersString>';
+            }
             final propertiesString = properties
                 .map((it) => it.name)
-                .map((it) => '"$it": \${this.$it}')
-                .join(', ');
+                .map((it) => ', "$it": \${$it}')
+                .join();
             b.statements.add(dart
-                .literalString('{"name": "$name", '
-                    '"typeParameters": {$typeParametersString}, '
-                    '"properties": {$propertiesString}}')
+                .literalString(
+                  '{"_type": "$name$typeParametersString"$propertiesString}',
+                )
                 .returned
                 .statement);
           })))),

--- a/packages/compiler_utils/src/package.candy
+++ b/packages/compiler_utils/src/package.candy
@@ -1,23 +1,22 @@
-/*public trait HirPackage {
+public trait Package {
   // TODO(JonasWanke): provide a query to get the name of a package
 }
 
-public class HirFilePackage {
+public class FilePackage {
   public let path: String /* Path */
 }
-impl HirFilePackage: HirPackage
+impl FilePackage: Package
 
-public class HirGitPackage {
+public class GitPackage {
   public let repoUrl: String /* Url */
   public let path: String /* Path */ = ""
   public let ref: String /* Sha1 */
 }
-impl HirGitPackage: HirPackage
+impl GitPackage: Package
 
-public class HirHostedPackage {
+public class HostedPackage {
   public let hostUrl: String /* Url */
   public let path: List<String>
   public let version: String /* Version */
 }
-impl HirHostedPackage: HirPackage
-*/
+impl HostedPackage: Package

--- a/packages/core/src/collections/iterable.candy
+++ b/packages/core/src/collections/iterable.candy
@@ -156,8 +156,9 @@ public trait Iterable<Item> {
     where({ !checker(it) })
   }
 
-  fun whereType<Result>(): Iterable<Item & Result> {
-    where({ it is Result }).cast<Item & Result>()
+  fun whereType<Result>(): Iterable<Result> {
+    // TODO(JonasWanke): return `Iterable<Item & Result>` when our type system gets smarter
+    where({ it is Result }).cast<Result>()
   }
 
   fun skip(n: Int): Iterable<Item> {

--- a/packages/cst/src/parser.candy
+++ b/packages/cst/src/parser.candy
@@ -62,7 +62,7 @@ class CstParser {
     let parser = punctuation(".")
         .plus()
         .sequence<List<CstNode<IdentifierToken | PunctuationToken>>>(
-          identifier()
+          identifier(true)
               .or<CstNode<PunctuationToken>>(punctuation("."))
               .cast<CstNode<IdentifierToken | PunctuationToken>>()
               .star()
@@ -71,7 +71,7 @@ class CstParser {
     node<CstUseLineTarget>(parser)
   }
   fun globalUseLineTarget(): Parser<String, CstNode<CstUseLineTarget>> {
-    let parser = identifier()
+    let parser = identifier(true)
         .or<CstNode<PunctuationToken>>(punctuation("."))
         .cast<CstNode<IdentifierToken | PunctuationToken>>()
         .plus()
@@ -86,9 +86,9 @@ class CstParser {
     let declarationBeginning = { keywordString: String =>
         modifiers().sequence<CstNode<KeywordToken>>(keyword(keywordString))
     }
-    let declarationBeginningWithName = { keywordString: String =>
+    let declarationBeginningWithName = { keywordString: String, startWithUppercase: Bool =>
         declarationBeginning(keywordString)
-            .sequence<Maybe<CstNode<IdentifierToken>>>(identifier().optional())
+            .sequence<Maybe<CstNode<IdentifierToken>>>(identifier(startWithUppercase).optional())
     }
 
     let optionalDeclarationContent = node<CstDeclarationContent>(
@@ -104,7 +104,7 @@ class CstParser {
       )
       .optional()
 
-    let module_ = declarationBeginningWithName("module")
+    let module_ = declarationBeginningWithName("module", true)
         .sequence<Maybe<CstNode<CstDeclarationContent>>>(optionalDeclarationContent)
         .map<CstDeclaration>({
           let modifiers = it.first.first.first
@@ -114,7 +114,7 @@ class CstParser {
           CstModule(modifiers, moduleKeyword, name, content)
         })
 
-    let trait_ = declarationBeginningWithName("trait")
+    let trait_ = declarationBeginningWithName("trait", true)
         .sequence<Maybe<CstNode<CstTypeParameters>>>(typeParameters().optional())
         .sequence<Maybe<(CstNode<PunctuationToken>, Maybe<CstNode<CstType>>)>>(
           punctuation(":")
@@ -151,7 +151,7 @@ class CstParser {
           CstImpl(modifiers, implKeyword, typeParameters, type, traits, content)
         })
 
-    let class_ = declarationBeginningWithName("class")
+    let class_ = declarationBeginningWithName("class", true)
         .sequence<Maybe<CstNode<CstTypeParameters>>>(typeParameters().optional())
         .sequence<Maybe<CstNode<CstDeclarationContent>>>(optionalDeclarationContent)
         .map<CstDeclaration>({
@@ -163,7 +163,7 @@ class CstParser {
           CstClass(modifiers, classKeyword, name, typeParameters, content)
         })
 
-    let function = declarationBeginningWithName("fun")
+    let function = declarationBeginningWithName("fun", false)
         .sequence<Maybe<CstNode<CstTypeParameters>>>(typeParameters().optional())
         .sequence<Maybe<CstNode<CstValueParameters>>>(valueParameters().optional())
         .sequence<Maybe<(CstNode<PunctuationToken>, Maybe<CstNode<CstType>>)>>(
@@ -196,12 +196,12 @@ class CstParser {
           )
         })
 
-    let property = declarationBeginningWithName("let")
+    let property = declarationBeginningWithName("let", false)
         .or<(
           (List<CstNode<IdentifierToken>>, CstNode<KeywordToken>),
           Maybe<CstNode<IdentifierToken>>,
         )>(
-          declarationBeginningWithName("var")
+          declarationBeginningWithName("var", false)
         )
         .cast<(
           (List<CstNode<IdentifierToken>>, CstNode<KeywordToken>),
@@ -245,7 +245,7 @@ class CstParser {
   fun valueParameter(): Parser<String, CstNode<CstValueParameter>> {
     // TODO(JonasWanke): allow modifiers
     // TODO(JonasWanke): allow parameters without a name
-    let valueParameter = identifier()
+    let valueParameter = identifier(false)
         .sequence<Maybe<(CstNode<PunctuationToken>, Maybe<CstNode<CstType>>)>>(
           punctuation(":")
               .sequence<Maybe<CstNode<CstType>>>(type.optional())
@@ -298,34 +298,36 @@ class CstParser {
         )
         .cast<Maybe<CstNode<PunctuationToken>>>()
 
-    // TODO(JonasWanke): allow modifiers
-    let namedType = punctuation(".")
-        .star()
-        .sequence<CstNode<IdentifierToken>>(identifier())
-        .sequence<List<(List<CstNode<PunctuationToken>>, CstNode<IdentifierToken>)>>(
+    let namedType = modifiers()
+        .sequence<List<CstNode<IdentifierToken | PunctuationToken>>>(
           punctuation(".")
-              .plus()
-              .sequence<CstNode<IdentifierToken>>(identifier())
-              .plus()
-        )
-        .map<List<CstNode<IdentifierToken | PunctuationToken>>>({
-          let initialDots = (it.first.first as Iterable<CstNode<PunctuationToken>>)
-              .cast<CstNode<IdentifierToken | PunctuationToken>>()
-          let initialIdentifier = it.first.second
-          let remaining = it.second
-          let result = MutableList.empty<CstNode<IdentifierToken | PunctuationToken>>()
-          result.appendAll(initialDots)
-          result.append(initialIdentifier as CstNode<IdentifierToken | PunctuationToken>)
-          for tuple in remaining {
-            let dots = (tuple.first as Iterable<CstNode<PunctuationToken>>)
-                .cast<CstNode<IdentifierToken | PunctuationToken>>()
-            result.appendAll(dots)
-            result.append(tuple.second as CstNode<IdentifierToken | PunctuationToken>)
-          }
-          result
-        })
+              .star()
+              .sequence<CstNode<IdentifierToken>>(identifier(true))
+              .sequence<List<(List<CstNode<PunctuationToken>>, CstNode<IdentifierToken>)>>(
+                punctuation(".")
+                    .plus()
+                    .sequence<CstNode<IdentifierToken>>(identifier(true))
+                    .star()
+              )
+              .map<List<CstNode<IdentifierToken | PunctuationToken>>>({
+                let initialDots = (it.first.first as Iterable<CstNode<PunctuationToken>>)
+                    .cast<CstNode<IdentifierToken | PunctuationToken>>()
+                let initialIdentifier = it.first.second
+                let remaining = it.second
+                let result = MutableList.empty<CstNode<IdentifierToken | PunctuationToken>>()
+                result.appendAll(initialDots)
+                result.append(initialIdentifier as CstNode<IdentifierToken | PunctuationToken>)
+                for tuple in remaining {
+                  let dots = (tuple.first as Iterable<CstNode<PunctuationToken>>)
+                      .cast<CstNode<IdentifierToken | PunctuationToken>>()
+                  result.appendAll(dots)
+                  result.append(tuple.second as CstNode<IdentifierToken | PunctuationToken>)
+                }
+                result
+              }),
+          )
         .sequence<Maybe<CstNode<CstTypeArguments>>>(typeArguments().optional())
-        .map<CstType>({ CstNamedType(List.empty<CstNode<IdentifierToken>>(), it.first, it.second) })
+        .map<CstType>({ CstNamedType(it.first.first, it.first.second, it.second) })
 
     let groupType = modifiers()
         .sequence<CstNode<PunctuationToken>>(punctuation("("))
@@ -466,7 +468,7 @@ class CstParser {
   }
   fun typeParameter(): Parser<String, CstNode<CstTypeParameter>> {
     let typeParameter = modifiers()
-        .sequence<Maybe<CstNode<IdentifierToken>>>(identifier().optional())
+        .sequence<Maybe<CstNode<IdentifierToken>>>(identifier(true).optional())
         .sequence<Maybe<(CstNode<PunctuationToken>, Maybe<CstNode<CstType>>)>>(
           punctuation(":")
               .sequence<Maybe<CstNode<CstType>>>(type.optional())
@@ -586,8 +588,9 @@ class CstParser {
           CstLambdaExpression(openingCurlyBrace, valueParameters, expressions, closingCurlyBrace)
         })
 
-    let identifierExpression = identifier()
-        .map<CstExpression>({ CstIdentifierExpression(it) })
+    let identifierExpression = choiceOf<String, CstNode<IdentifierToken>>(
+      List.of2<Parser<String, CstNode<IdentifierToken>>>(identifier(false), identifier(true)),
+    ).map<CstExpression>({ CstIdentifierExpression(it) })
 
     let groupExpression = punctuation("(")
         .sequence<Maybe<CstNode<CstExpression>>>(expression_.optional())
@@ -597,7 +600,6 @@ class CstParser {
           let expression = it.first.second
           let closingParenthesis = it.second
           CstGroupExpression(openingParenthesis, expression, closingParenthesis)
-          loop {}
         })
 
     let tupleExpression = punctuation("(")
@@ -625,7 +627,7 @@ class CstParser {
 
 
     let navigationPostfix = punctuation(".")
-        .sequence<Maybe<CstNode<IdentifierToken>>>(identifier().optional())
+        .sequence<Maybe<CstNode<IdentifierToken>>>(identifier(false).optional())
         .map<(CstNode<CstExpression>) => CstExpression>({
           { receiver: CstNode<CstExpression> =>
             CstNavigationExpression(receiver, it.first, it.second)
@@ -811,7 +813,7 @@ class CstParser {
       (Maybe<CstNode<IdentifierToken>>, CstNode<PunctuationToken>),
       CstNode<CstExpression>,
     >(
-      identifier()
+      identifier(false)
           .optional()
           .sequence<CstNode<PunctuationToken>>(punctuation("=")),
       expression_,
@@ -821,7 +823,7 @@ class CstParser {
 
   // utilities
 
-  fun modifiers(): Parser<String, List<CstNode<IdentifierToken>>> { identifier().star() }
+  fun modifiers(): Parser<String, List<CstNode<IdentifierToken>>> { identifier(false).star() }
 
   fun node<T>(parser: Parser<String, T>): Parser<String, CstNode<T>> {
     parser.map<CstNode<T>>({ CstNode<T>(getNextNodeId(), it) })
@@ -857,12 +859,11 @@ class CstParser {
         .map<KeywordToken>({ KeywordToken(it.first.span, it.second, keyword) })
     node<KeywordToken>(parser)
   }
-  fun identifier(): Parser<String, CstNode<IdentifierToken>> {
+  fun identifier(startWithUppercase: Bool = false): Parser<String, CstNode<IdentifierToken>> {
     let firstCharacter = character(
           {
-            "a" <= it && it <= "z"
-            || "A" <= it && it <= "Z"
-            || it == "_"
+            (!startWithUppercase && "a" <= it && it <= "z")
+            || (startWithUppercase && "A" <= it && it <= "Z")
           },
           "Letter or underscore expected.",
         )
@@ -873,7 +874,7 @@ class CstParser {
             || "0" <= it && it <= "9"
             || it == "_"
           },
-          "Letter, digit or underscore expected.",
+          "Letter, digit, or underscore expected.",
         )
     let parser = firstCharacter
         .sequence<List<String>>(followingCharacter.star())

--- a/packages/cst/src/parser.candy
+++ b/packages/cst/src/parser.candy
@@ -208,9 +208,7 @@ class CstParser {
         .or<(
           (List<CstNode<IdentifierToken>>, CstNode<KeywordToken>),
           Maybe<CstNode<IdentifierToken>>,
-        )>(
-          declarationBeginningWithName("var", false)
-        )
+        )>(declarationBeginningWithName("var", false))
         .cast<(
           (List<CstNode<IdentifierToken>>, CstNode<KeywordToken>),
           Maybe<CstNode<IdentifierToken>>,
@@ -220,9 +218,7 @@ class CstParser {
               .sequence<Maybe<CstNode<CstType>>>(type.optional())
               .optional()
         )
-        .sequence<Maybe<CstNode<CstDelegationBody>>>(
-            delegationBody().optional()
-        )
+        .sequence<Maybe<CstNode<CstDelegationBody>>>(delegationBody().optional())
         .map<CstProperty>({
           let modifiers = it.first.first.first.first
           let keyword = it.first.first.first.second
@@ -484,13 +480,19 @@ class CstParser {
   }
   fun typeParameter(): Parser<String, CstNode<CstTypeParameter>> {
     let typeParameter = modifiers()
-        .sequence<Maybe<CstNode<IdentifierToken>>>(identifier(true).optional())
-        .sequence<Maybe<(CstNode<PunctuationToken>, Maybe<CstNode<CstType>>)>>(
-          punctuation(":")
-              .sequence<Maybe<CstNode<CstType>>>(type.optional())
-              .optional()
+        .sequence<(
+          Maybe<CstNode<IdentifierToken>>,
+          Maybe<(CstNode<PunctuationToken>, Maybe<CstNode<CstType>>)>,
+        )>(
+          atLeastOne<
+            CstNode<IdentifierToken>,
+            (CstNode<PunctuationToken>, Maybe<CstNode<CstType>>),
+          >(
+            identifier(true),
+            punctuation(":").sequence<Maybe<CstNode<CstType>>>(type.optional()),
+          )
         )
-        .map<CstTypeParameter>({ CstTypeParameter(it.first.first, it.first.second, it.second) })
+        .map<CstTypeParameter>({ CstTypeParameter(it.first, it.second.first, it.second.second) })
     node<CstTypeParameter>(typeParameter)
   }
 

--- a/packages/cst/src/parser.candy
+++ b/packages/cst/src/parser.candy
@@ -83,13 +83,6 @@ class CstParser {
 
   fun declaration(): Parser<String, CstNode<CstDeclaration>> {
     let declaration = notYetDefined<String, CstNode<CstDeclaration>>("Parser not yet defined.")
-    let declarationBeginning = { keywordString: String =>
-        modifiers().sequence<CstNode<KeywordToken>>(keyword(keywordString))
-    }
-    let declarationBeginningWithName = { keywordString: String, startWithUppercase: Bool =>
-        declarationBeginning(keywordString)
-            .sequence<Maybe<CstNode<IdentifierToken>>>(identifier(startWithUppercase).optional())
-    }
 
     let optionalDeclarationContent = node<CstDeclarationContent>(
         punctuation("\👍")
@@ -196,7 +189,22 @@ class CstParser {
           )
         })
 
-    let property = declarationBeginningWithName("let", false)
+    declaration.delegate = node<CstDeclaration>(
+      choiceOf<String, CstDeclaration>(
+        List.of6<Parser<String, CstDeclaration>>(
+          module_,
+          trait_,
+          impl_,
+          class_,
+          function,
+          property().cast<CstDeclaration>(),
+        ),
+      ),
+    )
+    declaration
+  }
+  fun property(): Parser<String, CstProperty> {
+    declarationBeginningWithName("let", false)
         .or<(
           (List<CstNode<IdentifierToken>>, CstNode<KeywordToken>),
           Maybe<CstNode<IdentifierToken>>,
@@ -215,7 +223,7 @@ class CstParser {
         .sequence<Maybe<CstNode<CstDelegationBody>>>(
             delegationBody().optional()
         )
-        .map<CstDeclaration>({
+        .map<CstProperty>({
           let modifiers = it.first.first.first.first
           let keyword = it.first.first.first.second
           let name = it.first.first.second
@@ -224,13 +232,21 @@ class CstParser {
           let initializer = it.second
           CstProperty(modifiers, keyword, name, type, initializer)
         })
-
-    declaration.delegate = node<CstDeclaration>(
-      choiceOf<String, CstDeclaration>(
-        List.of6<Parser<String, CstDeclaration>>(module_, trait_, impl_, class_, function, property),
-      ),
-    )
-    declaration
+  }
+  fun declarationBeginning(
+    keywordString: String,
+  ): Parser<String, (List<CstNode<IdentifierToken>>, CstNode<KeywordToken>)> {
+      modifiers().sequence<CstNode<KeywordToken>>(keyword(keywordString))
+  }
+  fun declarationBeginningWithName(
+    keywordString: String,
+    startWithUppercase: Bool,
+  ): Parser<
+    String,
+    ((List<CstNode<IdentifierToken>>, CstNode<KeywordToken>), Maybe<CstNode<IdentifierToken>>),
+  > {
+      declarationBeginning(keywordString)
+          .sequence<Maybe<CstNode<IdentifierToken>>>(identifier(startWithUppercase).optional())
   }
 
   fun valueParameters(): Parser<String, CstNode<CstValueParameters>> {
@@ -612,10 +628,9 @@ class CstParser {
           CstTupleExpression(openingParenthesis, valueArguments, closingParenthesis)
         })
 
-    // TODO(JonasWanke): property expressions
-
     let primitiveExpressions = choiceOf<String, CstExpression>(
-        List.of6<Parser<String, CstExpression>>(
+        List.of7<Parser<String, CstExpression>>(
+          property().cast<CstExpression>(),
           intExpression,
           stringExpression,
           lambdaExpression,

--- a/packages/cst/src/parser.candy
+++ b/packages/cst/src/parser.candy
@@ -807,12 +807,15 @@ class CstParser {
     node<CstValueArguments>(valueArguments)
   }
   fun valueArgument(): Parser<String, CstNode<CstValueArgument>> {
-    let valueArgument = identifier()
-        .optional()
-        .sequence<CstNode<PunctuationToken>>(punctuation("="))
-        .optional()
-        .sequence<Maybe<CstNode<CstExpression>>>(expression_.optional())
-        .map<CstValueArgument>({ CstValueArgument(it.first, it.second) })
+    let valueArgument = atLeastOne<
+      (Maybe<CstNode<IdentifierToken>>, CstNode<PunctuationToken>),
+      CstNode<CstExpression>,
+    >(
+      identifier()
+          .optional()
+          .sequence<CstNode<PunctuationToken>>(punctuation("=")),
+      expression_,
+    ).map<CstValueArgument>({ CstValueArgument(it.first, it.second) })
     node<CstValueArgument>(valueArgument)
   }
 
@@ -827,6 +830,20 @@ class CstParser {
     let id = CstNodeId(nextId)
     nextId = nextId + 1
     id
+  }
+
+  fun atLeastOne<T1, T2>(
+    parser1: Parser<String, T1>,
+    parser2: Parser<String, T2>,
+  ): Parser<String, (Maybe<T1>, Maybe<T2>)> {
+    choiceOf<String, (Maybe<T1>, Maybe<T2>)>(
+      List.of2<Parser<String, (Maybe<T1>, Maybe<T2>)>>(
+        parser1
+            .map<Maybe<T1>>({ Some<T1>(it) })
+            .sequence<Maybe<T2>>(parser2.optional()),
+        parser2.map<(Maybe<T1>, Maybe<T2>)>({ Tuple(None<T1>(), Some<T2>(it)) }),
+      ),
+    )
   }
 
   // lexer


### PR DESCRIPTION
<!-- Please enter the corresponding issue ID: -->


<!-- Add the breaking label (PR: BREAKING) if applicable. -->

<!-- Please summarize your changes: -->
* upper- and lowercase is now relevant while parsing:
  * uppercase: module (and package) names, type and type parameter names
  * lowercase: modifiers, property and function names, value parameter names (and of course keywords)
  * identifier expression can currently parse both, though, in the future, we might differentiate between type/module/etc. names and property/function/etc. names directly in the parser
* various fixes in the parser
* simplified `toString()`s are now generated: Instead of separate `"name": "Foo"` and `"typeParameters": {…}`, only a simplified `"_type": "Foo<…>"` gets generated. Hence, properties don't need their own sub-map anymore, but reside directly next to the `"_type"` field.
