### PR TITLE
Continues the journey to a great type solver

### DIFF
--- a/new-packages/Core/src/Assert.candy
+++ b/new-packages/Core/src/Assert.candy
@@ -8,5 +8,5 @@ public fun assert(condition: Bool, message: String = "Assert failed.") {
   # This function is useful for ensuring that your mental model of the state of your program matches
   # its actual state.
 
-  !condition.then({ panic(message) })
+  (!condition).then({ panic(message) })
 }

--- a/new-packages/Core/src/Assert.candy
+++ b/new-packages/Core/src/Assert.candy
@@ -8,5 +8,5 @@ public fun assert(condition: Bool, message: String = "Assert failed.") {
   # This function is useful for ensuring that your mental model of the state of your program matches
   # its actual state.
 
-  (!condition).then({ panic(message) })
+  condition.not().then({ panic(message) })
 }

--- a/new-packages/Core/src/Bool.candy
+++ b/new-packages/Core/src/Bool.candy
@@ -3,35 +3,47 @@ use ..Operators
 
 public type Bool = True | False
 
-public fun true(): Bool { Bool.True }
-public fun false(): Bool { Bool.False }
+public fun true(): Bool { Bool.True() }
+public fun false(): Bool { Bool.False() }
+
+impl Bool {
+  fun not(): Bool { this.match[Bool](true = { false }, false = { true }) }
+}
+
+impl Bool: And {
+  fun and(other: Bool): Bool { this.match[Bool](true = { other }, false = { false() }) }
+}
+
+impl Bool: Or {
+  fun or(other: Bool): Bool { this.match[Bool](true = { true }, false = { other }) }
+}
 
 impl Bool: Equals {
-  builtin fun equals(other: Bool): Bool
+  fun equals(other: Bool): Bool { this.match[Bool](true = { other }, false = { other.not() }) }
 }
-impl Bool: And {
-  builtin fun and(other: Bool): Bool
-}
-impl Bool: Or {
-  builtin fun or(other: Bool): Bool
-}
+
 impl Bool: Opposite {
-  builtin fun opposite(other: Bool): Bool
+  fun opposite(other: Bool): Bool { this.match[Bool](true = { false }, false = { true }) }
 }
+
 impl Bool: Implies {
-  builtin fun implies(other: Bool): Bool
+  fun implies(other: Bool): Bool { this.match[Bool](true = { other }, false = { true() }) }
 }
 
 impl Bool {
-  fun lazyAnd(other: () -> Bool): Bool { !this.then({ false() }).else(other) }
-  ## TODO(marcelgarus): Rename this to just `and` as soon as we support overloading.
+  public fun lazyAnd(other: () -> Bool): Bool {
+    ## TODO(marcelgarus): Rename this to just `and` as soon as we support overloading.
+    this.match[Bool](true = other, false = { false() })
+  }
   
-  fun lazyOr(other: () -> Bool): Bool { this.then({ true() }).else(other) }
-  ## TODO(marcelgarus): Rename this to just `or` as soon as we support overloading.
+  public fun lazyOr(other: () -> Bool): Bool {
+    ## TODO(marcelgarus): Rename this to just `or` as soon as we support overloading.
+    this.match[Bool](true = { true() }, false = other)
+  }
 }
 
 impl Bool {
-  builtin fun then[T](body: () -> T): Maybe[T]
+  public fun then[T](body: () -> T): Maybe[T] { if[T](this, body) }
 }
 
-public fun if[T](condition: Bool, thenBody: () -> T): Maybe[T] { condition.then(thenBody) }
+public builtin fun if[T](condition: Bool, thenBody: () -> T): Maybe[T]

--- a/new-packages/Core/src/Bool.candy
+++ b/new-packages/Core/src/Bool.candy
@@ -7,7 +7,7 @@ public fun true(): Bool { Bool.True() }
 public fun false(): Bool { Bool.False() }
 
 impl Bool {
-  fun not(): Bool { this.match[Bool](true = { false }, false = { true }) }
+  fun not(): Bool { this.match[Bool](true = { false() }, false = { true() }) }
 }
 
 impl Bool: And {
@@ -15,15 +15,11 @@ impl Bool: And {
 }
 
 impl Bool: Or {
-  fun or(other: Bool): Bool { this.match[Bool](true = { true }, false = { other }) }
+  fun or(other: Bool): Bool { this.match[Bool](true = { true() }, false = { other }) }
 }
 
 impl Bool: Equals {
   fun equals(other: Bool): Bool { this.match[Bool](true = { other }, false = { other.not() }) }
-}
-
-impl Bool: Opposite {
-  fun opposite(other: Bool): Bool { this.match[Bool](true = { false }, false = { true }) }
 }
 
 impl Bool: Implies {
@@ -46,4 +42,6 @@ impl Bool {
   public fun then[T](body: () -> T): Maybe[T] { if[T](this, body) }
 }
 
-public builtin fun if[T](condition: Bool, thenBody: () -> T): Maybe[T]
+public fun if[T](condition: Bool, thenBody: () -> T): Maybe[T] {
+  condition.match[Maybe[T]](true = { Maybe[T].Some(thenBody()) }, false = { Maybe[T].None() })
+}

--- a/new-packages/Core/src/Loops.candy
+++ b/new-packages/Core/src/Loops.candy
@@ -6,7 +6,7 @@ public builtin fun loop(body: () -> Nothing): Never
 ## TODO(marcelgarus): Implement this in pure Candy once we have tail-call elimination.
 
 impl Int {
-  fun times(body: () -> Nothing) {
+  public fun times(body: () -> Nothing) {
     # Executes the `body` `this` many times.
     
     body()

--- a/new-packages/Core/src/Loops.candy
+++ b/new-packages/Core/src/Loops.candy
@@ -1,4 +1,4 @@
-builtin fun loop(body: () -> Nothing): Never
+public builtin fun loop(body: () -> Nothing): Never
 # Executes the body infinitely often.
 ## TODO(marcelgarus): Implement this in pure Candy once we have tail-call elimination.
 

--- a/new-packages/Core/src/Loops.candy
+++ b/new-packages/Core/src/Loops.candy
@@ -9,7 +9,9 @@ impl Int {
   public fun times(body: () -> Nothing) {
     # Executes the `body` `this` many times.
     
-    body()
-    (this - 1).times(body)
+    if(this > 0, {
+      body()
+      (this - 1).times(body)
+    })
   }
 }

--- a/new-packages/Core/src/Maybe.candy
+++ b/new-packages/Core/src/Maybe.candy
@@ -19,13 +19,13 @@ impl[T] Maybe[T] {
   }
 
   public fun flatMap[Out](mapper: (T) -> Maybe[Out]): Maybe[Out] {
-    this.match[Maybe[Out]](some = { Maybe[Out].Some(mapper(it)) }, none = { None })
+    this.match[Maybe[Out]](some = { Maybe[Out].Some(mapper(it)) }, none = { Maybe[Out].None() })
   }
 
   public fun do(body: (T) -> Nothing) { this.map[Nothing](body) }
 
   public fun isSome(): Bool { this.match[Bool](some = { true() }, none = { false() }) }
-  public fun isNone(): Bool { !this.isSome() }
+  public fun isNone(): Bool { this.isSome().not() }
 }
 
 impl[T: Equals] Maybe[T]: Equals {

--- a/new-packages/Core/src/Maybe.candy
+++ b/new-packages/Core/src/Maybe.candy
@@ -1,5 +1,5 @@
-use ..Primitives
 use ..Bool
+use ..Primitives
 
 public type Maybe[T] = Some T | None
 

--- a/new-packages/Core/src/Maybe.candy
+++ b/new-packages/Core/src/Maybe.candy
@@ -1,27 +1,38 @@
 use ..Bool
 use ..Operators
+use ..Panic
 use ..Primitives
 
 public type Maybe[T] = Some T | None
 
 impl[T] Maybe[T] {
-  fun unwrap(): T
-  fun else(alternative: () -> T): T { todo("Implement Maybe.else") }
-  fun map[Out](mapper: (T) -> Out): Maybe[Out] { flatMap[Out]({ Maybe.Some[Out](mapper(it)) }) }
-  fun flatMap[Out](mapper: (T) -> Maybe[Out]): Maybe[Out] { todo("Implement Maybe.flatMap") }
-  fun cast[Out](): Maybe[Out] { map[Out]({ it.as[Out]().unwrap() }) }
-  fun do(body: (T) -> Nothing) { map[Nothing]({ body(it) }) }
-  fun isSome(): Bool { todo("Implement Maybe.isSome") }
-  fun isNone(): Bool { todo("Implement Maybe.isNone") }
+  public fun unwrap(): T {
+    this.else({ panic("Called unwrap on None.") })
+  }
+
+  public fun else(alternative: () -> T): T {
+    this.match[T](some = { it }, none = alternative)
+  }
+
+  public fun map[Out](mapper: (T) -> Out): Maybe[Out] {
+    this.flatMap[Out]({ Maybe[Out].Some(mapper(it)) })
+  }
+
+  public fun flatMap[Out](mapper: (T) -> Maybe[Out]): Maybe[Out] {
+    this.match[Maybe[Out]](some = { Maybe[Out].Some(mapper(it)) }, none = { None })
+  }
+
+  public fun do(body: (T) -> Nothing) { this.map[Nothing](body) }
+
+  public fun isSome(): Bool { this.match[Bool](some = { true() }, none = { false() }) }
+  public fun isNone(): Bool { !this.isSome() }
 }
+
 impl[T: Equals] Maybe[T]: Equals {
   fun equals(other: Maybe[T]): Bool {
-    if(this.isNone().and(other.isNone()), {
-      true
-    }).else({
-      if(this.isSome().and(other.isSome()), {
-        this.unwrap().equals(other.unwrap())
-      }).else({ false })
-    })
+    this.match[Bool](
+      some = { a -> other.match[Bool](some = { b -> a == b }, none = { false() }) }
+      none = { other.isNone() }
+    )
   }
 }

--- a/new-packages/Core/src/Maybe.candy
+++ b/new-packages/Core/src/Maybe.candy
@@ -3,7 +3,7 @@ use ..Primitives
 
 public type Maybe[T] = Some T | None
 
-impl Maybe[T] {
+impl[T] Maybe[T] {
   fun unwrap(): T
   fun else(alternative: () -> T): T { todo("Implement Maybe.else") }
   fun map[Out](mapper: (T) -> Out): Maybe[Out] { flatMap[Out]({ Maybe.Some[Out](mapper(it)) }) }

--- a/new-packages/Core/src/Maybe.candy
+++ b/new-packages/Core/src/Maybe.candy
@@ -1,4 +1,5 @@
 use ..Bool
+use ..Operators
 use ..Primitives
 
 public type Maybe[T] = Some T | None
@@ -12,4 +13,15 @@ impl[T] Maybe[T] {
   fun do(body: (T) -> Nothing) { map[Nothing]({ body(it) }) }
   fun isSome(): Bool { todo("Implement Maybe.isSome") }
   fun isNone(): Bool { todo("Implement Maybe.isNone") }
+}
+impl[T: Equals] Maybe[T]: Equals {
+  fun equals(other: Maybe[T]): Bool {
+    if(this.isNone().and(other.isNone()), {
+      true
+    }).else({
+      if(this.isSome().and(other.isSome()), {
+        this.unwrap().equals(other.unwrap())
+      }).else({ false })
+    })
+  }
 }

--- a/new-packages/Core/src/Operators/Arithmetic.candy
+++ b/new-packages/Core/src/Operators/Arithmetic.candy
@@ -1,55 +1,48 @@
-public trait Add: BinaryPlus[This, This] {
-  ## TODO(marcelgarus): Make this generic over the `Other` type and the return type.
-
+public trait Add {
   fun add(other: This): This
-
-  fun plus(other: This): This { add(other) }
+}
+impl Add: InfixPlus[This, This] {
+  fun infixPlus(other: This): This { this.add(other) }
 }
 
-public trait Subtract: BinaryMinus[This, This] {
-  ## TODO(marcelgarus): Make this generic over the `Other` type and the return type.
-
+public trait Subtract {
   fun subtract(other: This): This
-
-  fun minus(other: This): This { subtract(other) }
+}
+impl Subtract: InfixMinus[This, This] {
+  fun infixMinus(other: This): This { this.subtract(other) }
 }
 
-public trait Negate: PrefixMinus[This] {
-  ## TODO(marcelgarus): Make this generic over the return type.
-
+public trait Negate {
   fun negate(): This
-
-  fun prefixMinus(): Result { negate() }
+}
+impl Negate: PrefixMinus[This] {
+  fun prefixMinus(): Result { this.negate() }
 }
 
-public trait Multiply: BinaryStar[This, This] {
-  ## TODO(marcelgarus): Make this generic over the `Other` type and the return type.
-
+public trait Multiply {
   fun multiply(other: This): This
-
-  fun star(other: This): This { multiply(other) }
+}
+impl Multiply: InfixStar[This, This] {
+  fun infixStar(other: This): This { this.multiply(other) }
 }
 
-public trait Divide: BinarySlash[This, This] {
-  ## TODO(marcelgarus): Make this generic over the `Other` type and the return type.
-
+public trait Divide {
   fun divide(other: This): This
-
-  fun slash(other: This): This { divide(other) }
+}
+impl Divide: InfixSlash[This, This] {
+  fun infixSlash(other: This): This { this.divide(other) }
 }
 
-public trait DivideTruncating: BinarySlashSlash[This, This] {
-  ## TODO(marcelgarus): Make this generic over the `Other` type and the return type.
-
+public trait DivideTruncating {
   fun divideTruncating(other: This): Int
-
-  fun slashSlash(other: This): This { divideTruncating(other) }
+}
+impl DivideTruncating: InfixSlashSlash[This, This] {
+  fun infixSlashSlash(other: This): This { this.divideTruncating(other) }
 }
 
 public trait Modulo {
-  ## TODO(marcelgarus): Make this generic over the `Other` type and the return type.
-
   fun modulo(other: This): This
-
-  fun percent(other: This): This { modulo(other) }
+}
+impl Modulo: InfixPercent {
+  fun infixPercent(other: This): This { this.modulo(other) }
 }

--- a/new-packages/Core/src/Operators/Arithmetic.candy
+++ b/new-packages/Core/src/Operators/Arithmetic.candy
@@ -1,4 +1,4 @@
-trait Add: BinaryPlus[This, This] {
+public trait Add: BinaryPlus[This, This] {
   ## TODO(marcelgarus): Make this generic over the `Other` type and the return type.
 
   fun add(other: This): This
@@ -6,7 +6,7 @@ trait Add: BinaryPlus[This, This] {
   fun plus(other: This): This { add(other) }
 }
 
-trait Subtract: BinaryMinus[This, This] {
+public trait Subtract: BinaryMinus[This, This] {
   ## TODO(marcelgarus): Make this generic over the `Other` type and the return type.
 
   fun subtract(other: This): This
@@ -14,7 +14,7 @@ trait Subtract: BinaryMinus[This, This] {
   fun minus(other: This): This { subtract(other) }
 }
 
-trait Negate: PrefixMinus[This] {
+public trait Negate: PrefixMinus[This] {
   ## TODO(marcelgarus): Make this generic over the return type.
 
   fun negate(): This
@@ -22,7 +22,7 @@ trait Negate: PrefixMinus[This] {
   fun prefixMinus(): Result { negate() }
 }
 
-trait Multiply: BinaryStar[This, This] {
+public trait Multiply: BinaryStar[This, This] {
   ## TODO(marcelgarus): Make this generic over the `Other` type and the return type.
 
   fun multiply(other: This): This
@@ -30,7 +30,7 @@ trait Multiply: BinaryStar[This, This] {
   fun star(other: This): This { multiply(other) }
 }
 
-trait Divide: BinarySlash[This, This] {
+public trait Divide: BinarySlash[This, This] {
   ## TODO(marcelgarus): Make this generic over the `Other` type and the return type.
 
   fun divide(other: This): This
@@ -38,7 +38,7 @@ trait Divide: BinarySlash[This, This] {
   fun slash(other: This): This { divide(other) }
 }
 
-trait DivideTruncating: BinarySlashSlash[This, This] {
+public trait DivideTruncating: BinarySlashSlash[This, This] {
   ## TODO(marcelgarus): Make this generic over the `Other` type and the return type.
 
   fun divideTruncating(other: This): Int
@@ -46,7 +46,7 @@ trait DivideTruncating: BinarySlashSlash[This, This] {
   fun slashSlash(other: This): This { divideTruncating(other) }
 }
 
-trait Modulo {
+public trait Modulo {
   ## TODO(marcelgarus): Make this generic over the `Other` type and the return type.
 
   fun modulo(other: This): This

--- a/new-packages/Core/src/Operators/Comparison.candy
+++ b/new-packages/Core/src/Operators/Comparison.candy
@@ -1,6 +1,6 @@
 use ..Equality
 
-trait Comparable: Equals
+public trait Comparable: Equals
   & BinaryLess[This, Bool]
   & BinaryLessEqual[This, Bool]
   & BinaryGreater[This, Bool]

--- a/new-packages/Core/src/Operators/Comparison.candy
+++ b/new-packages/Core/src/Operators/Comparison.candy
@@ -1,24 +1,38 @@
 use ..Equality
 
-public trait Comparable: Equals
-  & BinaryLess[This, Bool]
-  & BinaryLessEqual[This, Bool]
-  & BinaryGreater[This, Bool]
-  & BinaryGreaterEqual[This, Bool] {
-  ## TODO(marcelgarus): Make this generic over an `Other` type.
-
+public trait Comparable {
   fun compareTo(other: This): Less | Equal | Greater
-
-  fun less(other: This): Bool { compareTo(other) is Less }
-  fun lessEqual(other: This): Bool { compareTo(other) is Less | Equal }
-  fun greater(other: This): Bool { compareTo(other) is Greater }
-  fun greaterEqual(other: This): Bool { compareTo(other) is Greater | Equal }
+}
+impl Comparable: InfixLess[This, Bool] {
+  fun infixLess(other: This): Bool {
+    this.compareTo(other).match[Bool](less = { true() }, equal = { false() }, greater = { false() })
+  }
+}
+impl Comparable: InfixLessEqual[This, Bool] {
+  fun infixLessEqual(other: This): Bool {
+    this.compareTo(other).match[Bool](less = { true() }, equal = { true() }, greater = { false() })
+  }
+}
+impl Comparable: Equals {
+  fun equals(other: This): Bool {
+    this.compareTo(other).match[Bool](less = { false() }, equal = { true() }, greater = { false() })
+  }
+}
+impl Comparable: InfixGreaterEqual[This, Bool] {
+  fun infixGreaterEqual(other: This): Bool {
+    this.compareTo(other).match[Bool](less = { false() }, equal = { true() }, greater = { true() })
+  }
+}
+impl Comparable: InfixGreater[This, Bool] {
+  fun infixGreater(other: This): Bool {
+    this.compareTo(other).match[Bool](less = { false() }, equal = { false() }, greater = { true() })
+  }
 }
 
-## TODO(marcelgarus): Maybe make these methods on `Iterable`?
+## TODO(marcelgarus): Maybe put these methods on `Iterable`?
 public fun min[T: Comparable](first: T, second: T): T {
-  if first <= second { first } else { second }
+  if[T](first <= second, { first }).else({ second })
 }
 public fun max[T: Comparable](first: T, second: T): T {
-  if first >= second { first } else { second }
+  if[T](first >= second, { first }).else({ second })
 }

--- a/new-packages/Core/src/Operators/Equality.candy
+++ b/new-packages/Core/src/Operators/Equality.candy
@@ -1,15 +1,17 @@
 use ...Bool
 use ..Raw
 
-public trait Equals: BinaryEquals[This, Bool] & BinaryNotEquals[This, Bool] {
+public trait Equals {
   fun equals(other: This): Bool
-  builtin fun equalsAny(other: Any): Bool
-
-  fun notEquals(other: This): Bool { !equals(other) }
-  fun notEqualsAny(other: Any): Bool { !equalsAny(other) }
 }
-
-## impl[Other] Equals[Other]: BinaryEquals[Other, Bool] & BinaryNotEquals[Other, Bool] {
-##   fun equalsOperator(other: Other): Bool { /* this === other || */ equals(other) }
-##   fun notEqualsOperator(other: Other): Bool { equalsOperator(other).not() }
-## }
+impl Equals {
+  public fun notEquals(other: This): Bool { !this.equals(other) }
+  public fun equalsAny(other: Any): Bool { other.as[This]().map[Bool]({ it == this }).else({ false() }) }
+  public fun notEqualsAny(other: Any): Bool { !this.equalsAny(other) }
+}
+impl Equals: InfixEqual[This, Bool] {
+  fun infixEqual(other: This) { this.equals(other) }
+}
+impl Equals: InfixExclamationEqual[This, Bool] {
+  fun infixExclamationEqual(other: This) { this.notEquals(other) }
+}

--- a/new-packages/Core/src/Operators/Equality.candy
+++ b/new-packages/Core/src/Operators/Equality.candy
@@ -1,7 +1,7 @@
 use ...Bool
 use ..Raw
 
-trait Equals: BinaryEquals[This, Bool] & BinaryNotEquals[This, Bool] {
+public trait Equals: BinaryEquals[This, Bool] & BinaryNotEquals[This, Bool] {
   fun equals(other: This): Bool
   builtin fun equalsAny(other: Any): Bool
 

--- a/new-packages/Core/src/Operators/Logical.candy
+++ b/new-packages/Core/src/Operators/Logical.candy
@@ -1,25 +1,29 @@
 use ...Bool
 
-public trait And: BinaryAmpersand[This, Bool] {
+public trait And {
   fun and(other: This): Bool
-
-  fun ampersand(other: This): Bool { and(other) }
+}
+impl And: InfixAmpersand[This, Bool] {
+  fun infixAmpersand(other: This): Bool { this.and(other) }
 }
 
-public trait Or: BinaryBar[This, Bool] {
+public trait Or {
   fun or(other: This): Bool
-
-  fun bar(other: This): Bool { or(other) }
+}
+impl Or: InfixBar[This, Bool] {
+  fun infixBar(other: This): Bool { this.or(other) }
 }
 
-public trait Opposite: PrefixExclamation[This] {
+public trait Opposite {
   fun opposite(): This
-
-  fun exclamation(): This { opposite() }
+}
+impl Opposite: PrefixExclamation[This] {
+  fun prefixExclamation(): This { this.opposite() }
 }
 
-public trait Implies: BinaryEqualGreater[This, Bool] {
+public trait Implies {
   fun implies(other: This): Bool
-
-  fun equalGreater(other: This): Bool { implies(other) }
+}
+impl InfixEqualGreater[This, Bool] {
+  fun infixEqualGreater(other: This): Bool { this.implies(other) }
 }

--- a/new-packages/Core/src/Operators/Logical.candy
+++ b/new-packages/Core/src/Operators/Logical.candy
@@ -14,13 +14,6 @@ impl Or: InfixBar[This, Bool] {
   fun infixBar(other: This): Bool { this.or(other) }
 }
 
-public trait Opposite {
-  fun opposite(): This
-}
-impl Opposite: PrefixExclamation[This] {
-  fun prefixExclamation(): This { this.opposite() }
-}
-
 public trait Implies {
   fun implies(other: This): Bool
 }

--- a/new-packages/Core/src/Operators/Logical.candy
+++ b/new-packages/Core/src/Operators/Logical.candy
@@ -1,24 +1,24 @@
 use ...Bool
 
-trait And: BinaryAmpersand[This, Bool] {
+public trait And: BinaryAmpersand[This, Bool] {
   fun and(other: This): Bool
 
   fun ampersand(other: This): Bool { and(other) }
 }
 
-trait Or: BinaryBar[This, Bool] {
+public trait Or: BinaryBar[This, Bool] {
   fun or(other: This): Bool
 
   fun bar(other: This): Bool { or(other) }
 }
 
-trait Opposite: PrefixExclamation[This] {
+public trait Opposite: PrefixExclamation[This] {
   fun opposite(): This
 
   fun exclamation(): This { opposite() }
 }
 
-trait Implies: BinaryEqualGreater[This, Bool] {
+public trait Implies: BinaryEqualGreater[This, Bool] {
   fun implies(other: This): Bool
 
   fun equalGreater(other: This): Bool { implies(other) }

--- a/new-packages/Core/src/Operators/Raw.candy
+++ b/new-packages/Core/src/Operators/Raw.candy
@@ -1,90 +1,90 @@
 ## Binary operators.
 
-trait BinaryEqualEqual[Other, Result] {
+public trait BinaryEqualEqual[Other, Result] {
   # The binary `==` operator.
 
   fun equalEqual(other: Other): Result
 }
 
-trait BinaryExclamationEqual[Other, Result] {
+public trait BinaryExclamationEqual[Other, Result] {
   # The binary `!=` operator.
 
   fun exclamationEqual(other: Other): Result
 }
 
-trait BinaryLess[Other, Result] {
+public trait BinaryLess[Other, Result] {
   # The binary `<` operator.
 
   fun less(other: Other): Result
 }
 
-trait BinaryLessEqual[Other, Result] {
+public trait BinaryLessEqual[Other, Result] {
   # The binary `<=`` operator.
 
   fun lessEqual(other: Other): Result
 }
 
-trait BinaryGreater[Other, Result] {
+public trait BinaryGreater[Other, Result] {
   # The binary `>` operator.
 
   fun greater(other: Other): Result
 }
 
-trait BinaryGreaterEqual[Other, Result] {
+public trait BinaryGreaterEqual[Other, Result] {
   # The binary `>=` operator.
 
   fun greaterEqual(other: Other): Result
 }
 
-trait BinaryPlus[Other, Result] {
+public trait BinaryPlus[Other, Result] {
   # The binary `+` operator.
 
   fun plus(other: Other): Result
 }
 
-trait BinaryMinus[Other, Result] {
+public trait BinaryMinus[Other, Result] {
   # The binary `-` operator.
 
   fun minus(other: Other): Result
 }
 
-trait BinaryStar[Other, Result] {
+public trait BinaryStar[Other, Result] {
   # The binary `*` operator.
 
   fun star(other: Other): Result
 }
 
-trait BinarySlash[Other, Result] {
+public trait BinarySlash[Other, Result] {
   # The binary `/` operator.
 
   fun slash(other: Other): Result
 }
 
-trait BinarySlashSlash[Other, Result] {
+public trait BinarySlashSlash[Other, Result] {
   # The binary `//` operator.
 
   fun slashSlash(other: Other): Result
 }
 
-trait BinaryPercent[Other, Result] {
+public trait BinaryPercent[Other, Result] {
   # The binary `%` operator.
 
   fun percent(other: Other): Result
 }
 
-trait BinaryAmpersand[Other, Result] {
+public trait BinaryAmpersand[Other, Result] {
   # The binary `&` operator.
 
   fun ampersand(other: Other): Result
 }
 
-trait BinaryBar[Other, Result] {
+public trait BinaryBar[Other, Result] {
   # The binary `|` operator.
 
   fun bar(other: Other): Result
 }
 
-trait BinaryEqualsGreater[Other, Result] {
+public trait BinaryEqualsGreater[Other, Result] {
   # The binary `=>` operator.
 
   fun bar(other: Other): Result
@@ -92,13 +92,13 @@ trait BinaryEqualsGreater[Other, Result] {
 
 ## Prefix operators.
 
-trait PrefixMinus[Other, Result] {
+public trait PrefixMinus[Other, Result] {
   # The prefix `-` operator.
 
   fun minus(): Result
 }
 
-trait PrefixExclamation[Other, Result] {
+public trait PrefixExclamation[Other, Result] {
   # The prefix `!` operator.
 
   fun exclamation(): Result

--- a/new-packages/Core/src/Operators/Raw.candy
+++ b/new-packages/Core/src/Operators/Raw.candy
@@ -1,105 +1,117 @@
-## Binary operators.
+## The Candy compiler knows the traits in this module and enables operators for types that implement
+## them.
 
-public trait BinaryEqualEqual[Other, Result] {
-  # The binary `==` operator.
+## TODO(marcelgarus): Document precedence here.
 
-  fun equalEqual(other: Other): Result
+
+## Infix operators.
+##
+## These are operators that are placed between two operands. For example, `+` is an infix operator
+## because you can write `a + b` to apply `+` to `a` and `b`.
+
+public trait InfixEqualEqual[Other, Result] {
+  # The infix `==` operator.
+
+  fun infixEqualEqual(other: Other): Result
 }
 
-public trait BinaryExclamationEqual[Other, Result] {
-  # The binary `!=` operator.
+public trait InfixExclamationEqual[Other, Result] {
+  # The infix `!=` operator.
 
-  fun exclamationEqual(other: Other): Result
+  fun infixExclamationEqual(other: Other): Result
 }
 
-public trait BinaryLess[Other, Result] {
-  # The binary `<` operator.
+public trait InfixLess[Other, Result] {
+  # The infix `<` operator.
 
-  fun less(other: Other): Result
+  fun infixLess(other: Other): Result
 }
 
-public trait BinaryLessEqual[Other, Result] {
-  # The binary `<=`` operator.
+public trait InfixLessEqual[Other, Result] {
+  # The infix `<=`` operator.
 
-  fun lessEqual(other: Other): Result
+  fun infixLessEqual(other: Other): Result
 }
 
-public trait BinaryGreater[Other, Result] {
-  # The binary `>` operator.
+public trait InfixGreater[Other, Result] {
+  # The infix `>` operator.
 
-  fun greater(other: Other): Result
+  fun infixGreater(other: Other): Result
 }
 
-public trait BinaryGreaterEqual[Other, Result] {
-  # The binary `>=` operator.
+public trait InfixGreaterEqual[Other, Result] {
+  # The infix `>=` operator.
 
-  fun greaterEqual(other: Other): Result
+  fun infixGreaterEqual(other: Other): Result
 }
 
-public trait BinaryPlus[Other, Result] {
-  # The binary `+` operator.
+public trait InfixPlus[Other, Result] {
+  # The infix `+` operator.
 
-  fun plus(other: Other): Result
+  fun infixPlus(other: Other): Result
 }
 
-public trait BinaryMinus[Other, Result] {
-  # The binary `-` operator.
+public trait InfixMinus[Other, Result] {
+  # The infix `-` operator.
 
-  fun minus(other: Other): Result
+  fun infixMinus(other: Other): Result
 }
 
-public trait BinaryStar[Other, Result] {
-  # The binary `*` operator.
+public trait InfixStar[Other, Result] {
+  # The infix `*` operator.
 
-  fun star(other: Other): Result
+  fun infixStar(other: Other): Result
 }
 
-public trait BinarySlash[Other, Result] {
-  # The binary `/` operator.
+public trait InfixSlash[Other, Result] {
+  # The infix `/` operator.
 
-  fun slash(other: Other): Result
+  fun infixSlash(other: Other): Result
 }
 
-public trait BinarySlashSlash[Other, Result] {
-  # The binary `//` operator.
+public trait InfixSlashSlash[Other, Result] {
+  # The infix `//` operator.
 
-  fun slashSlash(other: Other): Result
+  fun infixSlashSlash(other: Other): Result
 }
 
-public trait BinaryPercent[Other, Result] {
-  # The binary `%` operator.
+public trait InfixPercent[Other, Result] {
+  # The infix `%` operator.
 
-  fun percent(other: Other): Result
+  fun infixPercent(other: Other): Result
 }
 
-public trait BinaryAmpersand[Other, Result] {
-  # The binary `&` operator.
+public trait InfixAmpersand[Other, Result] {
+  # The infix `&` operator.
 
-  fun ampersand(other: Other): Result
+  fun infixAmpersand(other: Other): Result
 }
 
-public trait BinaryBar[Other, Result] {
-  # The binary `|` operator.
+public trait InfixBar[Other, Result] {
+  # The infix `|` operator.
 
-  fun bar(other: Other): Result
+  fun infixBar(other: Other): Result
 }
 
-public trait BinaryEqualsGreater[Other, Result] {
-  # The binary `=>` operator.
+public trait InfixEqualGreater[Other, Result] {
+  # The infix `=>` operator.
 
-  fun bar(other: Other): Result
+  fun infixEqualGreater(other: Other): Result
 }
 
 ## Prefix operators.
+##
+## These are operators placed before their operand. For example, `-` is (also) a prefix operator
+## because you can write `-5` to apply `-` to the `5`.
 
-public trait PrefixMinus[Other, Result] {
+public trait PrefixMinus[Result] {
   # The prefix `-` operator.
 
-  fun minus(): Result
+  fun prefixMinus(): Result
 }
 
-public trait PrefixExclamation[Other, Result] {
+public trait PrefixExclamation[Result] {
   # The prefix `!` operator.
 
-  fun exclamation(): Result
+  fun prefixExclamation(): Result
 }

--- a/new-packages/Core/src/Operators/Raw/.candy
+++ b/new-packages/Core/src/Operators/Raw/.candy
@@ -1,0 +1,7 @@
+## The Candy compiler knows the traits in this module and enables operators for the types that
+## implement them.
+
+## TODO(marcelgarus): Document precedence here.
+
+public use .Infix
+public use .Prefix

--- a/new-packages/Core/src/Operators/Raw/.candy
+++ b/new-packages/Core/src/Operators/Raw/.candy
@@ -1,5 +1,5 @@
-## The Candy compiler knows the traits in this module and enables operators for the types that
-## implement them.
+# The Candy compiler knows the traits in this module and enables operators for the types that
+# implement them.
 
 ## TODO(marcelgarus): Document precedence here.
 

--- a/new-packages/Core/src/Operators/Raw/Infix.candy
+++ b/new-packages/Core/src/Operators/Raw/Infix.candy
@@ -1,13 +1,7 @@
-## The Candy compiler knows the traits in this module and enables operators for types that implement
-## them.
-
-## TODO(marcelgarus): Document precedence here.
-
-
-## Infix operators.
-##
-## These are operators that are placed between two operands. For example, `+` is an infix operator
-## because you can write `a + b` to apply `+` to `a` and `b`.
+# Infix operators.
+#
+# These are operators that are placed between two operands. For example, `+` is an infix operator
+# because you can write `a + b` to apply `+` to `a` and `b`.
 
 public trait InfixEqualEqual[Other, Result] {
   # The infix `==` operator.
@@ -97,21 +91,4 @@ public trait InfixEqualGreater[Other, Result] {
   # The infix `=>` operator.
 
   fun infixEqualGreater(other: Other): Result
-}
-
-## Prefix operators.
-##
-## These are operators placed before their operand. For example, `-` is (also) a prefix operator
-## because you can write `-5` to apply `-` to the `5`.
-
-public trait PrefixMinus[Result] {
-  # The prefix `-` operator.
-
-  fun prefixMinus(): Result
-}
-
-public trait PrefixExclamation[Result] {
-  # The prefix `!` operator.
-
-  fun prefixExclamation(): Result
 }

--- a/new-packages/Core/src/Operators/Raw/Prefix.candy
+++ b/new-packages/Core/src/Operators/Raw/Prefix.candy
@@ -1,0 +1,10 @@
+# Prefix operators.
+#
+# These are operators placed before their operand. For example, `-` is (also) a prefix operator
+# because you can write `-5` to apply `-` to the `5`.
+
+public trait PrefixMinus[Result] {
+  # The prefix `-` operator.
+
+  fun prefixMinus(): Result
+}

--- a/new-packages/Core/src/Panic.candy
+++ b/new-packages/Core/src/Panic.candy
@@ -1,3 +1,3 @@
 use ..Primitives
 
-builtin fun panic(message: String): Never
+public builtin fun panic(message: String): Never

--- a/new-packages/Playground/src/Types.candy
+++ b/new-packages/Playground/src/Types.candy
@@ -1,5 +1,12 @@
-type Foo = Unit
+builtin type Blub
+builtin type Foo[T]
 
-trait Bar {}
+trait Bar {
+  fun baz(): Blub
+}
 
-impl Foo: Bar {}
+impl[T] Foo[T]: Bar {
+  fun baz(): Blub {
+    print("Hi.")
+  }
+}

--- a/packages/ast/src/declarations.candy
+++ b/packages/ast/src/declarations.candy
@@ -28,6 +28,9 @@ impl AstDeclaration: AstNode & Equals & Hash {
   fun hash<T>(hasher: Hasher<T>) { (modifiers as Hash).unsafeHash<T>(hasher) }
 }
 
+public trait AstWithTypeParameters {
+  public let typeParameters: List<AstTypeParameter>
+}
 
 public class AstModule {
   public let id: AstDeclarationId
@@ -66,7 +69,7 @@ public class AstTrait {
   public let upperBound: Maybe<AstInlineType>
   public let innerDeclarations: List<AstTrait | AstType | AstFunction>
 }
-impl AstTrait: AstDeclaration & Equals & Hash {
+impl AstTrait: AstWithTypeParameters & AstDeclaration & Equals & Hash {
   fun equals(other: This): Bool {
     (id as Equals) == (other.id as Equals) &&
       candyDoc.unsafeEquals(other.candyDoc) &&
@@ -98,7 +101,7 @@ public class AstImpl {
   public let traits: List<AstNamedType | AstErrorType>
   public let innerDeclarations: List<AstFunction>
 }
-impl AstImpl: AstDeclaration & Equals & Hash {
+impl AstImpl: AstWithTypeParameters & AstDeclaration & Equals & Hash {
   fun equals(other: This): Bool {
     (id as Equals) == (other.id as Equals) &&
       (modifiers as Iterable<AstIdentifier>)
@@ -130,7 +133,7 @@ public class AstType {
   public let typeParameters: List<AstTypeParameter>
   public let type: Maybe<AstInlineType>
 }
-impl AstType: AstDeclaration & Equals & Hash {
+impl AstType: AstWithTypeParameters & AstDeclaration & Equals & Hash {
   fun equals(other: This): Bool {
     (id as Equals) == (other.id as Equals) &&
       candyDoc.unsafeEquals(other.candyDoc) &&
@@ -162,7 +165,7 @@ public class AstFunction {
   public let returnType: AstInlineType
   public let body: Maybe<AstBlockBody | AstExpressionBody | AstDelegationBody>
 }
-impl AstFunction: AstDeclaration & Equals & Hash {
+impl AstFunction: AstWithTypeParameters & AstDeclaration & Equals & Hash {
   fun equals(other: This): Bool {
     (id as Equals) == (other.id as Equals) &&
       candyDoc.unsafeEquals(other.candyDoc) &&

--- a/packages/hir/src/example.candy
+++ b/packages/hir/src/example.candy
@@ -60,4 +60,17 @@ fun solverExample(context: QueryContext<List<CompilerError>>) {
   print("Environment:")
   print(getSolverEnvironmentOfScope(context, playground))
   //print("Does {type.toString_()} implement Equals? {environment.solve(equalsImpl(type)).toString_()}")
+  print("")
+  print("Outputs:")
+  for queryOutputs in context.outputs().entries() {
+    let queryName = queryOutputs.first
+    let inputsToErrors = queryOutputs.second
+    for entry in inputsToErrors.entries() {
+      let input = entry.first
+      let errors = entry.second
+      for error in errors {
+        print("{queryName}({input}): {error}")
+      }
+    }
+  }
 }

--- a/packages/hir/src/example.candy
+++ b/packages/hir/src/example.candy
@@ -52,15 +52,12 @@ fun resolvingExample(context: QueryContext<List<CompilerError>>) {
 }
 
 fun solverExample(context: QueryContext<List<CompilerError>>) {
-  let file = FancyFile(Package.playground(context), Path.parse("src/Types.candy"))
+  let playground = Package.playground(context)
+  let file = FancyFile(playground, Path.parse("src/Types.candy"))
   let declarations = (fileToHirModule(context, file) as HirInnerModule).declarations(context)
   print("Declarations are {declarations}.")
-  let anImpl = ((declarations as Iterable<HirDeclaration>).third().unwrap() as HirImpl)
-  print("Impl is {anImpl}.")
-  let rule = hirImplToSolverRule(context, anImpl)
-  print("Rule is {rule}.")
   print("")
-  print("All impls of core:")
-  print(getAllImplsInScope(context, Package.core(context)))
+  print("Environment:")
+  print(getSolverEnvironmentOfScope(context, playground))
   //print("Does {type.toString_()} implement Equals? {environment.solve(equalsImpl(type)).toString_()}")
 }

--- a/packages/hir/src/lowering/types.candy
+++ b/packages/hir/src/lowering/types.candy
@@ -439,7 +439,7 @@ fun getSolverEnvironmentOfScope(context: QueryContext<List<CompilerError>>, scop
 }
 
 fun makeSureImplsAreNotConflicting(context: QueryContext<List<CompilerError>>, scope: Package) {
-  query<Unit, List<CompilerError>>( context, "makeSureImplsAreNotConflicting", scope as Equals & Hash, {
+  query<Unit, List<CompilerError>>(context, "makeSureImplsAreNotConflicting", scope as Equals & Hash, {
     for implsForSameTrait in (getAllImplsInScope(context, scope) as Iterable<HirImpl>)
       .where({ it.implementedTrait(context) is Some })
       .groupBy<HirInlineType>({ it.implementedTrait(context).unwrap() })

--- a/packages/hir/src/lowering/types.candy
+++ b/packages/hir/src/lowering/types.candy
@@ -167,8 +167,7 @@ impl HirParameterType {
       Tuple(
         (((this.declaration as HasAst).ast(context) as AstWithTypeParameters)
           .typeParameters as Iterable<AstTypeParameter>)
-          .where({ it.name.value == this.name })
-          .single()
+          .singleWhere({ it.name.value == this.name })
           .flatMap<AstInlineType>({ it.upperBound })
           .map<HirInlineType>({ astInlineTypeToHirInlineType(context, it, this.declaration) }),
         List.empty<CompilerError>(),
@@ -191,7 +190,6 @@ impl HirImpl {
               upperBound => Tuple(it, upperBound)
             })
           })
-          .where({ (it.second is Some) })
           .unsafeToMap<HirParameterType, HirInlineType>(),
         List.empty<CompilerError>(),
       )

--- a/packages/hir/src/lowering/types.candy
+++ b/packages/hir/src/lowering/types.candy
@@ -161,12 +161,26 @@ fun astInlineTypeToHirInlineType(
 }
 
 impl HirImpl {
-  fun constraints(): Map<HirParameterType, HirInlineType> {
+  fun constraints(context: QueryContext<List<CompilerError>>): Map<HirParameterType, HirInlineType> {
     // The type constraints of an impl. For example, `impl[T: Equals] Foo[T]: Equals` has the
     // constraints `T: Equals`.
 
-    // TODO(marcelgarus): Support constraints.
-    Map.empty<HirParameterType, HirInlineType>()
+    query<Map<HirParameterType, HirInlineType>, List<CompilerError>>(
+      context, "HirImpl.constraints", this as Equals & Hash, {
+
+      let constraints = MutableMap.empty<HirParameterType, HirInlineType>()
+
+      for parameter in this.ast(context).typeParameters {
+        if (parameter.upperBound is Some) {
+          constraints.set(
+            HirParameterType(this, parameter.name.value),
+            astInlineTypeToHirInlineType(context, parameter.upperBound.unwrap(), this),
+          )
+        }
+      }
+
+      Tuple(constraints, List.empty<CompilerError>())
+    })
   }
 
   fun baseType(context: QueryContext<List<CompilerError>>): HirInlineType {
@@ -246,7 +260,7 @@ fun hirImplToSolverRule(
     // Lower the constraints. For example, in the impl `impl[T: Equals] Foo[T]: Equals`, the
     // `solverConstraints` are a list containing `Equals(?T)`.
     let solverConstraints = MutableList.empty<SolverGoal>()
-    for constraint in hirImpl.constraints().entries() {
+    for constraint in hirImpl.constraints(context).entries() {
       let result = hirInlineTypeToSolverTypeAndGoals(context, constraint.second)
       if (result is None) { return Tuple(None<SolverRule>(), List.empty<CompilerError>()) }
       solverConstraints.appendAll(

--- a/packages/hir/src/lowering/types.candy
+++ b/packages/hir/src/lowering/types.candy
@@ -160,6 +160,23 @@ fun astInlineTypeToHirInlineType(
   )
 }
 
+impl HirParameterType {
+  fun upperBound(context: QueryContext<List<CompilerError>>): Maybe<HirInlineType> {
+    query<Maybe<HirInlineType>, List<CompilerError>>(
+      context, "HirParameterType.upperBound", this as Equals & Hash, {
+      Tuple(
+        (((this.declaration as HasAst).ast(context) as AstWithTypeParameters)
+          .typeParameters as Iterable<AstTypeParameter>)
+          .where({ it.name.value == this.name })
+          .single()
+          .flatMap<AstInlineType>({ it.upperBound })
+          .map<HirInlineType>({ astInlineTypeToHirInlineType(context, it, this.declaration) }),
+        List.empty<CompilerError>(),
+      )
+    })
+  }
+}
+
 impl HirImpl {
   fun constraints(context: QueryContext<List<CompilerError>>): Map<HirParameterType, HirInlineType> {
     // The type constraints of an impl. For example, `impl[T: Equals] Foo[T]: Equals` has the
@@ -167,19 +184,17 @@ impl HirImpl {
 
     query<Map<HirParameterType, HirInlineType>, List<CompilerError>>(
       context, "HirImpl.constraints", this as Equals & Hash, {
-
-      let constraints = MutableMap.empty<HirParameterType, HirInlineType>()
-
-      for parameter in this.ast(context).typeParameters {
-        if (parameter.upperBound is Some) {
-          constraints.set(
-            HirParameterType(this, parameter.name.value),
-            astInlineTypeToHirInlineType(context, parameter.upperBound.unwrap(), this),
-          )
-        }
-      }
-
-      Tuple(constraints, List.empty<CompilerError>())
+      Tuple(
+        (this.typeParameters(context) as Iterable<HirParameterType>)
+          .maybeMap<(HirParameterType, HirInlineType)>({
+            it.upperBound(context).map<(HirParameterType, HirInlineType)>({
+              upperBound => Tuple(it, upperBound)
+            })
+          })
+          .where({ (it.second is Some) })
+          .unsafeToMap<HirParameterType, HirInlineType>(),
+        List.empty<CompilerError>(),
+      )
     })
   }
 
@@ -439,14 +454,8 @@ fun hirInlineTypeToSolverTypeAndGoals(
 fun getSolverEnvironmentOfScope(context: QueryContext<List<CompilerError>>, scope: Package): Environment {
   query<Environment, List<CompilerError>>(
     context, "getSolverEnvironmentOfScope", scope as Equals & Hash, {
-    let impls = getAllImplsInScope(context, scope)
-    let rules = impls
-      .items()
-      .maybeMap<SolverRule>({
-        let rule = hirImplToSolverRule(context, it)
-        print("Rule is {rule}")
-        rule
-      })
+    let rules = getAllImplsInScope(context, scope).items()
+      .maybeMap<SolverRule>({ hirImplToSolverRule(context, it) })
       .toList()
     Tuple(Environment(rules), List.empty<CompilerError>())
   })

--- a/packages/hir/src/lowering/types.candy
+++ b/packages/hir/src/lowering/types.candy
@@ -422,6 +422,22 @@ fun hirInlineTypeToSolverTypeAndGoals(
   })
 }
 
+fun getSolverEnvironmentOfScope(context: QueryContext<List<CompilerError>>, scope: Package): Environment {
+  query<Environment, List<CompilerError>>(
+    context, "getSolverEnvironmentOfScope", scope as Equals & Hash, {
+    let impls = getAllImplsInScope(context, scope)
+    let rules = impls
+      .items()
+      .maybeMap<SolverRule>({
+        let rule = hirImplToSolverRule(context, it)
+        print("Rule is {rule}")
+        rule
+      })
+      .toList()
+    Tuple(Environment(rules), List.empty<CompilerError>())
+  })
+}
+
 fun makeSureImplsAreNotConflicting(context: QueryContext<List<CompilerError>>, scope: Package) {
   query<Unit, List<CompilerError>>( context, "makeSureImplsAreNotConflicting", scope as Equals & Hash, {
     for implsForSameTrait in (getAllImplsInScope(context, scope) as Iterable<HirImpl>)

--- a/packages/hir/src/types.candy
+++ b/packages/hir/src/types.candy
@@ -7,7 +7,7 @@ public trait HirInlineType: Equals & Hash
 
 
 public class HirErrorType {}
-impl HirErrorType: HirInlineType & Equals & Hash {
+impl HirErrorType: Equals & Hash & HirInlineType {
   fun equals(other: This): Bool { true }
   fun hash<T>(hasher: Hasher<T>) {}
 }
@@ -30,7 +30,7 @@ public class HirNamedType {
     HirNamedType(HirType.coreString(context), List.empty<HirInlineType>())
   }
 }
-impl HirNamedType: HirInlineType & Equals & Hash {
+impl HirNamedType: Equals & Hash & HirInlineType {
   fun equals(other: This): Bool {
     declaration == other.declaration
       && (parameterTypes as Iterable<HirInlineType>)
@@ -48,7 +48,7 @@ public class HirFunctionType {
   public let parameterTypes: List<HirInlineType>
   public let returnType: HirInlineType
 }
-impl HirFunctionType: HirInlineType & Equals & Hash {
+impl HirFunctionType: Equals & Hash & HirInlineType {
   fun equals(other: This): Bool {
     (receiverType as Equals) == (other.receiverType as Equals)
       && (parameterTypes as Iterable<HirInlineType>)
@@ -79,7 +79,7 @@ public class HirTupleType {
     "tenth",
   )
 }
-impl HirTupleType: HirInlineType & Equals & Hash {
+impl HirTupleType: Equals & Hash & HirInlineType {
   fun equals(other: This): Bool {
     (types as Iterable<HirInlineType>).unsafeEquals(other.types as Iterable<HirInlineType>)
   }
@@ -90,7 +90,7 @@ impl HirTupleType: HirInlineType & Equals & Hash {
 public class HirNamedTupleType {
   public let types: List<(String, HirInlineType)>
 }
-impl HirNamedTupleType: HirInlineType & Equals & Hash {
+impl HirNamedTupleType: Equals & Hash & HirInlineType {
   fun equals(other: This): Bool {
     (types as Iterable<(String, HirInlineType)>)
       .unsafeEquals(other.types as Iterable<(String, HirInlineType)>)
@@ -102,7 +102,7 @@ impl HirNamedTupleType: HirInlineType & Equals & Hash {
 public class HirEnumType {
   public let variants: Map<String, Maybe<HirInlineType>>
 }
-impl HirEnumType: HirInlineType & Equals & Hash {
+impl HirEnumType: Equals & Hash & HirInlineType {
   fun equals(other: This): Bool { variants.unsafeEquals(other.variants) }
   fun hash<T>(hasher: Hasher<T>) { variants.unsafeHash<T>(hasher) }
 }
@@ -112,7 +112,7 @@ public class HirIntersectionType {
   public let types: List<HirInlineType>
   // TODO(JonasWanke): Use a `Set<HirInlineType>` when we have sets that keep insertion order.
 }
-impl HirIntersectionType: HirInlineType & Equals & Hash {
+impl HirIntersectionType: Equals & Hash & HirInlineType {
   fun equals(other: This): Bool {
     (types as Iterable<HirInlineType>).unsafeEquals(other.types as Iterable<HirInlineType>)
   }
@@ -121,7 +121,7 @@ impl HirIntersectionType: HirInlineType & Equals & Hash {
 
 
 public class HirThisType
-impl HirThisType: HirInlineType & Equals & Hash {
+impl HirThisType: Equals & Hash & HirInlineType {
   fun equals(other: This): Bool { true }
   fun hash<T>(hasher: Hasher<T>) {}
 }
@@ -131,7 +131,7 @@ public class HirParameterType {
   public let declaration: HirTrait | HirImpl | HirType | HirFunction
   public let name: String
 }
-impl HirParameterType: HirInlineType & Equals & Hash {
+impl HirParameterType: Equals & Hash & HirInlineType {
   fun equals(other: This): Bool {
     (declaration as Equals) == other.declaration && name == other.name
   }
@@ -145,7 +145,7 @@ impl HirParameterType: HirInlineType & Equals & Hash {
 public class HirReflectionType {
   public let target: HirModule | HirTrait | HirType | HirFunction | HirParameterType
 }
-impl HirReflectionType: HirInlineType & Equals & Hash {
+impl HirReflectionType: Equals & Hash & HirInlineType {
   fun equals(other: This): Bool { (target as Equals) == (other.target as Equals) }
   fun hash<T>(hasher: Hasher<T>) { (target as Hash).hash<T>(hasher) }
 }


### PR DESCRIPTION
Adds several utilities for working with impls, for example getting the `constraints` or `baseType`.
Also implements lowering for impls. For example, `impl[T: Equals] Maybe[T]: Equals` gets properly lowered to the `SolverRule` `Equals(Maybe[T]) <- Equals(T)`.

Impls for traits don't get lowered properly yet, but I'm working on that.

This PR also fixes some flaws in the new Core library.