### PR TITLE
Type solving

### DIFF
--- a/new-packages/Core/src/Maybe.candy
+++ b/new-packages/Core/src/Maybe.candy
@@ -19,7 +19,7 @@ impl[T] Maybe[T] {
   }
 
   public fun flatMap[Out](mapper: (T) -> Maybe[Out]): Maybe[Out] {
-    this.match[Maybe[Out]](some = { Maybe[Out].Some(mapper(it)) }, none = { Maybe[Out].None() })
+    this.match[Maybe[Out]](some = { mapper(it) }, none = { Maybe[Out].None() })
   }
 
   public fun do(body: (T) -> Nothing) { this.map[Nothing](body) }

--- a/new-packages/Core/src/Operators/Arithmetic.candy
+++ b/new-packages/Core/src/Operators/Arithmetic.candy
@@ -1,3 +1,6 @@
+use ...Int
+use ..Raw
+
 public trait Add {
   fun add(other: This): This
 }

--- a/new-packages/Core/src/Operators/Arithmetic.candy
+++ b/new-packages/Core/src/Operators/Arithmetic.candy
@@ -43,6 +43,6 @@ impl DivideTruncating: InfixSlashSlash[This, This] {
 public trait Modulo {
   fun modulo(other: This): This
 }
-impl Modulo: InfixPercent {
+impl Modulo: InfixPercent[This, This] {
   fun infixPercent(other: This): This { this.modulo(other) }
 }

--- a/new-packages/Core/src/Operators/Comparison.candy
+++ b/new-packages/Core/src/Operators/Comparison.candy
@@ -1,4 +1,6 @@
+use ...Bool
 use ..Equality
+use ..Raw
 
 public trait Comparable {
   fun compareTo(other: This): Less | Equal | Greater

--- a/new-packages/Core/src/Operators/Logical.candy
+++ b/new-packages/Core/src/Operators/Logical.candy
@@ -1,4 +1,5 @@
 use ...Bool
+use ..Raw
 
 public trait And {
   fun and(other: This): Bool

--- a/new-packages/Core/src/Operators/Logical.candy
+++ b/new-packages/Core/src/Operators/Logical.candy
@@ -17,6 +17,6 @@ impl Or: InfixBar[This, Bool] {
 public trait Implies {
   fun implies(other: This): Bool
 }
-impl InfixEqualGreater[This, Bool] {
+impl Implies: InfixEqualGreater[This, Bool] {
   fun infixEqualGreater(other: This): Bool { this.implies(other) }
 }

--- a/new-packages/Core/src/Primitives.candy
+++ b/new-packages/Core/src/Primitives.candy
@@ -44,8 +44,7 @@ public builtin type Nothing
 # * function calls of functions without an explicit return value like `print("Hello, world!")`
 # * the explicit nothing instance: `nothing`
 
-public fun nothing(): Nothing { functionThatReturnsNothing() }
-fun functionThatReturnsNothing(): Nothing {}
+public fun nothing(): Nothing {}
 
 ## Because the `Never` type contains itself, it's impossible to instantiate.
 public type Never = Never

--- a/new-packages/Playground/src/Types.candy
+++ b/new-packages/Playground/src/Types.candy
@@ -1,11 +1,18 @@
 builtin type Blub
 builtin type Foo[T]
 
-trait Bar {
+trait Bar[T] {
+}
+trait Baz[T] {
   fun baz(): Blub
 }
 
 impl[T] Foo[T]: Bar {
+  fun baz(): Blub {
+    print("Hi.")
+  }
+}
+impl[T] Bar[T]: Baz[T] {
   fun baz(): Blub {
     print("Hi.")
   }

--- a/new-packages/Playground/src/Types.candy
+++ b/new-packages/Playground/src/Types.candy
@@ -1,19 +1,16 @@
-builtin type Blub
-builtin type Foo[T]
+builtin type Foo
 
-trait Bar[T] {
-}
-trait Baz[T] {
-  fun baz(): Blub
-}
+trait Bar {}
+trait Baz[T] {}
 
-impl[T] Foo[T]: Bar {
-  fun baz(): Blub {
-    print("Hi.")
-  }
-}
-impl[T] Bar[T]: Baz[T] {
-  fun baz(): Blub {
-    print("Hi.")
-  }
-}
+## Type implements trait
+impl Foo: Bar {}
+
+## Trait implements trait
+impl Bar: Baz[Foo] {}
+
+## Type implements trait with This
+impl Foo: Baz[This] {}
+
+## Trait implements trait with This
+impl Bar: Baz[This] {}

--- a/packages/hir/src/example.candy
+++ b/packages/hir/src/example.candy
@@ -65,20 +65,20 @@ fun solverExample(context: QueryContext<List<CompilerError>>) {
     print("The rule is {rule.unwrap().toString_()}.")
   }
 
-  // print("Environment:")
-  // print(getSolverEnvironmentOfScope(context, playground))
+  print("Environment:")
+  print(getSolverEnvironmentOfScope(context, playground).toString_())
   // print("Does {type.toString_()} implement Equals? {environment.solve(equalsImpl(type)).toString_()}")
-  // print("")
-  // print("Outputs:")
-  // for queryOutputs in context.outputs().entries() {
-  //   let queryName = queryOutputs.first
-  //   let inputsToErrors = queryOutputs.second
-  //   for entry in inputsToErrors.entries() {
-  //     let input = entry.first
-  //     let errors = entry.second
-  //     for error in errors {
-  //       print("{queryName}({input}): {error}")
-  //     }
-  //   }
-  // }
+  print("")
+  print("Outputs:")
+  for queryOutputs in context.outputs().entries() {
+    let queryName = queryOutputs.first
+    let inputsToErrors = queryOutputs.second
+    for entry in inputsToErrors.entries() {
+      let input = entry.first
+      let errors = entry.second
+      for error in errors {
+        print("{queryName}({input}): {error}")
+      }
+    }
+  }
 }

--- a/packages/hir/src/example.candy
+++ b/packages/hir/src/example.candy
@@ -57,20 +57,24 @@ fun solverExample(context: QueryContext<List<CompilerError>>) {
   let declarations = (fileToHirModule(context, file) as HirInnerModule).declarations(context)
   print("Declarations are {declarations}.")
   print("")
-  print("Environment:")
-  print(getSolverEnvironmentOfScope(context, playground))
-  //print("Does {type.toString_()} implement Equals? {environment.solve(equalsImpl(type)).toString_()}")
-  print("")
-  print("Outputs:")
-  for queryOutputs in context.outputs().entries() {
-    let queryName = queryOutputs.first
-    let inputsToErrors = queryOutputs.second
-    for entry in inputsToErrors.entries() {
-      let input = entry.first
-      let errors = entry.second
-      for error in errors {
-        print("{queryName}({input}): {error}")
-      }
-    }
-  }
+  let anImpl = ((declarations as Iterable<HirDeclaration>).get(5).unwrap() as HirImpl)
+  let rule = hirImplToSolverRule(context, anImpl)
+  print("The rule is {rule}.")
+
+  // print("Environment:")
+  // print(getSolverEnvironmentOfScope(context, playground))
+  // print("Does {type.toString_()} implement Equals? {environment.solve(equalsImpl(type)).toString_()}")
+  // print("")
+  // print("Outputs:")
+  // for queryOutputs in context.outputs().entries() {
+  //   let queryName = queryOutputs.first
+  //   let inputsToErrors = queryOutputs.second
+  //   for entry in inputsToErrors.entries() {
+  //     let input = entry.first
+  //     let errors = entry.second
+  //     for error in errors {
+  //       print("{queryName}({input}): {error}")
+  //     }
+  //   }
+  // }
 }

--- a/packages/hir/src/example.candy
+++ b/packages/hir/src/example.candy
@@ -59,7 +59,11 @@ fun solverExample(context: QueryContext<List<CompilerError>>) {
   print("")
   let anImpl = ((declarations as Iterable<HirDeclaration>).get(5).unwrap() as HirImpl)
   let rule = hirImplToSolverRule(context, anImpl)
-  print("The rule is {rule}.")
+  if (rule is None) {
+    print("Couldn't lower impl to rule.")
+  } else {
+    print("The rule is {rule.unwrap().toString_()}.")
+  }
 
   // print("Environment:")
   // print(getSolverEnvironmentOfScope(context, playground))

--- a/packages/hir/src/lowering/types.candy
+++ b/packages/hir/src/lowering/types.candy
@@ -35,6 +35,24 @@ fun astInlineTypeToHirInlineType(
         let nameParts = ((astType as AstNamedType).nameParts as Iterable<AstIdentifier>)
           .map<String>({ it.value })
 
+        if ((nameParts as Iterable).length() == 1) {
+          if (nameParts as Iterable<String>).first().unwrap() == "This" {
+            if (scope is HirTrait || scope is HirImpl) {
+              return Tuple(
+                HirThisType(scope as HirTrait | HirImpl) as HirInlineType,
+                List.empty<CompilerError>()
+              )
+            } else {
+              return Tuple(
+                HirErrorType() as HirInlineType,
+                List.of1<CompilerError>(
+                  ThisTypeCanOnlyBeUsedInImplOrTraitCompilerError((astType as AstNamedType), scope),
+                ),
+              )
+            }
+          }
+        }
+
         // Try to find the first part of the `nameParts`. Then, find children inside its
         // declarations.
         // TODO(marcelgarus): When resolving `Foo Bar`, we currently accept a `Bar` next to `Foo` if
@@ -502,6 +520,20 @@ impl HirType {
       // })
     })
   }
+}
+
+public class ThisTypeCanOnlyBeUsedInImplOrTraitCompilerError {
+  public let thisType: AstNamedType
+  public let scope: HirDeclaration
+}
+impl ThisTypeCanOnlyBeUsedInImplOrTraitCompilerError: CompilerError {
+  public fun id(): String { "this-type-can-only-be-used-in-impl-or-trait" }
+
+  public fun location(): Location {
+    todo("Implement ThisTypeCanOnlyBeUsedInImplOrTraitCompilerError.location") // TODO(marcelgarus)
+  }
+  public fun title(): String { "The This type can only be used in impls or traits." }
+  public fun description(): String { "You can't use the This type in modules or type definitions" }
 }
 
 public class CannotImplementTraitOfTraitCompilerError {

--- a/packages/hir/src/lowering/types.candy
+++ b/packages/hir/src/lowering/types.candy
@@ -411,9 +411,7 @@ fun hirInlineTypeToSolverTypeAndGoals(
         // TODO(marcelgarus): In the long term, choose a more elegant substitution than just the
         // 1000th.
         let substitution = SolverVariable(canonicalVariable(1000))
-        let goals = MutableList.of1<SolverGoal>(
-          SolverGoal(declaration as HirTrait, List.of1<SolverType>(substitution))
-        )
+        let goals = MutableList.empty<SolverGoal>()
         let solverParameters = MutableList.empty<SolverType>()
         for parameter in parameters {
           let result = hirInlineTypeToSolverTypeAndGoals(context, parameter)
@@ -423,6 +421,12 @@ fun hirInlineTypeToSolverTypeAndGoals(
           goals.appendAll(result.unwrap().second)
           solverParameters.append(result.unwrap().first)
         }
+        goals.append(
+          SolverGoal(
+            declaration as HirTrait,
+            (solverParameters as Iterable<SolverType>).followedBy(List.of1<SolverType>(substitution)).toList(),
+          )
+        )
         return Tuple(
           Some<(SolverType, List<SolverGoal>)>(Tuple(substitution, goals)),
           List.empty<CompilerError>(),

--- a/packages/hir/src/lowering/types.candy
+++ b/packages/hir/src/lowering/types.candy
@@ -323,7 +323,10 @@ fun hirImplToSolverRule(
       // For now, we're probably fine with only implementing "simple" traits like `Iterable<Int>`.
       // (As "primitive" types like `List` etc. are also traits, resolving this todo is somewhat of
       // a priority.)
-      return Tuple(None<SolverRule>(), List.empty<CompilerError>())
+      return Tuple(
+        None<SolverRule>(),
+        List.of1<CompilerError>(CannotImplementTraitOfTraitCompilerError(hirImpl)),
+      )
     }
     assert((solverTraitAndGoals.second as Iterable).length() == 1, "Foo")
 
@@ -499,6 +502,21 @@ impl HirType {
       // })
     })
   }
+}
+
+public class CannotImplementTraitOfTraitCompilerError {
+  public let theImpl: HirImpl
+}
+impl CannotImplementTraitOfTraitCompilerError: CompilerError {
+  public fun id(): String { "cannot-implement-trait-of-trait" }
+
+  public fun location(): Location {
+    todo("Implement CannotImplementTraitOfTraitCompilerError.location") // TODO(marcelgarus)
+  }
+  public fun title(): String {
+    "You cannot implement a trait containing another trait as a generic parameter yet."
+  }
+  public fun description(): String { "The offending impl: {theImpl}" }
 }
 
 public class ConflictingImplsCompilerError {

--- a/packages/hir/src/lowering/types.candy
+++ b/packages/hir/src/lowering/types.candy
@@ -40,7 +40,7 @@ fun astInlineTypeToHirInlineType(
             if (scope is HirTrait || scope is HirImpl) {
               return Tuple(
                 HirThisType(scope as HirTrait | HirImpl) as HirInlineType,
-                List.empty<CompilerError>()
+                List.empty<CompilerError>(),
               )
             } else {
               return Tuple(

--- a/packages/hir/src/lowering/types.candy
+++ b/packages/hir/src/lowering/types.candy
@@ -456,7 +456,40 @@ fun hirInlineTypeToSolverTypeAndGoals(
     // TODO(marcelgarus): Handle HirNamedTupleType
     // TODO(marcelgarus): Handle HirEnumType
     // TODO(marcelgarus): Handle HirIntersectionType
-    // TODO(marcelgarus): Handle HirThisType
+    if (hirType is HirThisType) {
+      let declaration = (hirType as HirThisType).declaration
+      if (declaration is HirTrait) {
+        // We don't need to lower `This` types in traits to solver types because we only use impls
+        // for logical type solving.
+        todo("Don't call hirTypeToSolverType for a This type in a trait")
+      }
+      if (declaration is HirImpl) {
+        // If a `This` type is used inside an impl, it just assumes the solver type of the base
+        // type.
+        //
+        // Whether that solver type is a `SolverVariable` or `SolverValue` depends on whether the
+        // impl is for a trait or type:
+        //
+        // * `impl Int: InfixAmpersand[This, Int]` has the lowered base type `Int`, so the `This`
+        //   gets replaced with `Int`, resulting in `InfixAmpersand(Int, Bool)`.
+        // * `impl And: InfixAmpersand[This, Bool]` has the lowered base type `?0` with the
+        //   additional goal `And(?0)`, so the `This` gets replaced with `?0`, resulting in
+        //   `InfixAmpersand(?0, Bool) <- And(?0)`.
+        let loweredBaseType = hirInlineTypeToSolverTypeAndGoals(
+          context,
+          (declaration as HirImpl).baseType(context),
+        )
+        if (loweredBaseType is None) {
+          // The failed lowering already produced errors.
+          return Tuple(None<(SolverType, List<SolverGoal>)>(), List.empty<CompilerError>())
+        }
+        let baseSolverType = loweredBaseType.unwrap().first
+        return Tuple(
+          Some<(SolverType, List<SolverGoal>)>(Tuple(baseSolverType, List.empty<SolverGoal>())),
+          List.empty<CompilerError>(),
+        )
+      }
+    }
     if (hirType is HirParameterType) {
       return Tuple(
         Some<(SolverType, List<SolverGoal>)>(

--- a/packages/hir/src/lowering/types.candy
+++ b/packages/hir/src/lowering/types.candy
@@ -346,7 +346,7 @@ fun hirImplToSolverRule(
         List.of1<CompilerError>(CannotImplementTraitOfTraitCompilerError(hirImpl)),
       )
     }
-    assert((solverTraitAndGoals.second as Iterable).length() == 1, "Foo")
+    assert((solverTraitAndGoals.second as Iterable).length() == 1, "Should never happen.")
 
     // Let's play this through for the impl `impl[T: Equals] Iterable[T]: Equals`.
     //

--- a/packages/hir/src/solver/impls.candy
+++ b/packages/hir/src/solver/impls.candy
@@ -95,6 +95,15 @@ class Environment {
   fun solve(goal: SolverGoal): SolverSolution {
     Solver(rules, MutableMap.empty<SolverGoal, SolverTree>()).solve(goal)
   }
+
+  fun toString_(): String {
+    mut let s = "Environment("
+    for rule in rules {
+      s = "{s}\n  {rule.toString_()}"
+    }
+    s = "{s}\n)"
+    s
+  }
 }
 
 

--- a/packages/hir/src/types.candy
+++ b/packages/hir/src/types.candy
@@ -120,10 +120,12 @@ impl HirIntersectionType: Equals & Hash & HirInlineType {
 }
 
 
-public class HirThisType
+public class HirThisType {
+  public let declaration: HirTrait | HirImpl
+}
 impl HirThisType: Equals & Hash & HirInlineType {
-  fun equals(other: This): Bool { true }
-  fun hash<T>(hasher: Hasher<T>) {}
+  fun equals(other: This): Bool { (declaration as Equals).equals(other.declaration as Equals) }
+  fun hash<T>(hasher: Hasher<T>) { (declaration as Hash).hash<T>(hasher) }
 }
 
 


### PR DESCRIPTION
The lowering of types to solver rules is pretty much done by now. 🎉 New things in this PR:
- Now it also works for impls containing the `This` type.
- Bug fix for lowering traits with type parameters.

Just to show off, here's an example of what the new, powerful lowering is capable of:

```
trait Bar {}
trait Baz[A, B] {}
impl[T: Bar] Bar: Baz[This, T] {}
```
This gets lowered to the following rule:
```
Baz(?0, ?T, ?0) <- Bar(?0), Bar(?T)
```

Next up:
* Implement checking if two impls can apply to the same type.
* Given a type and a trait, find the relevant impl.