### PR TITLE
Continue type solving

### DIFF
--- a/new-packages/Playground/src/.candy
+++ b/new-packages/Playground/src/.candy
@@ -1,0 +1,2 @@
+public use .Types
+public use .UseLines

--- a/new-packages/Playground/src/Types.candy
+++ b/new-packages/Playground/src/Types.candy
@@ -1,16 +1,8 @@
 builtin type Foo
+builtin type A
+builtin type B
 
-trait Bar {}
-trait Baz[T] {}
+trait Map[K, V] {}
 
-## Type implements trait
-impl Foo: Bar {}
-
-## Trait implements trait
-impl Bar: Baz[Foo] {}
-
-## Type implements trait with This
-impl Foo: Baz[This] {}
-
-## Trait implements trait with This
-impl Bar: Baz[This] {}
+impl[T] Foo: Map[T, A] {}
+impl[T] Foo: Map[B, T] {}

--- a/new-packages/Playground/src/UseLines/.candy
+++ b/new-packages/Playground/src/UseLines/.candy
@@ -1,5 +1,4 @@
 use Core
 use .Blub
-use .Types
 
 type Bar = (bar: Foo)

--- a/packages/hir/src/example.candy
+++ b/packages/hir/src/example.candy
@@ -6,6 +6,7 @@ use incremental
 use ..declarations
 use ..file
 use ..lowering
+use ..types
 
 fun main() {
   let context = QueryContext.create<List<CompilerError>>()
@@ -54,10 +55,10 @@ fun resolvingExample(context: QueryContext<List<CompilerError>>) {
 fun solverExample(context: QueryContext<List<CompilerError>>) {
   let playground = Package.playground(context)
   let file = FancyFile(playground, Path.parse("src/Types.candy"))
-  let declarations = (fileToHirModule(context, file) as HirInnerModule).declarations(context)
+  let declarations = ((fileToHirModule(context, file) as HirInnerModule).declarations(context) as Iterable<HirDeclaration>)
   print("Declarations are {declarations}.")
   print("")
-  let anImpl = ((declarations as Iterable<HirDeclaration>).get(5).unwrap() as HirImpl)
+  let anImpl = (declarations.get(5).unwrap() as HirImpl)
   let rule = hirImplToSolverRule(context, anImpl)
   if (rule is None) {
     print("Couldn't lower impl to rule.")
@@ -65,6 +66,16 @@ fun solverExample(context: QueryContext<List<CompilerError>>) {
     print("The rule is {rule.unwrap().toString_()}.")
   }
 
+  print("Declarations: {declarations}")
+
+  let foo = HirNamedType(declarations.get(0).unwrap() as HirTrait | HirType, List.empty<HirInlineType>())
+  let a = HirNamedType(declarations.get(1).unwrap() as HirTrait | HirType, List.empty<HirInlineType>())
+  let mapAA = HirNamedType(declarations.get(3).unwrap() as HirTrait | HirType, List.of2<HirInlineType>(a, a))
+
+  let theImpl = implFor(context, foo as HirInlineType, mapAA as HirInlineType, playground)
+  print("The impl: {theImpl}")
+
+  print("")
   print("Environment:")
   print(getSolverEnvironmentOfScope(context, playground).toString_())
   // print("Does {type.toString_()} implement Equals? {environment.solve(equalsImpl(type)).toString_()}")

--- a/packages/hir/src/lowering/types.candy
+++ b/packages/hir/src/lowering/types.candy
@@ -450,7 +450,7 @@ fun hirInlineTypeToSolverTypeAndGoals(
           List.empty<CompilerError>(),
         )
       }
-      todo("We should a {hirType} referring to {declaration}")
+      todo("We should handle a {hirType} referring to {declaration}")
     }
     // TODO(marcelgarus): For now, we only support impls for nominal types. If we want to support
     // `impl A | B: Equals` or `impl (name: String, age: UInt): Clone`, we'll need to add support
@@ -601,8 +601,7 @@ impl ConflictingImplsCompilerError: CompilerError {
   }
   public fun title(): String { "Conflicting impls." }
   public fun description(): String {
-    /// TODO(marcelgarus): add a description for this error
-    ""
+    "Impl {impl1} conflicts with {impl2}, because both bases {base1} and {base2} apply to the same type {conflictingType}."
   }
 }
 

--- a/packages/hir/src/lowering/types.candy
+++ b/packages/hir/src/lowering/types.candy
@@ -364,6 +364,7 @@ fun hirImplToSolverRule(
     Tuple(
       Some<SolverRule>(
         SolverRule(
+          hirImpl,
           (solverTraitAndGoals.second as Iterable<SolverGoal>)
             .single()
             .unwrap() // We checked the length above.
@@ -519,18 +520,27 @@ fun getSolverEnvironmentOfScope(context: QueryContext<List<CompilerError>>, scop
 
 fun makeSureImplsAreNotConflicting(context: QueryContext<List<CompilerError>>, scope: Package) {
   query<Unit, List<CompilerError>>(context, "makeSureImplsAreNotConflicting", scope as Equals & Hash, {
-    for implsForSameTrait in (getAllImplsInScope(context, scope) as Iterable<HirImpl>)
+    for implsForSameTrait in (getAllImplsInScope(context, scope).items() as Iterable<HirImpl>)
       .where({ it.implementedTrait(context) is Some })
       .groupBy<HirInlineType>({ it.implementedTrait(context).unwrap() })
       .values() {
-      let solverTypesOfImpls = (implsForSameTrait as Iterable<HirImpl>)
-        .maybeMap<SolverType>({
+      let implsAndBasesForCurrentTrait = (implsForSameTrait as Iterable<HirImpl>)
+        .maybeMap<(HirImpl, SolverType)>({
           hirInlineTypeToSolverTypeAndGoals(context, it.baseType(context))
-            .map<SolverType>({ it.first })
+            .map<(HirImpl, SolverType)>({ solverTypeAndGoals => Tuple(it, solverTypeAndGoals.first) })
         })
         .toList()
-      for base1 in solverTypesOfImpls {
-        for base2 in solverTypesOfImpls {
+      for implAndBase1 in implsAndBasesForCurrentTrait {
+        for implAndBase2 in implsAndBasesForCurrentTrait {
+          let impl1 = implAndBase1.first
+          let impl2 = implAndBase2.first
+          let base1 = implAndBase1.second
+          let base2 = implAndBase2.second
+
+          if (impl1 as Equals) == (impl2 as Equals) {
+            continue
+          }
+
           let unified = base1.unify(base2)
           if unified is Some {
             // Unifying the impl types succeeded. This means there's a type to which both impls
@@ -538,7 +548,9 @@ fun makeSureImplsAreNotConflicting(context: QueryContext<List<CompilerError>>, s
             let conflicting = base1.substituteAll(unified.unwrap())
             return Tuple(
               unit,
-              List.of1<CompilerError>(ConflictingImplsCompilerError(base1, base2, conflicting)),
+              List.of1<CompilerError>(
+                ConflictingImplsCompilerError(impl1, impl2, base1, base2, conflicting),
+              ),
             )
           }
         }
@@ -548,15 +560,51 @@ fun makeSureImplsAreNotConflicting(context: QueryContext<List<CompilerError>>, s
   })
 }
 
-impl HirType {
-  fun implFor(context: QueryContext<List<CompilerError>>, trait_: HirTrait): Maybe<HirImpl> {
-    query<Maybe<HirImpl>, List<CompilerError>>( context, "HirType.implements", this as Equals & Hash, {
-      todo("Implement HirType.implFor")
-      // let impls = (getAllImpls(context) as Iterable<HirImpl>).where({ it.trait_ == trait_ }).where({
-      //   it.type_.unify(this) is Some
-      // })
-    })
-  }
+// TODO(marcelgarus): Support getting the impl for a trait with generics. This would basically
+// mean we'd have to accept an arbitrary `HirInlineType` as the `trait_`.
+fun implFor(
+  context: QueryContext<List<CompilerError>>,
+  base: HirInlineType,
+  trait_: HirInlineType,
+  scope: Package,
+): Maybe<HirImpl> {
+  query<Maybe<HirImpl>, List<CompilerError>>(context, "HirType.implements", base as Equals & Hash, {
+    let environment = getSolverEnvironmentOfScope(context, scope)
+    let baseSolverAndGoals = hirInlineTypeToSolverTypeAndGoals(context, base)
+    let traitSolverAndGoals = hirInlineTypeToSolverTypeAndGoals(context, trait_)
+    if (baseSolverAndGoals is None || traitSolverAndGoals is None) {
+      return Tuple(None<HirImpl>(), List.empty<CompilerError>())
+    }
+    let baseType = baseSolverAndGoals.unwrap().first
+    let traitType = traitSolverAndGoals.unwrap().first
+    let baseGoals = baseSolverAndGoals.unwrap().second
+    let traitGoals = traitSolverAndGoals.unwrap().second
+
+    if (traitType is SolverValue) {
+      todo("This shouldn't happen. Trait should be lowered to a SolverVariable.")
+    }
+    if !((traitGoals as Iterable).length() == 1) {
+      return Tuple(
+        None<HirImpl>(),
+        List.of1<CompilerError>(TryingToFindImplForTraitWithTraitAsParameterCompilerError(trait_)),
+      )
+    }
+
+    let solution = environment.solve(
+      (traitGoals as Iterable<SolverGoal>).single().unwrap().substituteAll(
+        Map.of1<SolverVariable, SolverType>(Tuple((traitType as SolverVariable), baseType)),
+      ),
+      baseGoals,
+    )
+    if (solution is SolverSolutionUnique) {
+      Tuple(
+        Some<HirImpl>((solution as SolverSolutionUnique).usedRule.originalImpl),
+        List.empty<CompilerError>(),
+      )
+    } else {
+      Tuple(None<HirImpl>(), List.empty<CompilerError>())
+    }
+  })
 }
 
 public class ThisTypeCanOnlyBeUsedInImplOrTraitCompilerError {
@@ -588,7 +636,24 @@ impl CannotImplementTraitOfTraitCompilerError: CompilerError {
   public fun description(): String { "The offending impl: {theImpl}" }
 }
 
+public class TryingToFindImplForTraitWithTraitAsParameterCompilerError {
+  public let trait_: HirInlineType
+}
+impl TryingToFindImplForTraitWithTraitAsParameterCompilerError: CompilerError {
+  public fun id(): String { "trying-to-find-impl-for-trait-with-trait-as-parameter" }
+
+  public fun location(): Location {
+    todo("Implement TryingToFindImplForTraitWithTraitAsParameterCompilerError.location") // TODO(marcelgarus)
+  }
+  public fun title(): String { "Conflicting impls." }
+  public fun description(): String {
+    "Trying to find an impl for trait {trait_}, which has another trait as a type parameter. That's not supported yet."
+  }
+}
+
 public class ConflictingImplsCompilerError {
+  public let impl1: HirImpl
+  public let impl2: HirImpl
   public let base1: SolverType
   public let base2: SolverType
   public let conflictingType: SolverType

--- a/packages/hir/src/solver/impls.candy
+++ b/packages/hir/src/solver/impls.candy
@@ -1,3 +1,5 @@
+use compiler_utils
+
 use ...declarations
 use ...types
 use ..types
@@ -22,8 +24,8 @@ class SolverGoal {
   }
   fun unify(other: SolverGoal): Maybe<Map<SolverVariable, SolverType>> {
     if !(trait_ == other.trait_) { return None<Map<SolverVariable, SolverType>>() }
-    SolverValue(canonicalVariable(0) as HirType, parameters)
-      .unify(SolverValue(canonicalVariable(0) as HirType, other.parameters))
+    SolverValue(canonicalVariable(0).declaration as HirType, parameters)
+      .unify(SolverValue(canonicalVariable(0).declaration as HirType, other.parameters))
   }
   fun substituteAll(substitutions: Map<SolverVariable, SolverType>): SolverGoal {
     SolverGoal(
@@ -36,7 +38,8 @@ class SolverGoal {
   fun canonicalize(): SolverGoal {
     SolverGoal(
       trait_,
-      (SolverValue(canonicalVariable(0) as HirType, parameters).canonicalize() as SolverValue).parameters,
+      (SolverValue(canonicalVariable(0).declaration as HirType, parameters)
+        .canonicalize() as SolverValue).parameters,
     )
   }
 }
@@ -45,8 +48,7 @@ impl SolverGoal: Equals & Hash {
     trait_ == other.trait_
       && (parameters as Iterable<SolverType>)
         .zip<SolverType>(other.parameters)
-        .map<Bool>({ (it.first as Equals) == (it.second as Equals) })
-        .all({ it })
+        .all({ (it.first as Equals) == (it.second as Equals) })
   }
   fun hash<T>(hasher: Hasher<T>) {
     trait_.hash<T>(hasher)
@@ -66,6 +68,7 @@ class SolverRule {
   ///   `Clone` if both `?0` and `?1` implement `Clone`
   /// * `Any(?T) <- <nothing>`: the fact that every `?T` implements `Any`
 
+  let originalImpl: HirImpl
   let goal: SolverGoal
   let subgoals: List<SolverGoal>
 
@@ -78,8 +81,7 @@ impl SolverRule: Equals & Hash {
     (goal as Equals) == (other.goal as Equals)
       && (subgoals as Iterable<SolverType>)
         .zip<SolverType>(other.subgoals as Iterable<SolverType>)
-        .map<Bool>({ (it.first as Equals) == (it.second as Equals) })
-        .all({ it })
+        .all({ (it.first as Equals) == (it.second as Equals) })
   }
   fun hash<T>(hasher: Hasher<T>) {
     goal.hash<T>(hasher)
@@ -92,8 +94,56 @@ impl SolverRule: Equals & Hash {
 class Environment {
   let rules: List<SolverRule>
 
-  fun solve(goal: SolverGoal): SolverSolution {
-    Solver(rules, MutableMap.empty<SolverGoal, SolverTree>()).solve(goal)
+  // TODO(marcelgarus): Somehow support solving logic that has multiple results. Currently, rules
+  // are of the form `consequence <- conditions` (with only one consequence), but we'd need multiple
+  // consequences to express something like "Implement `Iterable[Equals]`". That's because there's
+  // no single `SolverGoal` that the trait `Iterable[Equals]` can be lowered to – `Iterable(Equals)`
+  // is not valid, because `Equals` is a trait, not a type. Essentially, we'd need something like
+  // `Iterable(?0, ?1), Equals(?1)`, e.g. "Are there ?0 and ?1 so that these goals are true?"
+  // I believe that Chalk, Rust's to-be type solver, manages this using something called
+  // [Opaque Types](https://rust-lang.github.io/chalk/book/clauses/opaque_types.html), but I'm not
+  // entirely sure. In Rust, this would correspond to an `impl Iterable<Box<dyn Equals>> for Foo`.
+  // As we rely even more than Rust on dynamic dispatch and being able to implement traits like
+  // `List[Equals]`, we'll definitely have to incorporate something like that into our solver
+  // someday.
+  fun solve(goal: SolverGoal, conditions: List<SolverGoal>): SolverSolution {
+    /// Checks if the goals are true if the conditions are met.
+    ///
+    /// For example, to check if `Iterable[Equals]` implements `Equals`, you might try to achieve
+    /// the goal `Equals(?0)` under the conditions `Iterable(?T, ?0), Equals(?T)`.
+
+    // Create virtual types for the types in the rule and implement the right traits for them. In
+    // the example above, we'd create virtual `$Virtual0` and `$Virtual1` types and implement the
+    // given traits for them, e.g. by adding the rules `Iterable($Virtual1, $Virtual0) <- ∅` and
+    // `Equals($Virtual0) <- ∅`. Then, we can ask a `Solver` whether `Equals($Virtual0)` holds.
+    let canonicalMapping = MutableMap.empty<SolverVariable, SolverVariable>()
+    // Canonicalized rules like `Iterable(?1, ?0)` and `Equals(?0)` (without `?T`).
+    let canonicalConditions = (conditions as Iterable<SolverGoal>).map<SolverGoal>({
+      SolverGoal(
+        it.trait_,
+        (SolverValue(canonicalVariable(0) as HirType, it.parameters)
+          .canonicalizeInternal(canonicalMapping) as SolverValue).parameters,
+      )
+    })
+    // Create a mapping from canonical variables like `?0` to virtual types like `$Virtual0`.
+    let canonicalToVirtual = MutableMap.empty<SolverVariable, SolverType>()
+    let virtualModule = HirTopLevelModule(Package(Path.parse("/virtual")))
+    for entry in (canonicalMapping as Map<SolverVariable, SolverType>).entries() {
+      canonicalToVirtual.set(
+        entry.first,
+        SolverValue(
+          HirType(virtualModule, "$Virtual{(entry.second as SolverValue).type.name}"),
+          List.empty<SolverType>(),
+        ),
+      )
+    }
+    let virtualRules = canonicalConditions
+      .map<SolverGoal>({ it.substituteAll(canonicalToVirtual) })
+      .map<SolverRule>({ SolverRule(HirImpl(virtualModule, 0), it, List.empty<SolverGoal>()) })
+
+    let newRules = (rules as Iterable<SolverRule>).followedBy(virtualRules).toList()
+    Solver(newRules, MutableMap.empty<SolverGoal, SolverTree>())
+      .solve(goal.substituteAll(canonicalToVirtual))
   }
 
   fun toString_(): String {
@@ -115,6 +165,7 @@ class SolverSolutionUnique {
   /// Indicates that there is exactly one type that can fulfill the goal.
 
   let refinedGoal: SolverGoal
+  let usedRule: SolverRule
 
   fun toString_(): String { "Unique({refinedGoal.toString_()})" }
 }
@@ -139,12 +190,10 @@ class Solver {
   let rules: List<SolverRule>
 
   let cache: MutableMap<SolverGoal, SolverTree>
-  /// Sometimes, the same goal needs to be reached multiple times.
+  /// Map that allows us to detect cycles and resolve them.
   ///
-  /// For example, when checking whether `Clone(Tuple<Int, Int>)`, it doesn't make sense to prove
-  /// `Clone(Int)` twice.
-  ///
-  /// This also allows us to detect cycles and resolve them.
+  /// It's also good for performance. For example, when checking whether `Clone(Tuple<Int, Int>)`,
+  /// it doesn't make sense to prove `Clone(Int)` twice.
 
   fun solve(goal: SolverGoal): SolverSolution {
     let goal = goal.canonicalize()
@@ -155,8 +204,6 @@ class Solver {
       .solve(this)
   }
 }
-
-// Solutions that solving a goal might produce.
 
 class SolverTree {
   let goal: SolverGoal
@@ -178,6 +225,7 @@ class SolverTree {
         .map<SolverStrand>({
           let result = it.goal.unify(goal).unwrap()
           SolverStrand(
+            it,
             it.goal.substituteAll(result),
             result.toMutable(),
             (it.subgoals as Iterable<SolverGoal>)
@@ -187,9 +235,7 @@ class SolverTree {
         })
     )
     let strandsAndSolutions = (strands as Iterable<SolverStrand>)
-      .map<(SolverStrand, SolverSolution)>({
-        Tuple(it, it.solve(context))
-      })
+      .map<(SolverStrand, SolverSolution)>({ Tuple(it, it.solve(context)) })
       .where({ !(it.second is SolverSolutionImpossible) })
       .toList()
     if (strandsAndSolutions as Iterable).length() > 1 {
@@ -209,13 +255,14 @@ class SolverTree {
     let solution = (solution as SolverSolutionUnique)
     let substitutions = strand.goal.unify(solution.refinedGoal).unwrap()
     let refinedGoal = goal.substituteAll(substitutions)
-    SolverSolutionUnique(refinedGoal)
+    SolverSolutionUnique(refinedGoal, solution.usedRule)
   }
 }
 
 class SolverStrand {
   /// A thread exploring possible solutions.
 
+  let usedRule: SolverRule
   let goal: SolverGoal
   let solutionSpace: MutableMap<SolverVariable, SolverType>
   let subgoals: MutableList<SolverGoal>
@@ -245,6 +292,6 @@ class SolverStrand {
         }
       }
     }
-    SolverSolutionUnique(goal.substituteAll(solutionSpace))
+    SolverSolutionUnique(goal.substituteAll(solutionSpace), usedRule)
   }
 }


### PR DESCRIPTION
This continues the type solving.
Now there's an `implFor` method that you can pass a `HirInlineType` representing the base type and another `HirInlineType` representing the trait and it will find the corresponding impl.

Example:

```
builtin type Foo
builtin type A
builtin type B

trait Map[K, V] {}

impl[T] Foo: Map[T, A] {}
impl[T] Foo: Map[T, B] {}
```

`implFor(HirInlineType representing Foo, HirInlineType representing Map[A, A])` returns the first impl
`implFor(HirInlineType representing Foo, HirInlineType representing Map[B, B])` returns the second impl