### PR TITLE
CST enum variant parsed too greedily

### DIFF
--- a/packages/compiler_utils/src/utils.candy
+++ b/packages/compiler_utils/src/utils.candy
@@ -10,5 +10,5 @@ public class SetOfString {
 }
 impl SetOfString: Equals & Hash {
   fun equals(other: This): Bool { value.unsafeEquals(other.value) }
-  fun hash<T>(hasher: Hasher<T>) { value.unsafeHash(hasher) }
+  fun hash<T>(hasher: Hasher<T>) { value.unsafeHash<T>(hasher) }
 }

--- a/packages/core/src/collections/list/module.candy
+++ b/packages/core/src/collections/list/module.candy
@@ -241,15 +241,15 @@ public trait MutableList<Item>: List<Item> {
     }
   }
 
-  fun unsafeSort() { unsafeSortBy<Item>({ it as Comparable }) }
+  fun unsafeSort() { unsafeSortBy<Comparable>({ it as Comparable }) }
   fun unsafeSortBy<T: Comparable>(selector: (Item) => T) {
     // TODO(JonasWanke): use something faster for larger lists
     // Currently using insertion sort.
     1.until(length()).do({ i =>
-      let item = get(i).unwrap()
+      let item = (get(i).unwrap() as Item)
       mut let j = i
       while j > 0 {
-        let leftItem = get(j - 1).unwrap()
+        let leftItem = (get(j - 1).unwrap() as Item)
         if ((selector(leftItem) as T) <= (selector(item) as T)) { break unit }
         set(j, leftItem as Item)
         j = j - 1

--- a/packages/cst/src/parser.candy
+++ b/packages/cst/src/parser.candy
@@ -404,16 +404,14 @@ class CstParser {
       ),
     )
     // We have to make sure that this doesn't match nothing.
-    let enumTypeVariant = atLeastOne<
-      List<CstNode<IdentifierToken>>,
-      (CstNode<IdentifierToken>, Maybe<CstNode<CstInlineType>>),
-    >(
-      identifier(false).plus(),
-      identifier(true).sequence<Maybe<CstNode<CstInlineType>>>(enumTypeVariantValueType.optional()),
-    )
+    let enumTypeVariant = modifiers()
+      .sequence<(CstNode<IdentifierToken>, Maybe<CstNode<CstInlineType>>)>(
+        identifier(true)
+          .sequence<Maybe<CstNode<CstInlineType>>>(enumTypeVariantValueType.optional()),
+      )
       .map<CstEnumTypeVariant>({
-        let modifiers = it.first.orElse({ List.empty<CstNode<IdentifierToken>>() })
-        let nameAndValue = it.second
+        let modifiers = it.first
+        let nameAndValue = Some<(CstNode<IdentifierToken>, Maybe<CstNode<CstInlineType>>)>(it.second)
         CstEnumTypeVariant(modifiers, nameAndValue)
       })
     let enumTypeVariant = node<CstEnumTypeVariant>(enumTypeVariant)


### PR DESCRIPTION

<!-- Add the breaking label (PR: BREAKING) if applicable. -->

<!-- Please summarize your changes: -->
```candy
public type Bool = True | False

public fun true(): Bool
```

is now parsed correctly. This also fixes some bugs preventing compilation.

