### PR TITLE
Core: Ranges & Progressions

### DIFF
--- a/new-packages/Core/src/.candy
+++ b/new-packages/Core/src/.candy
@@ -9,6 +9,7 @@ public use .Maybe
 public use .Operators
 public use .Panic
 public use .Primitives
+public use .Ranges
 public use .Result
 public use .String
 public use .Todo

--- a/new-packages/Core/src/Ranges/.candy
+++ b/new-packages/Core/src/Ranges/.candy
@@ -1,1 +1,2 @@
+public use .Progressions
 public use .Ranges

--- a/new-packages/Core/src/Ranges/.candy
+++ b/new-packages/Core/src/Ranges/.candy
@@ -1,0 +1,1 @@
+public use .Ranges

--- a/new-packages/Core/src/Ranges/Progressions.candy
+++ b/new-packages/Core/src/Ranges/Progressions.candy
@@ -1,0 +1,114 @@
+use ...Bool
+use ...Collections
+use ...Int
+use ...Maybe
+use ...Operators
+
+public trait IntProgression: Equals {
+  fun startBound(): Maybe[Int]
+  fun endBound(): Maybe[Int]
+  fun stepSize(): Int
+
+  fun contains(item: Int): Bool {
+    let startMatches = this.startBound()
+      .map[Bool]({ it <= item & (item - it) % this.stepSize() == 0 })
+      .else({ true() })
+    let endMatches = this.endBound()
+      .map[Bool]({ item <= it & (it - item) % this.stepSize() == 0 })
+      .else({ true() })
+    startMatches & endMatches
+  }
+}
+
+
+public type BoundedIntProgression = (start: Int, end: Int, step: Int)
+# A `Progression` where `this.start` is inclusive and `this.end` is exclusive.
+#
+# Invariants:
+# * `this step != 0`
+# * `(this step > 0) then { this end > this start } else { this end < this start }`
+# * `(this end - 1 - this start) % this step == 0`
+
+impl BoundedIntProgression: IntProgression {
+  fun startBound(): Maybe[Int] { Maybe[Int].Some(this.start) }
+  fun endBound(): Maybe[Int] { Maybe[Int].Some(this.end) }
+  fun stepSize(): Int { this.step }
+}
+impl BoundedIntProgression: Equals {
+  fun equals(other: This): Bool {
+    this.start == other.start & this.end == other.end & this.step = other.step
+  }
+}
+impl BoundedIntProgression: Hash {
+  fun hash[H: Hasher](): H {
+    H.combine(List[H].of(this.start.hash[H](), this.end.hash[H](), this.step.hash[H]()))
+  }
+}
+impl BoundedIntProgression: Iterate[Int] {
+  fun iterate(): Maybe[(Int, Iterate[Int])] {
+    (this.end > this.start).then[(Int, Iterate[Int])]({
+      (this.start, BoundedIntProgression(this.start + this.step, this.end, this.step))
+    })
+  }
+
+  ## TODO(JonasWanke): Add a constant-time `contains(item)` when we have something like
+  ## where-clauses for generic types and `iterate.contains` can be declared directly inside
+  ## `Iterate`. Same for the progressions below.
+
+  fun length(): Int {
+    if (this.start == this.end, { 0 })
+      .else({ this.end - 1 - this.start) // this.step + 1 })
+  }
+}
+
+
+public type FromIntProgression = (start: Int, step: Int)
+# A `Progression` where `this.start` is inclusive and without an end.
+#
+# Invariant: `this step != 0`
+
+impl FromIntProgression: IntProgression {
+  fun startBound(): Maybe[Int] { Maybe[Int].Some(this.start) }
+  fun endBound(): Maybe[Int] { Maybe[Int].None() }
+  fun stepSize(): Int { this.step }
+}
+impl FromIntProgression: Equals {
+  fun equals(other: This): Bool { this.start == other.start & this.step = other.step }
+}
+impl FromIntProgression: Hash {
+  fun hash[H: Hasher](): H {
+    H.combine(List[H].of(this.start.hash[H](), this.step.hash[H]()))
+  }
+}
+impl FromIntProgression: Iterate[Int] {
+  fun iterate(): Maybe[(Int, Iterate[Int])] {
+    Maybe[(Int, Iterate[Int])]
+      .Some((this.start, FromIntProgression(this.start + this.step, this.step)))
+  }
+}
+impl FromIntProgression {
+  public fun reverse(): ToIntProgression { ToIntProgression(this.start + 1, -this.step) }
+}
+
+
+public type ToIntProgression = (end: Int, step: Int)
+# A `Progression` where `this.end` is exclusive and without a start.
+#
+# Invariant: `this step != 0`
+
+impl ToIntProgression: IntProgression {
+  fun startBound(): Maybe[Int] { Maybe[Int].None() }
+  fun endBound(): Maybe[Int] { Maybe[Int].Some(this.end) }
+  fun stepSize(): Int { this.step }
+}
+impl ToIntProgression: Equals {
+  fun equals(other: This): Bool { this.end == other.end & this.step = other.step }
+}
+impl ToIntProgression: Hash {
+  fun hash[H: Hasher](): H {
+    H.combine(List[H].of(this.end.hash[H](), this.step.hash[H]()))
+  }
+}
+impl ToIntProgression {
+  fun reverse(): FromIntProgression { FromIntProgression(this.end - 1, -this.step) }
+}

--- a/new-packages/Core/src/Ranges/Progressions.candy
+++ b/new-packages/Core/src/Ranges/Progressions.candy
@@ -27,7 +27,7 @@ public type BoundedIntProgression = (start: Int, end: Int, step: Int)
 # Invariants:
 # * `this step != 0`
 # * `(this step > 0) then { this end >= this start } else { this end <= this start }`
-# * `(this end - 1 - this start) % this step == 0`
+# * `this start == this end | (this end - 1 - this start) % this step == 0`
 
 impl BoundedIntProgression: IntProgression {
   fun startBound(): Maybe[Int] { Maybe[Int].Some(this.start) }

--- a/new-packages/Core/src/Ranges/Progressions.candy
+++ b/new-packages/Core/src/Ranges/Progressions.candy
@@ -26,7 +26,7 @@ public type BoundedIntProgression = (start: Int, end: Int, step: Int)
 #
 # Invariants:
 # * `this step != 0`
-# * `(this step > 0) then { this end > this start } else { this end < this start }`
+# * `(this step > 0) then { this end >= this start } else { this end <= this start }`
 # * `(this end - 1 - this start) % this step == 0`
 
 impl BoundedIntProgression: IntProgression {

--- a/new-packages/Core/src/Ranges/Ranges.candy
+++ b/new-packages/Core/src/Ranges/Ranges.candy
@@ -1,5 +1,6 @@
 use ...Bool
 use ...Collections
+use ...Hash
 use ...Int
 use ...Operators
 

--- a/new-packages/Core/src/Ranges/Ranges.candy
+++ b/new-packages/Core/src/Ranges/Ranges.candy
@@ -1,0 +1,208 @@
+use ...Bool
+use ...Collections
+use ...Int
+use ...Operators
+
+public trait Range[T: Compare]: Equals {
+  fun startBound(): RangeBound[T]
+  fun endBound(): RangeBound[T]
+
+  fun contains(item: T): Bool {
+    let startMatches = this.startBound().match[Bool](
+      included = { it <= item },
+      excluded = { it < item },
+      unbounded = { true() },
+    )
+    let endMatches = this.endBound().match[Bool](
+      included = { item <= it },
+      excluded = { item < it },
+      unbounded = { true() },
+    )
+    startMatches & endMatches
+  }
+}
+
+
+public type RangeBound[T: Compare] = Included T | Excluded T | Unbounded
+impl[T: Compare] RangeBound[T]: Equals {
+  fun equals(other: This): Bool {
+    this.match(
+      included = { value ->
+        other.match(included = { value == it }, excluded = { false() }, unbounded = { false() })
+      },
+      excluded = { value ->
+        other.match(included = { false() }, excluded = { value == it }, unbounded = { false() })
+      },
+      unbounded = {
+        other.match(included = { false() }, excluded = { false() }, unbounded = { true() })
+      },
+    )
+  }
+}
+impl[T: Compare & Hash] RangeBound[T]: Hash {
+  fun hash[H: Hasher](): H {
+    this.match(
+      included = { H.combine(List[H].of(0.hash[H](), it.hash[H]())) },
+      excluded = { H.combine(List[H].of(1.hash[H](), it.hash[H]())) },
+      unbounded = { 2.hash[H]() },
+    )
+  }
+}
+
+
+## Inclusive start
+
+public type ClosedRange[T: Compare] = (start: T, end: T)
+# A `Range` where `this.start` and `this.end` are inclusive (`this.start=..=this.end`).
+
+impl[T: Compare] ClosedRange[T]: Range[T] {
+  fun startBound(): RangeBound[T] { RangeBound[T].Included(this.start) }
+  fun endBound(): RangeBound[T] { RangeBound[T].Included(this.end) }
+}
+impl[T: Compare] ClosedRange[T]: Equals {
+  fun equals(other: This): Bool { this.start == other.start & this.end == other.end }
+}
+impl[T: Compare] ClosedRange[T]: Hash {
+  fun hash[H: Hasher](): H { H.combine(List[H].of(this.start.hash[H](), this.end.hash[H]())) }
+}
+
+
+public type ClosedOpenRange[T: Compare] = (start: T, end: T)
+# A `Range` where `this.start` is inclusive and `this.end` is exclusive (`this.start=..this.end`).
+
+impl[T: Compare] ClosedOpenRange[T]: Range[T] {
+  fun startBound(): RangeBound[T] { RangeBound[T].Included(this.start) }
+  fun endBound(): RangeBound[T] { RangeBound[T].Excluded(this.end) }
+}
+impl[T: Compare] ClosedOpenRange[T]: Equals {
+  fun equals(other: This): Bool { this.start == other.start & this.end == other.end }
+}
+impl[T: Compare] ClosedOpenRange[T]: Hash {
+  fun hash[H: Hasher](): H { H.combine(List[H].of(this.start.hash[H](), this.end.hash[H]())) }
+}
+impl ClosedOpenRange[Int] {
+  public fun toClosedRange(): ClosedRange[Int] { ClosedRange(this.start, this.end - 1) }
+}
+
+
+public type ClosedUnboundedRange[T: Compare] = (start: T)
+# A `Range` where `this.start` is inclusive and without an upper bound (`this.start=..`).
+
+impl[T: Compare] ClosedUnboundedRange[T]: Range[T] {
+  fun startBound(): RangeBound[T] { RangeBound[T].Included(this.start) }
+  fun endBound(): RangeBound[T] { RangeBound[T].Unbounded() }
+}
+impl[T: Compare] ClosedUnboundedRange[T]: Equals {
+  fun equals(other: This): Bool { this.start == other.start }
+}
+impl[T: Compare] ClosedUnboundedRange[T]: Hash {
+  fun hash[H: Hasher](): H { this.start.hash[H]() }
+}
+
+## Exclusive start
+
+public type OpenClosedRange[T: Compare] = (start: T, end: T)
+# A `Range` where `this.start` is exclusive and `this.end` is inclusive (`this.start..=this.end`).
+
+impl[T: Compare] OpenClosedRange[T]: Range[T] {
+  fun startBound(): RangeBound[T] { RangeBound[T].Excluded(this.start) }
+  fun endBound(): RangeBound[T] { RangeBound[T].Included(this.end) }
+}
+impl[T: Compare] OpenClosedRange[T]: Equals {
+  fun equals(other: This): Bool { this.start == other.start & this.end == other.end }
+}
+impl[T: Compare] OpenClosedRange[T]: Hash {
+  fun hash[H: Hasher](): H { H.combine(List[H].of(this.start.hash[H](), this.end.hash[H]())) }
+}
+impl OpenClosedRange[Int] {
+  public fun toClosedRange(): ClosedRange[Int] { ClosedRange(this.start + 1, this.end) }
+}
+
+
+public type OpenRange[T: Compare] = (start: T, end: T)
+# A `Range` where `this.start` and `this.end` are exclusive (`this.start..this.end`).
+
+impl[T: Compare] OpenRange[T]: Range[T] {
+  fun startBound(): RangeBound[T] { RangeBound[T].Excluded(this.start) }
+  fun endBound(): RangeBound[T] { RangeBound[T].Excluded(this.end) }
+}
+impl[T: Compare] OpenRange[T]: Equals {
+  fun equals(other: This): Bool { this.start == other.start & this.end == other.end }
+}
+impl[T: Compare] OpenRange[T]: Hash {
+  fun hash[H: Hasher](): H { H.combine(List[H].of(this.start.hash[H](), this.end.hash[H]())) }
+}
+impl OpenRange[Int] {
+  public fun toClosedRange(): ClosedRange[Int] { ClosedRange(this.start + 1, this.end - 1) }
+}
+
+
+public type OpenUnboundedRange[T: Compare] = (start: T)
+# A `Range` where `this.start` is exclusive and without an upper bound (`this.start..`).
+
+impl[T: Compare] OpenUnboundedRange[T]: Range[T] {
+  fun startBound(): RangeBound[T] { RangeBound[T].Excluded(this.start) }
+  fun endBound(): RangeBound[T] { RangeBound[T].Unbounded() }
+}
+impl[T: Compare] OpenUnboundedRange[T]: Equals {
+  fun equals(other: This): Bool { this.start == other.start }
+}
+impl[T: Compare] OpenUnboundedRange[T]: Hash {
+  fun hash[H: Hasher](): H { this.start.hash[H]() }
+}
+impl OpenUnboundedRange[Int] {
+  public fun toClosedUnboundedRange(): ClosedUnboundedRange[Int] {
+    ClosedUnboundedRange(this.start + 1)
+  }
+}
+
+## Unbounded start
+
+public type UnboundedClosedRange[T: Compare] = (end: T)
+# A `Range` where `this.end` is inclusive and without a lower bound (`..=this.end`).
+
+impl[T: Compare] UnboundedClosedRange[T]: Range[T] {
+  fun startBound(): RangeBound[T] { RangeBound[T].Unbounded() }
+  fun endBound(): RangeBound[T] { RangeBound[T].Included(this.end) }
+}
+impl[T: Compare] UnboundedClosedRange[T]: Equals {
+  fun equals(other: This): Bool { this.end == other.end }
+}
+impl[T: Compare] UnboundedClosedRange[T]: Hash {
+  fun hash[H: Hasher](): H { this.end.hash[H]() }
+}
+
+
+public type UnboundedOpenRange[T: Compare] = (end: T)
+# A `Range` where `this.end` is exclusive and without a lower bound (`..this.end`).
+
+impl[T: Compare] UnboundedOpenRange[T]: Range[T] {
+  fun startBound(): RangeBound[T] { RangeBound[T].Unbounded() }
+  fun endBound(): RangeBound[T] { RangeBound[T].Excluded(this.end) }
+}
+impl[T: Compare] UnboundedOpenRange[T]: Equals {
+  fun equals(other: This): Bool { this.end == other.end }
+}
+impl[T: Compare] UnboundedOpenRange[T]: Hash {
+  fun hash[H: Hasher](): H { this.end.hash[H]() }
+}
+impl UnboundedOpenRange[Int] {
+  public fun toUnboundedClosedRange(): UnboundedClosedRange[Int] {
+    UnboundedClosedRange(this.end - 1)
+  }
+}
+
+
+public type UnboundedRange[T: Compare] = Unit
+# A `Range` without a lower or upper bound (`..`).
+
+impl[T: Compare] UnboundedRange[T]: Range[T] {
+  fun startBound(): RangeBound[T] { RangeBound[T].Unbounded() }
+  fun endBound(): RangeBound[T] { RangeBound[T].Unbounded() }
+}
+impl[T: Compare] UnboundedRange[T]: Equals {
+  fun equals(other: This): Bool { true() }
+}
+impl[T: Compare] UnboundedRange[T]: Hash {
+  fun hash[H: Hasher](): H { unit().hash[H]() }
+}

--- a/new-packages/Core/src/Ranges/Ranges.candy
+++ b/new-packages/Core/src/Ranges/Ranges.candy
@@ -3,6 +3,7 @@ use ...Collections
 use ...Hash
 use ...Int
 use ...Operators
+use ..Progressions
 
 public trait Range[T: Compare]: Equals {
   fun startBound(): RangeBound[T]
@@ -66,6 +67,12 @@ impl[T: Compare] ClosedRange[T]: Equals {
 impl[T: Compare] ClosedRange[T]: Hash {
   fun hash[H: Hasher](): H { H.combine(List[H].of(this.start.hash[H](), this.end.hash[H]())) }
 }
+impl ClosedRange[Int] {
+  public fun toClosedOpenRange(): ClosedOpenRange[Int] { ClosedOpenRange(this.start, this.end + 1) }
+  public fun toProgression(stepSize: Int): ClosedIntProgression {
+    this.toClosedOpenRange().toProgression()
+  }
+}
 
 
 public type ClosedOpenRange[T: Compare] = (start: T, end: T)
@@ -82,7 +89,10 @@ impl[T: Compare] ClosedOpenRange[T]: Hash {
   fun hash[H: Hasher](): H { H.combine(List[H].of(this.start.hash[H](), this.end.hash[H]())) }
 }
 impl ClosedOpenRange[Int] {
-  public fun toClosedRange(): ClosedRange[Int] { ClosedRange(this.start, this.end - 1) }
+  public fun toProgression(stepSize: Int): ClosedIntProgression {
+    let actualEnd = this.end - (this.end - this.start) % stepSize
+    ClosedIntProgression(this.start, actualEnd, stepSize)
+  }
 }
 
 
@@ -98,6 +108,11 @@ impl[T: Compare] ClosedUnboundedRange[T]: Equals {
 }
 impl[T: Compare] ClosedUnboundedRange[T]: Hash {
   fun hash[H: Hasher](): H { this.start.hash[H]() }
+}
+impl ClosedUnboundedRange[Int] {
+  public fun toProgression(stepSize: Int): FromIntProgression {
+    FromIntProgression(this.start, stepSize)
+  }
 }
 
 ## Exclusive start
@@ -116,7 +131,12 @@ impl[T: Compare] OpenClosedRange[T]: Hash {
   fun hash[H: Hasher](): H { H.combine(List[H].of(this.start.hash[H](), this.end.hash[H]())) }
 }
 impl OpenClosedRange[Int] {
-  public fun toClosedRange(): ClosedRange[Int] { ClosedRange(this.start + 1, this.end) }
+  public fun toClosedOpenRange(): ClosedOpenRange[Int] {
+    ClosedOpenRange(this.start + 1, this.end + 1)
+  }
+  public fun toProgression(stepSize: Int): ClosedIntProgression {
+    this.toClosedOpenRange().toProgression(stepSize)
+  }
 }
 
 
@@ -134,7 +154,10 @@ impl[T: Compare] OpenRange[T]: Hash {
   fun hash[H: Hasher](): H { H.combine(List[H].of(this.start.hash[H](), this.end.hash[H]())) }
 }
 impl OpenRange[Int] {
-  public fun toClosedRange(): ClosedRange[Int] { ClosedRange(this.start + 1, this.end - 1) }
+  public fun toClosedOpenRange(): ClosedOpenRange[Int] { ClosedOpenRange(this.start + 1, this.end) }
+  public fun toProgression(stepSize: Int): ClosedIntProgression {
+    this.toClosedOpenRange().toProgression(stepSize)
+  }
 }
 
 
@@ -155,6 +178,9 @@ impl OpenUnboundedRange[Int] {
   public fun toClosedUnboundedRange(): ClosedUnboundedRange[Int] {
     ClosedUnboundedRange(this.start + 1)
   }
+  public fun toProgression(stepSize: Int): FromIntProgression {
+    this.toClosedUnboundedRange().toProgression(stepSize)
+  }
 }
 
 ## Unbounded start
@@ -171,6 +197,9 @@ impl[T: Compare] UnboundedClosedRange[T]: Equals {
 }
 impl[T: Compare] UnboundedClosedRange[T]: Hash {
   fun hash[H: Hasher](): H { this.end.hash[H]() }
+}
+impl UnboundedClosedRange[Int] {
+  public fun toProgression(stepSize: Int): ToIntProgression { ToIntProgression(this.end) }
 }
 
 
@@ -191,6 +220,9 @@ impl UnboundedOpenRange[Int] {
   public fun toUnboundedClosedRange(): UnboundedClosedRange[Int] {
     UnboundedClosedRange(this.end - 1)
   }
+  public fun toProgression(stepSize: Int): ToIntProgression {
+    this.toUnboundedClosedRange().toProgression(stepSize)
+  }
 }
 
 
@@ -206,4 +238,7 @@ impl[T: Compare] UnboundedRange[T]: Equals {
 }
 impl[T: Compare] UnboundedRange[T]: Hash {
   fun hash[H: Hasher](): H { unit().hash[H]() }
+}
+impl UnboundedRange[Int] {
+  public fun toProgression(stepSize: Int): UnboundedIntProgression { UnboundedIntProgression() }
 }


### PR DESCRIPTION

<!-- Add the breaking label (PR: BREAKING) if applicable. -->

<!-- Please summarize your changes: -->
Some things to note:

* I didn't add an `UnboundedIntProgression` yet, which would probably have a `step` and some `alignment` (to be able to offer a `contains` method).
* The range syntax used in the doc comments of ranges is not final. I'm not a fan of `a=..b` being the syntax for the probably most common range with an inclusive start and exclusive end.
* I didn't add a `Step` trait yet as we decided to only offer `IntProgression`s for now.

