### PR TITLE
Start implementing type solving

### DIFF
--- a/new-packages/Core/src/Bool.candy
+++ b/new-packages/Core/src/Bool.candy
@@ -1,5 +1,5 @@
 use ..Maybe
-## use ..Operators
+use ..Operators
 
 public type Bool = True | False
 

--- a/new-packages/Playground/src/Types.candy
+++ b/new-packages/Playground/src/Types.candy
@@ -1,0 +1,5 @@
+type Foo = Unit
+
+trait Bar {}
+
+impl Foo: Bar {}

--- a/new-packages/Playground/src/UseLines/.candy
+++ b/new-packages/Playground/src/UseLines/.candy
@@ -1,4 +1,5 @@
 use Core
 use .Blub
+use .Types
 
 type Bar = (bar: Foo)

--- a/packages/compiler_utils/src/utils.candy
+++ b/packages/compiler_utils/src/utils.candy
@@ -1,8 +1,20 @@
-public data class DataTuple2<T1: Equals & Hash, T2: Equals & Hash> {
-  // TODO(JonasWanke): delete this when `(Equals & Hash, Equals & Hash)`
-  //   implements `(Equals & Hash)`
+public class DataTuple2<T1: Equals & Hash, T2: Equals & Hash> {
+  // TODO(JonasWanke): delete this when `(Equals & Hash, Equals & Hash)` implements
+  // `(Equals & Hash)`.
   public let first: T1
   public let second: T2
+}
+impl<T1: Equals & Hash, T2: Equals & Hash> DataTuple2<T1, T2>: Equals & Hash {
+  fun equals(other: This): Bool {
+    let other = (other as DataTuple2<T1, T2>)
+    // TODO(marcelgarus): Remove this cast when our type system is smart enough to figure this out.
+    (first as Equals).equalsAny(other.first as Equals) &&
+      (second as Equals).equalsAny(other.second as Equals)
+  }
+  fun hash<T>(hasher: Hasher<T>) {
+    (first as Hash).hash<T>(hasher)
+    (second as Hash).hash<T>(hasher)
+  }
 }
 
 public class SetOfString {

--- a/packages/hir/src/example.candy
+++ b/packages/hir/src/example.candy
@@ -1,5 +1,6 @@
 use ast
 use compiler_utils
+use cst
 use incremental
 
 use ..declarations
@@ -10,9 +11,10 @@ fun main() {
   let context = QueryContext.create<List<CompilerError>>()
   print("Core package path is {getCorePath(context)}.")
 
-  declarationsExample(context)
-  useLinesExample(context)
-  resolvingExample(context)
+  //declarationsExample(context)
+  //useLinesExample(context)
+  //resolvingExample(context)
+  solverExample(context)
 }
 
 fun declarationsExample(context: QueryContext<List<CompilerError>>) {
@@ -47,4 +49,15 @@ fun resolvingExample(context: QueryContext<List<CompilerError>>) {
   let any = (primitives as Iterable<HirDeclaration>).first().unwrap()
   let never = "Never".resolveIdentifier(context, any)
   print("Candidates for Never: {never}")
+}
+
+fun solverExample(context: QueryContext<List<CompilerError>>) {
+  let file = FancyFile(Package.playground(context), Path.parse("src/Types.candy"))
+  let declarations = (fileToHirModule(context, file) as HirInnerModule).declarations(context)
+  print("Declarations are {declarations}.")
+  let anImpl = ((declarations as Iterable<HirDeclaration>).third().unwrap() as HirImpl)
+  print("Impl is {anImpl}.")
+  let rule = hirImplToSolverRule(context, anImpl)
+  print("Rule is {rule}.")
+  //print("Does {type.toString_()} implement Equals? {environment.solve(equalsImpl(type)).toString_()}")
 }

--- a/packages/hir/src/lowering/resolving.candy
+++ b/packages/hir/src/lowering/resolving.candy
@@ -15,7 +15,7 @@ fun resolveIdentifier(
 ): Set<HirType | HirTrait | HirFunction | HirModule> {
   query<Set<HirType | HirTrait | HirFunction | HirModule>, List<CompilerError>>(
     context,
-    "String.resolveIdentifier",
+    "resolveIdentifier",
     DataTuple2<String, HirDeclaration>(identifier, scope) as Equals & Hash,
     {
       let candidates = MutableSet.empty<HirType | HirTrait | HirFunction | HirModule>()

--- a/packages/hir/src/lowering/types.candy
+++ b/packages/hir/src/lowering/types.candy
@@ -48,15 +48,15 @@ fun astInlineTypeToHirInlineType(
         }
 
         // There should be exactly one candidate left.
-        if (candidates as Iterable).isEmpty() {
+        if (candidates.items() as Iterable).isEmpty() {
           return Tuple(
-            HirErrorType(),
+            HirErrorType() as HirInlineType,
             List.of1<CompilerError>(UnknownTypeCompilerError(astType as AstNamedType)),
           )
         }
-        if (candidates as Iterable).length() > 1 {
+        if (candidates.items() as Iterable).length() > 1 {
           return Tuple(
-            HirErrorType(),
+            HirErrorType() as HirInlineType,
             List.of1<CompilerError>(
               // This cast from `Set<HirType | HirTrait | HirFunction | HirModule>` to
               // `Set<HirType | HirTrait | HirModule>` succeeds because the name is uppercase, so no
@@ -65,14 +65,16 @@ fun astInlineTypeToHirInlineType(
             ),
           )
         }
-        let declaration = (candidates as Iterable<HirDeclaration>).single().unwrap()
+        let declaration = (candidates.items() as Iterable).cast<HirDeclaration>().single().unwrap()
+        // TODO(marcelgarus): Directly cast this to `Iterable<HirDeclaration>` when the generated
+        // Dart code is smarter.
         assert((declaration is HirType) || (declaration is HirTrait), "Declaration should be HirType or HirTrait.")
 
         let types = ((astType as AstNamedType).typeArguments as Iterable<AstTypeArgument>)
           .map<HirInlineType>({ astInlineTypeToHirInlineType(context, it.type, scope) })
           .toList()
         return Tuple(
-          HirNamedType((declaration as HirTrait | HirType), types),
+          HirNamedType((declaration as HirTrait | HirType), types) as HirInlineType,
           List.empty<CompilerError>(),
         )
       }
@@ -86,7 +88,7 @@ fun astInlineTypeToHirInlineType(
               .map<HirInlineType>({ astInlineTypeToHirInlineType(context, it, scope) })
               .toList(),
             astInlineTypeToHirInlineType(context, (astType as AstFunctionType).returnType, scope),
-          ),
+          ) as HirInlineType,
           List.empty<CompilerError>()
         )
       }
@@ -97,7 +99,7 @@ fun astInlineTypeToHirInlineType(
             ((astType as AstTupleType).types as Iterable<AstInlineType>)
               .map<HirInlineType>({ astInlineTypeToHirInlineType(context, it, scope) })
               .toList(),
-          ),
+          ) as HirInlineType,
           List.empty<CompilerError>(),
         )
       }
@@ -110,7 +112,7 @@ fun astInlineTypeToHirInlineType(
                 Tuple(it.name.value, astInlineTypeToHirInlineType(context, it.type, scope))
               })
               .toList(),
-          ),
+          ) as HirInlineType,
           List.empty<CompilerError>(),
         )
       }
@@ -128,7 +130,7 @@ fun astInlineTypeToHirInlineType(
           HirEnumType(
             (loweredVariants as Iterable<(String, Maybe<HirInlineType>)>)
               .unsafeToMap<String, Maybe<HirInlineType>>(),
-          ),
+          ) as HirInlineType,
           List.empty<CompilerError>(),
         )
       }
@@ -139,7 +141,7 @@ fun astInlineTypeToHirInlineType(
             ((astType as AstIntersectionType).types as Iterable<AstInlineType>)
               .map<HirInlineType>({ astInlineTypeToHirInlineType(context, it, scope) })
               .toList(),
-          ),
+          ) as HirInlineType,
           List.empty<CompilerError>(),
         )
       }
@@ -175,15 +177,26 @@ impl HirImpl {
 
     query<Maybe<HirInlineType>, List<CompilerError>>(context, "HirImpl.implementedTrait", this as Equals & Hash, {
       let traits = this.ast(context).traits
+      print("Getting traits of impl {this}. Ast is {this.ast(context)}.")
       if !((traits as Iterable).length() == 1) {
         // TODO(marcelgarus): Support impls for more than one trait.
-        return Tuple(None<HirInlineType>(), List.empty<CompilerError>())
+        return Tuple(
+          None<HirInlineType>(),
+          List.empty<CompilerError>(
+            // UnsupportedFeatureCompilerError(
+            //   Location(, Span(0, 1)),
+            //   "This impl is for more than one trait: {this}",
+            // ),
+          ),
+        )
       }
       Tuple(
         Some<HirInlineType>(
           astInlineTypeToHirInlineType(
             context,
-            (traits as Iterable<AstInlineType>).single().unwrap(),
+            (traits as Iterable).cast<AstInlineType>().single().unwrap(),
+            // TODO(marcelgarus): Directly cast this into a `Iterable<AstInlineType>` when the Dart
+            // type system gets good enough.
             this,
           ),
         ),
@@ -210,6 +223,7 @@ fun hirImplToSolverRule(
     let solverConstraints = MutableList.empty<SolverGoal>()
     for constraint in hirImpl.constraints().entries() {
       let result = hirInlineTypeToSolverTypeAndGoals(context, constraint.second)
+      print("Lowered constraint is {result}")
       if (result is None) { return Tuple(None<SolverRule>(), List.empty<CompilerError>()) }
       solverConstraints.appendAll(
         (result.unwrap().second as Iterable<SolverGoal>)
@@ -232,7 +246,9 @@ fun hirImplToSolverRule(
     // Lower the base type. For example, in the impl `impl Iterable[Int]: Foo`, the base type
     // `Iterable[Int]` gets lowered to `?0` with the goal `Iterable(Int, ?0)`.
     let baseType = hirImpl.baseType(context)
+    print("Base type is {baseType}")
     let solverBaseAndGoals = hirInlineTypeToSolverTypeAndGoals(context, baseType)
+    print("Lowered base type is {solverBaseAndGoals}")
     if (solverBaseAndGoals is None) { return Tuple(None<SolverRule>(), List.empty<CompilerError>()) }
     let solverBaseAndGoals: (SolverType, List<SolverGoal>) = solverBaseAndGoals.unwrap()
 
@@ -241,9 +257,14 @@ fun hirImplToSolverRule(
     // implement a trait – like `impl Foo { ... }` – don't correspond to a `SolverRule` and cause
     // this function to return `None`.
     let traitType = hirImpl.implementedTrait(context)
+    print("Trait type is {traitType}")
     if (traitType is None) { return Tuple(None<SolverRule>(), List.empty<CompilerError>()) }
+    if (traitType.unwrap() is HirErrorType) {
+      return Tuple(None<SolverRule>(), List.empty<CompilerError>())
+    }
     let traitType = (traitType.unwrap() as HirNamedType)
     let solverTraitAndGoals = hirInlineTypeToSolverTypeAndGoals(context, traitType)
+    print("Lowered trait type is {solverTraitAndGoals}")
     if (solverTraitAndGoals is None) { return Tuple(None<SolverRule>(), List.empty<CompilerError>()) }
     let solverTraitAndGoals: (SolverType, List<SolverGoal>) = solverTraitAndGoals.unwrap()
     if ((solverTraitAndGoals.second as Iterable).length() > 1) {
@@ -309,31 +330,33 @@ fun hirInlineTypeToSolverTypeAndGoals(
     Maybe<(SolverType, List<SolverGoal>)>,
     List<CompilerError>,
   >(context, "hirInlineTypeToSolverTypeAndGoals", hirType as Equals & Hash, {
-    if (hirType is HirErrorType) { return None<(SolverType, List<SolverGoal>)>() }
+    if (hirType is HirErrorType) {
+      return Tuple(None<(SolverType, List<SolverGoal>)>(), List.empty<CompilerError>())
+    }
     if (hirType is HirNamedType) {
       let declaration = (hirType as HirNamedType).declaration
       let parameters = ((hirType as HirNamedType).parameterTypes as Iterable<HirInlineType>)
       if (declaration is HirTrait) {
+        // We'll return a substitution that will have to satisfy the trait. For example, given the
+        // trait `Equals`, we'll return `?0` with the goal `Equals(?0)`. The `?0` is this
+        // substitution.
+        // TODO(marcelgarus): In the long term, choose a more elegant substitution than just the
+        // 1000th.
+        let substitution = SolverVariable(canonicalVariable(1000))
         let goals = MutableList.of1<SolverGoal>(
-          SolverGoal(hirType as HirTrait, List.empty<SolverType>())
+          SolverGoal(declaration as HirTrait, List.of1<SolverType>(substitution))
         )
         let solverParameters = MutableList.empty<SolverType>()
         for parameter in parameters {
           let result = hirInlineTypeToSolverTypeAndGoals(context, parameter)
-          if (result is None) { return None<(SolverType, List<SolverGoal>)>() }
+          if (result is None) {
+            return Tuple(None<(SolverType, List<SolverGoal>)>(), List.empty<CompilerError>())
+          }
           goals.appendAll(result.unwrap().second)
           solverParameters.append(result.unwrap().first)
         }
-        // TODO(marcelgarus): In the long term, choose a more elegant substitution.
-        let substitution = SolverVariable(canonicalVariable(1000))
-        goals.append(SolverGoal(hirType as HirTrait, List.of1<SolverType>(substitution)))
         return Tuple(
-          Some<(SolverType, List<SolverGoal>)>(
-            Tuple(
-              substitution,
-              goals,
-            ),
-          ),
+          Some<(SolverType, List<SolverGoal>)>(Tuple(substitution, goals)),
           List.empty<CompilerError>(),
         )
       }
@@ -342,7 +365,9 @@ fun hirInlineTypeToSolverTypeAndGoals(
         let solverParameters = MutableList.empty<SolverType>()
         for parameter in parameters {
           let result = hirInlineTypeToSolverTypeAndGoals(context, parameter)
-          if (result is None) { return None<(SolverType, List<SolverGoal>)>() }
+          if (result is None) {
+            return Tuple(None<(SolverType, List<SolverGoal>)>(), List.empty<CompilerError>())
+          }
           goals.appendAll(result.unwrap().second)
           solverParameters.append(result.unwrap().first)
         }

--- a/packages/hir/src/lowering/types.candy
+++ b/packages/hir/src/lowering/types.candy
@@ -177,7 +177,6 @@ impl HirImpl {
 
     query<Maybe<HirInlineType>, List<CompilerError>>(context, "HirImpl.implementedTrait", this as Equals & Hash, {
       let traits = this.ast(context).traits
-      print("Getting traits of impl {this}. Ast is {this.ast(context)}.")
       if !((traits as Iterable).length() == 1) {
         // TODO(marcelgarus): Support impls for more than one trait.
         return Tuple(
@@ -223,7 +222,6 @@ fun hirImplToSolverRule(
     let solverConstraints = MutableList.empty<SolverGoal>()
     for constraint in hirImpl.constraints().entries() {
       let result = hirInlineTypeToSolverTypeAndGoals(context, constraint.second)
-      print("Lowered constraint is {result}")
       if (result is None) { return Tuple(None<SolverRule>(), List.empty<CompilerError>()) }
       solverConstraints.appendAll(
         (result.unwrap().second as Iterable<SolverGoal>)
@@ -246,9 +244,7 @@ fun hirImplToSolverRule(
     // Lower the base type. For example, in the impl `impl Iterable[Int]: Foo`, the base type
     // `Iterable[Int]` gets lowered to `?0` with the goal `Iterable(Int, ?0)`.
     let baseType = hirImpl.baseType(context)
-    print("Base type is {baseType}")
     let solverBaseAndGoals = hirInlineTypeToSolverTypeAndGoals(context, baseType)
-    print("Lowered base type is {solverBaseAndGoals}")
     if (solverBaseAndGoals is None) { return Tuple(None<SolverRule>(), List.empty<CompilerError>()) }
     let solverBaseAndGoals: (SolverType, List<SolverGoal>) = solverBaseAndGoals.unwrap()
 
@@ -257,14 +253,12 @@ fun hirImplToSolverRule(
     // implement a trait – like `impl Foo { ... }` – don't correspond to a `SolverRule` and cause
     // this function to return `None`.
     let traitType = hirImpl.implementedTrait(context)
-    print("Trait type is {traitType}")
     if (traitType is None) { return Tuple(None<SolverRule>(), List.empty<CompilerError>()) }
     if (traitType.unwrap() is HirErrorType) {
       return Tuple(None<SolverRule>(), List.empty<CompilerError>())
     }
     let traitType = (traitType.unwrap() as HirNamedType)
     let solverTraitAndGoals = hirInlineTypeToSolverTypeAndGoals(context, traitType)
-    print("Lowered trait type is {solverTraitAndGoals}")
     if (solverTraitAndGoals is None) { return Tuple(None<SolverRule>(), List.empty<CompilerError>()) }
     let solverTraitAndGoals: (SolverType, List<SolverGoal>) = solverTraitAndGoals.unwrap()
     if ((solverTraitAndGoals.second as Iterable).length() > 1) {


### PR DESCRIPTION
This adds the fundamentals for type solving.

For example, given these type definitions:
```
type Foo = Unit
trait Bar {}
impl Foo: Bar {}
```
We can now lower the impl into this `SolverRule`: `Foo(Bar)`

Next steps:
- Make the lowering more robust. Specifically, an impl like `impl[T] Foo[T]: Bar` can't get lowered yet, because `Foo[T]` gets lowered to an invalid HIR type (`Foo[HirErrorType]`).
- Support getting _all_ impls.
- Turn all impls into `SolverRule`s.
- Check that no two impls for the same trait can be unified. This disallows `impl[T] Foo[Int, T]: Bar` and `impl[T] Foo[T, String]: Bar`, because the implementation of `Bar` for `Foo[Int, String]` would be ambiguous.
- Put all those `SolverRule`s into a solver `Environment`. This represents the type system and can be queried against.
- Add queries for checking whether a type implements a trait and if a type contains a method with a given signature.