### PR TITLE
Add compiler CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,71 @@
+on: pull_request
+
+name: Continuous Integration
+
+env:
+  RUST_VERSION: nightly
+
+defaults:
+  run:
+    working-directory: ./compiler
+
+jobs:
+  check:
+    name: Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: ${{ env.RUST_VERSION }}
+          override: true
+      - uses: actions-rs/cargo@v1
+        with:
+          command: check
+
+  test:
+    name: Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: ${{ env.RUST_VERSION }}
+          override: true
+      - uses: actions-rs/cargo@v1
+        with:
+          command: test
+
+  format:
+    name: Format
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: ${{ env.RUST_VERSION }}
+          override: true
+          components: rustfmt
+      - uses: actions-rs/cargo@v1
+        with:
+          command: fmt
+          args: --all -- --check
+
+  clippy:
+    name: Clippy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: ${{ env.RUST_VERSION }}
+          override: true
+          components: clippy
+      - uses: actions-rs/cargo@v1
+        with:
+          command: clippy
+          args: -- -D warnings

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,10 +5,6 @@ name: Continuous Integration
 env:
   RUST_VERSION: nightly
 
-defaults:
-  run:
-    working-directory: ./compiler
-
 jobs:
   check:
     name: Check
@@ -23,6 +19,7 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: check
+          args: --manifest-path compiler/Cargo.toml
 
   test:
     name: Tests
@@ -37,6 +34,7 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: test
+          args: --manifest-path compiler/Cargo.toml
 
   format:
     name: Format
@@ -52,7 +50,7 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: fmt
-          args: --all -- --check
+          args: --manifest-path compiler/Cargo.toml --all -- --check
 
   clippy:
     name: Clippy
@@ -68,4 +66,4 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: clippy
-          args: -- -D warnings
+          args: --manifest-path compiler/Cargo.toml -- -D warnings

--- a/.github/workflows/compiler.yaml
+++ b/.github/workflows/compiler.yaml
@@ -1,6 +1,6 @@
 on: pull_request
 
-name: Continuous Integration
+name: Compiler
 
 env:
   RUST_VERSION: nightly

--- a/candy.code-workspace
+++ b/candy.code-workspace
@@ -20,5 +20,8 @@
       "name": "Old Packages",
       "path": "old-packages"
     }
-  ]
+  ],
+  "settings": {
+    "rust-analyzer.checkOnSave.command": "clippy"
+  }
 }

--- a/compiler/Cargo.toml
+++ b/compiler/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "candy"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 [profile.release]
 debug = true

--- a/compiler/src/compiler/ast.rs
+++ b/compiler/src/compiler/ast.rs
@@ -119,7 +119,6 @@ pub enum AstError {
     StructKeyWithoutColon,
     StructValueWithoutComma,
     StructPositionalAfterNamedField,
-    ExpectedIdentifier,
     ExpectedParameter,
     LambdaWithoutClosingCurlyBrace,
 }

--- a/compiler/src/compiler/ast.rs
+++ b/compiler/src/compiler/ast.rs
@@ -112,7 +112,6 @@ pub enum AstError {
     UnexpectedPunctuation,
     TextWithoutClosingQuote,
     ParenthesizedWithoutClosingParenthesis,
-    CallOfANonIdentifier,
     StructWithNonStructField,
     StructWithoutClosingBrace,
     StructKeyWithoutColon,

--- a/compiler/src/compiler/ast.rs
+++ b/compiler/src/compiler/ast.rs
@@ -245,7 +245,9 @@ impl CollectErrors for Ast {
                 errors: mut recovered_errors,
             } => {
                 errors.append(&mut recovered_errors);
-                child.map(|child| child.collect_errors(errors));
+                if let Some(child) = child {
+                    child.collect_errors(errors)
+                }
             }
         }
     }

--- a/compiler/src/compiler/ast.rs
+++ b/compiler/src/compiler/ast.rs
@@ -79,14 +79,8 @@ pub struct Lambda {
 
 #[derive(Debug, PartialEq, Eq, Clone, Hash)]
 pub struct Call {
-    pub receiver: CallReceiver,
+    pub receiver: Box<Ast>,
     pub arguments: Vec<Ast>,
-}
-#[derive(Debug, PartialEq, Eq, Clone, Hash)]
-pub enum CallReceiver {
-    Identifier(AstString),
-    StructAccess(StructAccess),
-    Call(Box<Call>),
 }
 
 #[derive(Debug, PartialEq, Eq, Clone, Hash)]
@@ -176,15 +170,6 @@ impl FindAst for Lambda {
 impl FindAst for Call {
     fn find(&self, id: &Id) -> Option<&Ast> {
         self.receiver.find(id).or_else(|| self.arguments.find(id))
-    }
-}
-impl FindAst for CallReceiver {
-    fn find(&self, id: &Id) -> Option<&Ast> {
-        match self {
-            CallReceiver::Identifier(_) => None,
-            CallReceiver::StructAccess(access) => access.find(id),
-            CallReceiver::Call(call) => call.find(id),
-        }
     }
 }
 impl FindAst for Assignment {
@@ -362,15 +347,6 @@ impl Display for Call {
                 .map(|argument| format!("  {argument}"))
                 .join("\n")
         )
-    }
-}
-impl Display for CallReceiver {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        match self {
-            CallReceiver::Identifier(identifier) => write!(f, "{}", identifier),
-            CallReceiver::StructAccess(struct_access) => write!(f, "{}", struct_access),
-            CallReceiver::Call(call) => write!(f, "{}", call),
-        }
     }
 }
 impl Display for AstString {

--- a/compiler/src/compiler/ast_to_hir.rs
+++ b/compiler/src/compiler/ast_to_hir.rs
@@ -35,10 +35,10 @@ fn hir_to_ast_id(db: &dyn AstToHir, id: hir::Id) -> Option<ast::Id> {
     hir_to_ast_id_mapping.get(&id).cloned()
 }
 fn hir_to_cst_id(db: &dyn AstToHir, id: hir::Id) -> Option<cst::Id> {
-    db.ast_to_cst_id(db.hir_to_ast_id(id.clone())?)
+    db.ast_to_cst_id(db.hir_to_ast_id(id)?)
 }
 fn hir_id_to_span(db: &dyn AstToHir, id: hir::Id) -> Option<Range<usize>> {
-    db.ast_id_to_span(db.hir_to_ast_id(id.clone())?)
+    db.ast_id_to_span(db.hir_to_ast_id(id)?)
 }
 fn hir_id_to_display_span(db: &dyn AstToHir, id: hir::Id) -> Option<Range<usize>> {
     let cst_id = db.hir_to_cst_id(id.clone())?;
@@ -82,19 +82,13 @@ fn compile_top_level(
     context.generate_sparkles();
     context.generate_use_asset();
     context.generate_use();
-    context.compile(&mut &ast);
+    context.compile(ast);
     context.generate_exports_struct();
 
     let id_mapping = context
         .id_mapping
         .into_iter()
-        .filter_map(|(key, value)| {
-            if let Some(value) = value {
-                Some((key, value))
-            } else {
-                None
-            }
-        })
+        .filter_map(|(key, value)| value.map(|value| (key, value)))
         .collect();
     (context.body, id_mapping)
 }
@@ -150,7 +144,7 @@ impl<'a> Context<'a> {
             self.push(None, Expression::nothing(), None)
         } else {
             let mut last_id = None;
-            for ast in asts.into_iter() {
+            for ast in asts {
                 last_id = Some(self.compile_single(ast));
             }
             last_id.unwrap()
@@ -181,11 +175,7 @@ impl<'a> Context<'a> {
                         );
                     }
                 };
-                self.push(
-                    Some(ast.id.clone()),
-                    Expression::Reference(reference.to_owned()),
-                    None,
-                )
+                self.push(Some(ast.id.clone()), Expression::Reference(reference), None)
             }
             AstKind::Symbol(Symbol(symbol)) => self.push(
                 Some(ast.id.clone()),
@@ -252,11 +242,7 @@ impl<'a> Context<'a> {
                 body
             }
             AstKind::Error { child, errors } => {
-                let child = if let Some(child) = child {
-                    Some(self.compile_single(&*child))
-                } else {
-                    None
-                };
+                let child = child.as_ref().map(|child| self.compile_single(child));
                 self.push(
                     Some(ast.id.clone()),
                     Expression::Error {
@@ -276,7 +262,7 @@ impl<'a> Context<'a> {
         identifier: Option<String>,
     ) -> hir::Id {
         let assignment_reset_state = self.start_scope();
-        let lambda_id = self.create_next_id(Some(id), identifier.clone());
+        let lambda_id = self.create_next_id(Some(id), identifier);
 
         for parameter in lambda.parameters.iter() {
             let name = parameter.value.to_string();
@@ -321,7 +307,7 @@ impl<'a> Context<'a> {
         id: Option<ast::Id>,
         struct_access: &StructAccess,
     ) -> hir::Id {
-        let struct_ = self.compile_single(&*struct_access.struct_);
+        let struct_ = self.compile_single(&struct_access.struct_);
         let key_id = self.push(
             Some(struct_access.key.id.clone()),
             Expression::Symbol(struct_access.key.value.uppercase_first_letter()),
@@ -359,7 +345,7 @@ impl<'a> Context<'a> {
                             child: None,
                             errors: vec![CompilerError {
                                 input: name.id.input.clone(),
-                                span: self.db.ast_id_to_span(name.id.clone()).unwrap(),
+                                span: self.db.ast_id_to_span(name.id).unwrap(),
                                 payload: CompilerErrorPayload::Hir(
                                     HirError::NeedsWithWrongNumberOfArguments,
                                 ),
@@ -369,7 +355,7 @@ impl<'a> Context<'a> {
                     return self.push(id, expression, None);
                 }
 
-                match self.identifiers.get(&name.value).map(|id| id.clone()) {
+                match self.identifiers.get(&name.value).cloned() {
                     Some(function) => {
                         self.push(Some(name.id), Expression::Reference(function), None)
                     }
@@ -388,7 +374,7 @@ impl<'a> Context<'a> {
             CallReceiver::StructAccess(struct_access) => {
                 self.lower_struct_access(None, &struct_access)
             }
-            CallReceiver::Call(call) => self.lower_call(None, &*call),
+            CallReceiver::Call(call) => self.lower_call(None, &call),
         };
         let arguments = self.lower_call_arguments(&call.arguments[..]);
         self.push(
@@ -525,11 +511,7 @@ impl<'a> Context<'a> {
                     .map(|(index, it)| {
                         (
                             self.push(None, Expression::Int(index as u64), Some("key".to_string())),
-                            self.push(
-                                None,
-                                Expression::Text(it.to_owned()),
-                                Some("rawPath".to_string()),
-                            ),
+                            self.push(None, Expression::Text(it), Some("rawPath".to_string())),
                         )
                     })
                     .collect();

--- a/compiler/src/compiler/ast_to_hir.rs
+++ b/compiler/src/compiler/ast_to_hir.rs
@@ -161,16 +161,16 @@ impl<'a> Context<'a> {
                 Expression::Text(string.value.to_owned()),
                 None,
             ),
-            AstKind::Identifier(Identifier(symbol)) => {
-                let reference = match self.identifiers.get(&symbol.value) {
+            AstKind::Identifier(Identifier(name)) => {
+                let reference = match self.identifiers.get(&name.value) {
                     Some(reference) => reference.to_owned(),
                     None => {
                         return self.push_error(
-                            Some(symbol.id.clone()),
+                            Some(name.id.clone()),
                             ast.id.input.clone(),
                             self.db.ast_id_to_span(ast.id.clone()).unwrap(),
                             HirError::UnknownReference {
-                                symbol: symbol.value.clone(),
+                                name: name.value.clone(),
                             },
                         );
                     }

--- a/compiler/src/compiler/cst.rs
+++ b/compiler/src/compiler/cst.rs
@@ -567,7 +567,7 @@ impl TreeWithIds for Cst {
 
         inner.or_else(|| {
             if self.span.contains(offset) || (is_end_inclusive && &self.span.end == offset) {
-                return Some(self);
+                Some(self)
             } else {
                 None
             }
@@ -609,31 +609,29 @@ impl<T: TreeWithIds> TreeWithIds for [T] {
         self.iter()
             .map(|it| it.first_id())
             .filter_map(Some)
-            .nth(0)
+            .next()
             .flatten()
     }
     fn find(&self, id: &Id) -> Option<&Cst> {
-        let slice = self.as_ref();
-        let child_index = slice
+        let child_index = self
             .binary_search_by_key(id, |it| it.first_id().unwrap())
             .or_else(|err| if err == 0 { Err(()) } else { Ok(err - 1) })
             .ok()?;
-        slice[child_index].find(id)
+        self[child_index].find(id)
     }
 
     fn first_offset(&self) -> Option<usize> {
         self.iter()
             .map(|it| it.first_offset())
             .filter_map(Some)
-            .nth(0)
+            .next()
             .flatten()
     }
     fn find_by_offset(&self, offset: &usize) -> Option<&Cst> {
-        let slice = self.as_ref();
-        let child_index = slice
+        let child_index = self
             .binary_search_by_key(offset, |it| it.first_offset().unwrap())
             .or_else(|err| if err == 0 { Err(()) } else { Ok(err - 1) })
             .ok()?;
-        slice[child_index].find_by_offset(offset)
+        self[child_index].find_by_offset(offset)
     }
 }

--- a/compiler/src/compiler/cst_to_ast.rs
+++ b/compiler/src/compiler/cst_to_ast.rs
@@ -53,8 +53,7 @@ fn ast(db: &dyn CstToAst, input: Input) -> Option<(Arc<Vec<Ast>>, HashMap<ast::I
     let asts = match db.cst(input.clone()) {
         Ok(cst) => {
             let cst = cst.unwrap_whitespace_and_comment();
-            let asts = (&mut context).lower_csts(&cst);
-            asts
+            context.lower_csts(&cst)
         }
         Err(InvalidInputError::DoesNotExist) => return None,
         Err(InvalidInputError::InvalidUtf8) => {
@@ -144,7 +143,7 @@ impl LoweringContext {
                 );
 
                 let text = parts
-                    .into_iter()
+                    .iter()
                     .filter_map(|it| match it {
                         Cst {
                             kind: CstKind::TextPart(text),
@@ -281,7 +280,7 @@ impl LoweringContext {
                 );
 
                 let fields = fields
-                    .into_iter()
+                    .iter()
                     .filter_map(|field| {
                         if let CstKind::StructField {
                             key,
@@ -493,6 +492,7 @@ impl LoweringContext {
             CstKind::Identifier(identifier) => {
                 self.create_string(key.id.to_owned(), identifier.uppercase_first_letter())
             }
+            // TODO: handle CstKind::Error
             _ => panic!(
                 "Expected an identifier after the dot in a struct access, but found `{}`.",
                 key
@@ -508,7 +508,7 @@ impl LoweringContext {
     fn lower_parameters(&mut self, csts: &[Cst]) -> (Vec<AstString>, Vec<CompilerError>) {
         let mut errors = vec![];
         let parameters = csts
-            .into_iter()
+            .iter()
             .enumerate()
             .map(|(index, it)| match self.lower_parameter(it) {
                 Ok(parameter) => parameter,

--- a/compiler/src/compiler/cst_to_ast.rs
+++ b/compiler/src/compiler/cst_to_ast.rs
@@ -27,8 +27,10 @@ pub trait CstToAst: CstDb + RcstToCst {
 
     fn cst_to_ast_id(&self, input: Input, id: cst::Id) -> Option<ast::Id>;
 
-    fn ast(&self, input: Input) -> Option<(Arc<Vec<Ast>>, HashMap<ast::Id, cst::Id>)>;
+    fn ast(&self, input: Input) -> Option<AstResult>;
 }
+
+type AstResult = (Arc<Vec<Ast>>, HashMap<ast::Id, cst::Id>);
 
 fn ast_to_cst_id(db: &dyn CstToAst, id: ast::Id) -> Option<cst::Id> {
     let (_, ast_to_cst_id_mapping) = db.ast(id.input.clone()).unwrap();
@@ -47,7 +49,7 @@ fn cst_to_ast_id(db: &dyn CstToAst, input: Input, id: cst::Id) -> Option<ast::Id
         .cloned()
 }
 
-fn ast(db: &dyn CstToAst, input: Input) -> Option<(Arc<Vec<Ast>>, HashMap<ast::Id, cst::Id>)> {
+fn ast(db: &dyn CstToAst, input: Input) -> Option<AstResult> {
     let mut context = LoweringContext::new(input.clone());
 
     let asts = match db.cst(input.clone()) {

--- a/compiler/src/compiler/hir.rs
+++ b/compiler/src/compiler/hir.rs
@@ -196,8 +196,7 @@ impl Body {
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub enum HirError {
-    UnknownReference { symbol: String },
-    UnknownFunction { name: String },
+    UnknownReference { name: String },
     PublicAssignmentInNotTopLevel,
     PublicAssignmentWithSameName { name: String },
     NeedsWithWrongNumberOfArguments,

--- a/compiler/src/compiler/hir.rs
+++ b/compiler/src/compiler/hir.rs
@@ -185,6 +185,7 @@ pub struct Body {
     pub identifiers: HashMap<Id, String>,
 }
 impl Body {
+    #[allow(dead_code)]
     pub fn return_value(&self) -> Id {
         self.expressions
             .keys()

--- a/compiler/src/compiler/hir_to_lir.rs
+++ b/compiler/src/compiler/hir_to_lir.rs
@@ -15,7 +15,7 @@ pub trait HirToLir: CstDb + AstToHir {
 }
 
 fn lir(db: &dyn HirToLir, input: Input) -> Option<Arc<Lir>> {
-    let (hir, _) = db.hir(input.clone())?;
+    let (hir, _) = db.hir(input)?;
     let instructions = compile_lambda(&[], &[], &hir);
     Some(Arc::new(Lir { instructions }))
 }

--- a/compiler/src/compiler/rcst.rs
+++ b/compiler/src/compiler/rcst.rs
@@ -44,7 +44,7 @@ pub enum Rcst {
         closing_parenthesis: Box<Rcst>,
     },
     Call {
-        name: Box<Rcst>,
+        receiver: Box<Rcst>,
         arguments: Vec<Rcst>,
     },
     Struct {
@@ -159,8 +159,11 @@ impl Display for Rcst {
                 inner.fmt(f)?;
                 closing_parenthesis.fmt(f)
             }
-            Rcst::Call { name, arguments } => {
-                name.fmt(f)?;
+            Rcst::Call {
+                receiver,
+                arguments,
+            } => {
+                receiver.fmt(f)?;
                 for argument in arguments {
                     argument.fmt(f)?;
                 }
@@ -284,7 +287,10 @@ impl IsMultiline for Rcst {
                     || inner.is_multiline()
                     || closing_parenthesis.is_multiline()
             }
-            Rcst::Call { name, arguments } => name.is_multiline() || arguments.is_multiline(),
+            Rcst::Call {
+                receiver,
+                arguments,
+            } => receiver.is_multiline() || arguments.is_multiline(),
             Rcst::Struct {
                 opening_bracket,
                 fields,

--- a/compiler/src/compiler/rcst_to_cst.rs
+++ b/compiler/src/compiler/rcst_to_cst.rs
@@ -151,8 +151,11 @@ impl RcstToCstExt for Rcst {
                 state.offset += text.len();
                 CstKind::TextPart(text)
             }
-            Rcst::Call { name, arguments } => CstKind::Call {
-                name: Box::new(name.to_cst(state)),
+            Rcst::Call {
+                receiver,
+                arguments,
+            } => CstKind::Call {
+                receiver: Box::new(receiver.to_cst(state)),
                 arguments: arguments.to_csts(state),
             },
             Rcst::Struct {

--- a/compiler/src/compiler/string_to_rcst.rs
+++ b/compiler/src/compiler/string_to_rcst.rs
@@ -775,7 +775,7 @@ mod parse {
                 Rcst::Parenthesized {
                     opening_parenthesis: Box::new(Rcst::OpeningParenthesis),
                     inner: Box::new(Rcst::Call {
-                        name: Box::new(Rcst::TrailingWhitespace {
+                        receiver: Box::new(Rcst::TrailingWhitespace {
                             child: Box::new(Rcst::Identifier("foo".to_string())),
                             whitespace: vec![Rcst::Whitespace(" ".to_string())]
                         }),
@@ -840,7 +840,7 @@ mod parse {
             Some((
                 "",
                 Rcst::Call {
-                    name: Box::new(Rcst::TrailingWhitespace {
+                    receiver: Box::new(Rcst::TrailingWhitespace {
                         child: Box::new(Rcst::Identifier("foo".to_string())),
                         whitespace: vec![
                             Rcst::Newline("\n".to_string()),
@@ -860,7 +860,7 @@ mod parse {
                         child: Box::new(Rcst::Parenthesized {
                             opening_parenthesis: Box::new(Rcst::OpeningParenthesis),
                             inner: Box::new(Rcst::Call {
-                                name: Box::new(Rcst::TrailingWhitespace {
+                                receiver: Box::new(Rcst::TrailingWhitespace {
                                     child: Box::new(Rcst::Identifier("foo".to_string())),
                                     whitespace: vec![Rcst::Whitespace(" ".to_string())]
                                 }),
@@ -885,11 +885,11 @@ mod parse {
 
         let (whitespace, mut expressions) = expressions.split_outer_trailing_whitespace();
         let arguments = expressions.split_off(1);
-        let name = expressions.into_iter().next().unwrap();
+        let receiver = expressions.into_iter().next().unwrap();
         Some((
             input,
             Rcst::Call {
-                name: Box::new(name),
+                receiver: Box::new(receiver),
                 arguments,
             }
             .wrap_in_whitespace(whitespace),
@@ -903,7 +903,7 @@ mod parse {
             Some((
                 "",
                 Rcst::Call {
-                    name: Box::new(Rcst::TrailingWhitespace {
+                    receiver: Box::new(Rcst::TrailingWhitespace {
                         child: Box::new(Rcst::Identifier("foo".to_string())),
                         whitespace: vec![Rcst::Whitespace(" ".to_string())],
                     }),
@@ -916,7 +916,7 @@ mod parse {
             Some((
                 "",
                 Rcst::Call {
-                    name: Box::new(Rcst::TrailingWhitespace {
+                    receiver: Box::new(Rcst::TrailingWhitespace {
                         child: Box::new(Rcst::Symbol("Foo".to_string())),
                         whitespace: vec![Rcst::Whitespace(" ".to_string())],
                     }),
@@ -942,7 +942,7 @@ mod parse {
             Some((
                 "\n2",
                 Rcst::Call {
-                    name: Box::new(Rcst::TrailingWhitespace {
+                    receiver: Box::new(Rcst::TrailingWhitespace {
                         child: Box::new(Rcst::Identifier("foo".to_string())),
                         whitespace: vec![
                             Rcst::Newline("\n".to_string()),
@@ -971,7 +971,7 @@ mod parse {
             Some((
                 "\nbar",
                 Rcst::Call {
-                    name: Box::new(Rcst::TrailingWhitespace {
+                    receiver: Box::new(Rcst::TrailingWhitespace {
                         child: Box::new(Rcst::Identifier("foo".to_string())),
                         whitespace: vec![Rcst::Whitespace(" ".to_string())],
                     }),
@@ -1016,11 +1016,11 @@ mod parse {
             Some((
                 "\n",
                 Rcst::Call {
-                    name: Box::new(Rcst::TrailingWhitespace {
+                    receiver: Box::new(Rcst::TrailingWhitespace {
                         child: Box::new(Rcst::Parenthesized {
                             opening_parenthesis: Box::new(Rcst::OpeningParenthesis),
                             inner: Box::new(Rcst::Call {
-                                name: Box::new(Rcst::TrailingWhitespace {
+                                receiver: Box::new(Rcst::TrailingWhitespace {
                                     child: Box::new(Rcst::Identifier("foo".to_string())),
                                     whitespace: vec![Rcst::Whitespace(" ".to_string())]
                                 }),
@@ -1044,7 +1044,7 @@ mod parse {
                 "\nbar = 5",
                 Rcst::TrailingWhitespace {
                     child: Box::new(Rcst::Call {
-                        name: Box::new(Rcst::TrailingWhitespace {
+                        receiver: Box::new(Rcst::TrailingWhitespace {
                             child: Box::new(Rcst::Identifier("foo".to_string())),
                             whitespace: vec![Rcst::Whitespace(" ".to_string())]
                         }),

--- a/compiler/src/compiler/string_to_rcst.rs
+++ b/compiler/src/compiler/string_to_rcst.rs
@@ -584,11 +584,8 @@ mod parse {
                         comment: " foo".to_string()
                     },
                     Rcst::Newline("\n".to_string()),
-                    Rcst::Error {
-                        unparsable_input: "\n ".to_string(),
-                        error: RcstError::WeirdWhitespaceInIndentation
-                    },
-                    Rcst::Whitespace(" ".to_string()),
+                    Rcst::Newline("\n".to_string()),
+                    Rcst::Whitespace("  ".to_string()),
                     Rcst::Comment {
                         octothorpe: Box::new(Rcst::Octothorpe),
                         comment: "bar".to_string()

--- a/compiler/src/compiler/string_to_rcst.rs
+++ b/compiler/src/compiler/string_to_rcst.rs
@@ -80,16 +80,12 @@ mod parse {
     use super::super::rcst::{IsMultiline, Rcst, RcstError};
     use itertools::Itertools;
 
-    static MEANINGFUL_PUNCTUATION: &'static str = "()[]:,{}->=.";
-    static SUPPORTED_WHITESPACE: &'static str = " \r\n\t";
+    static MEANINGFUL_PUNCTUATION: &str = "()[]:,{}->=.";
+    static SUPPORTED_WHITESPACE: &str = " \r\n\t";
 
     fn literal<'a>(input: &'a str, literal: &'static str) -> Option<&'a str> {
         log::trace!("literal({input:?}, {literal:?})");
-        if input.starts_with(literal) {
-            Some(&input[literal.len()..])
-        } else {
-            None
-        }
+        input.strip_prefix(literal)
     }
     #[test]
     fn test_literal() {
@@ -281,7 +277,7 @@ mod parse {
             return None;
         }
         if w.chars().all(|c| c.is_ascii_digit()) {
-            let value = u64::from_str_radix(&w, 10).expect("Couldn't parse int.");
+            let value = str::parse(&w).expect("Couldn't parse int.");
             Some((input, Rcst::Int { value, string: w }))
         } else {
             Some((
@@ -1160,7 +1156,7 @@ mod parse {
                 key: Box::new(key),
                 colon: Box::new(colon),
                 value: Box::new(value),
-                comma: comma.map(|it| Box::new(it)),
+                comma: comma.map(Box::new),
             });
         }
         let input = outer_input;

--- a/compiler/src/database.rs
+++ b/compiler/src/database.rs
@@ -33,12 +33,12 @@ pub struct Database {
     storage: salsa::Storage<Self>,
     pub open_inputs: HashMap<Input, Vec<u8>>,
 }
-impl<'a> salsa::Database for Database {}
+impl salsa::Database for Database {}
 
 impl Database {
     pub fn did_open_input(&mut self, input: &Input, content: Vec<u8>) {
         let old_value = self.open_inputs.insert(input.clone(), content);
-        if let Some(_) = old_value {
+        if old_value.is_some() {
             log::warn!("Input {input} was opened, but it was already open.");
         }
 
@@ -46,7 +46,7 @@ impl Database {
     }
     pub fn did_change_input(&mut self, input: &Input, content: Vec<u8>) {
         let old_value = self.open_inputs.insert(input.to_owned(), content);
-        if let None = old_value {
+        if old_value.is_none() {
             log::warn!("Input {input} was changed, but it wasn't open before.");
         }
 
@@ -54,7 +54,7 @@ impl Database {
     }
     pub fn did_close_input(&mut self, input: &Input) {
         let old_value = self.open_inputs.remove(input);
-        if let None = old_value {
+        if old_value.is_none() {
             log::warn!("Input {input} was closed, but it wasn't open before.");
         }
 

--- a/compiler/src/fuzzer/fuzzer.rs
+++ b/compiler/src/fuzzer/fuzzer.rs
@@ -105,7 +105,7 @@ impl Fuzzer {
                         Status::new_fuzzing_attempt(db, self.closure.clone())
                     } else {
                         Status::PanickedForArguments {
-                            arguments: arguments.clone(),
+                            arguments,
                             reason: reason.clone(),
                             tracer: vm.tracer.clone(),
                         }

--- a/compiler/src/fuzzer/mod.rs
+++ b/compiler/src/fuzzer/mod.rs
@@ -9,7 +9,6 @@ use crate::{
     vm::{use_provider::DbUseProvider, value::Closure, TearDownResult, Vm},
 };
 use itertools::Itertools;
-use log;
 use std::fs;
 
 pub async fn fuzz(db: &Database, input: Input) {
@@ -18,7 +17,7 @@ pub async fn fuzz(db: &Database, input: Input) {
         let module_closure = Closure::of_input(db, input.clone()).unwrap();
         let use_provider = DbUseProvider { db };
         vm.set_up_module_closure_execution(&use_provider, module_closure);
-        vm.run_synchronously_until_completion(&db).ok();
+        vm.run_synchronously_until_completion(db).ok();
         vm
     };
 
@@ -47,7 +46,7 @@ pub async fn fuzz(db: &Database, input: Input) {
                     arguments.iter().map(|it| format!("{}", it)).join(" "),
                 );
                 log::error!("This was the stack trace:");
-                tracer.dump_stack_trace(&db);
+                tracer.dump_stack_trace(db);
 
                 let trace = tracer.dump_call_tree();
                 let mut trace_file = input.to_path().unwrap();

--- a/compiler/src/fuzzer/utils.rs
+++ b/compiler/src/fuzzer/utils.rs
@@ -42,5 +42,5 @@ pub fn did_need_in_closure_cause_panic(
             }
         }
     }
-    return false;
+    false
 }

--- a/compiler/src/input.rs
+++ b/compiler/src/input.rs
@@ -16,9 +16,7 @@ pub trait InputDb: InputWatcher {
 
 fn get_string_input(db: &dyn InputDb, input: Input) -> Option<Arc<String>> {
     let content = get_input(db, input)?;
-    String::from_utf8((*content).clone())
-        .ok()
-        .map(|it| Arc::new(it))
+    String::from_utf8((*content).clone()).ok().map(Arc::new)
 }
 
 fn get_input(db: &dyn InputDb, input: Input) -> Option<Arc<Vec<u8>>> {
@@ -79,7 +77,7 @@ impl From<PathBuf> for Input {
         let project_dir = PROJECT_DIRECTORY.lock().unwrap().clone().unwrap();
         let path = match fs::canonicalize(&path)
             .expect("Path does not exist or is invalid.")
-            .strip_prefix(fs::canonicalize(project_dir).unwrap().clone())
+            .strip_prefix(fs::canonicalize(project_dir).unwrap())
         {
             Ok(path) => path.to_owned(),
             Err(_) => return Input::ExternalFile(path),
@@ -107,7 +105,7 @@ impl Input {
     pub fn to_path(&self) -> Option<PathBuf> {
         match self {
             Input::File(components) => {
-                let mut path = PROJECT_DIRECTORY.lock().unwrap().clone().unwrap().clone();
+                let mut path = PROJECT_DIRECTORY.lock().unwrap().clone().unwrap();
                 for component in components {
                     path.push(component);
                 }

--- a/compiler/src/input.rs
+++ b/compiler/src/input.rs
@@ -148,7 +148,7 @@ mod test {
     #[test]
     fn on_demand_input_works() {
         let mut db = Database::default();
-        let input: Input = PathBuf::from("/foo.rs").into();
+        let input = Input::File(vec!["foo.rs".to_string()]);
 
         db.did_open_input(&input, "123".to_string().into_bytes());
         assert_eq!(

--- a/compiler/src/input.rs
+++ b/compiler/src/input.rs
@@ -156,7 +156,7 @@ mod test {
         assert_eq!(
             db.rcst(input.clone()).unwrap().as_ref().to_owned(),
             vec![Rcst::Int {
-                value: 12u8.into(),
+                value: 123u8.into(),
                 string: "123".to_string()
             },],
         );

--- a/compiler/src/language_server/definition.rs
+++ b/compiler/src/language_server/definition.rs
@@ -35,7 +35,7 @@ pub fn find_definition(
     let target_cst = db.find_cst(input.clone(), target_cst_id);
 
     let result = GotoDefinitionResponse::Link(vec![LocationLink {
-        origin_selection_range: Some(db.range_to_lsp(input.clone(), origin_cst.span.clone())),
+        origin_selection_range: Some(db.range_to_lsp(input.clone(), origin_cst.span)),
         target_uri: params.text_document.uri,
         target_range: db.range_to_lsp(input.clone(), target_cst.span.clone()),
         target_selection_range: db.range_to_lsp(input, target_cst.display_span()),

--- a/compiler/src/language_server/folding_range.rs
+++ b/compiler/src/language_server/folding_range.rs
@@ -79,7 +79,7 @@ impl<'a> Context<'a> {
                 }
 
                 self.visit_cst(name);
-                self.visit_csts(&arguments);
+                self.visit_csts(arguments);
             }
             // TODO: support folding ranges for structs
             CstKind::Struct { fields, .. } => self.visit_csts(fields),
@@ -116,9 +116,9 @@ impl<'a> Context<'a> {
                     FoldingRangeKind::Region,
                 );
                 if let Some((parameters, _)) = parameters_and_arrow {
-                    self.visit_csts(&parameters);
+                    self.visit_csts(parameters);
                 }
-                self.visit_csts(&body);
+                self.visit_csts(body);
             }
             CstKind::Assignment {
                 name,
@@ -138,8 +138,8 @@ impl<'a> Context<'a> {
                 }
 
                 self.visit_cst(name);
-                self.visit_csts(&parameters);
-                self.visit_csts(&body);
+                self.visit_csts(parameters);
+                self.visit_csts(body);
             }
             CstKind::Error { .. } => {}
         }

--- a/compiler/src/language_server/folding_range.rs
+++ b/compiler/src/language_server/folding_range.rs
@@ -67,18 +67,21 @@ impl<'a> Context<'a> {
             CstKind::Text { .. } => {}
             CstKind::TextPart(_) => {}
             CstKind::Parenthesized { inner, .. } => self.visit_cst(inner),
-            CstKind::Call { name, arguments } => {
+            CstKind::Call {
+                receiver,
+                arguments,
+            } => {
                 if !arguments.is_empty() {
-                    let name = name.unwrap_whitespace_and_comment();
+                    let receiver = receiver.unwrap_whitespace_and_comment();
                     let last_argument = arguments.last().unwrap().unwrap_whitespace_and_comment();
                     self.push(
-                        name.span.end,
+                        receiver.span.end,
                         last_argument.span.end,
                         FoldingRangeKind::Region,
                     );
                 }
 
-                self.visit_cst(name);
+                self.visit_cst(receiver);
                 self.visit_csts(arguments);
             }
             // TODO: support folding ranges for structs

--- a/compiler/src/language_server/hints/constant_evaluator.rs
+++ b/compiler/src/language_server/hints/constant_evaluator.rs
@@ -23,12 +23,12 @@ pub struct ConstantEvaluator {
 
 impl ConstantEvaluator {
     pub fn update_input(&mut self, db: &Database, input: Input) {
-        let module_closure = Closure::of_input(&db, input.clone()).unwrap();
+        let module_closure = Closure::of_input(db, input.clone()).unwrap();
         let mut vm = Vm::new();
-        let use_provider = DbUseProvider { db: &db };
+        let use_provider = DbUseProvider { db };
         vm.set_up_module_closure_execution(&use_provider, module_closure);
 
-        self.vms.insert(input.clone(), vm);
+        self.vms.insert(input, vm);
     }
 
     pub fn remove_input(&mut self, input: Input) {
@@ -62,7 +62,7 @@ impl ConstantEvaluator {
             .fuzzable_closures
             .iter()
             .filter(|(id, _)| &id.input == input)
-            .map(|it| it.clone())
+            .cloned()
             .collect_vec()
     }
 
@@ -73,14 +73,14 @@ impl ConstantEvaluator {
         let mut hints = vec![];
 
         if let Status::Panicked { reason } = vm.status() {
-            let hint = panic_hint(&db, input.clone(), &vm, reason)
+            let hint = panic_hint(db, input.clone(), vm, reason)
                 .expect("Module panicked, but we couldn't build a panic hint to communicate that.");
             hints.push(hint);
         };
         if let Some(path) = input.to_path() {
             let trace = vm.tracer.dump_call_tree();
             let trace_file = path.clone_with_extension("candy.trace");
-            fs::write(trace_file.clone(), trace).unwrap();
+            fs::write(trace_file, trace).unwrap();
         }
 
         for entry in vm.tracer.log() {
@@ -112,7 +112,7 @@ impl ConstantEvaluator {
             hints.push(Hint {
                 kind: HintKind::Value,
                 text: format!("{value}"),
-                position: id_to_end_of_line(&db, id).unwrap(),
+                position: id_to_end_of_line(db, id).unwrap(),
             });
         }
 
@@ -124,21 +124,16 @@ fn panic_hint(db: &Database, input: Input, vm: &Vm, reason: String) -> Option<Hi
     // We want to show the hint at the last call site still inside the current
     // module. If there is no call site in this module, then the panic results
     // from a compiler error in a previous stage which is already reported.
-    let last_call_in_this_module = vm
-        .tracer
-        .stack()
-        .iter()
-        .filter(|entry| {
-            let id = match entry {
-                TraceEntry::CallStarted { id, .. } => id,
-                TraceEntry::NeedsStarted { id, .. } => id,
-                _ => return false,
-            };
-            // Make sure the entry comes from the same file and is not generated
-            // code.
-            id.input == input && db.hir_to_cst_id(id.clone()).is_some()
-        })
-        .next()?;
+    let last_call_in_this_module = vm.tracer.stack().iter().find(|entry| {
+        let id = match entry {
+            TraceEntry::CallStarted { id, .. } => id,
+            TraceEntry::NeedsStarted { id, .. } => id,
+            _ => return false,
+        };
+        // Make sure the entry comes from the same file and is not generated
+        // code.
+        id.input == input && db.hir_to_cst_id(id.clone()).is_some()
+    })?;
 
     let (id, call_info) = match last_call_in_this_module {
         TraceEntry::CallStarted { id, closure, args } => (

--- a/compiler/src/language_server/hints/fuzzer.rs
+++ b/compiler/src/language_server/hints/fuzzer.rs
@@ -28,8 +28,8 @@ impl FuzzerManager {
     ) {
         let closures = self
             .fuzzable_closures
-            .entry(input.clone())
-            .or_insert_with(|| HashMap::new());
+            .entry(input)
+            .or_insert_with(HashMap::new);
 
         for (id, new_closure) in fuzzable_closures {
             let old_closure = closures.insert(id.clone(), new_closure.clone());
@@ -106,7 +106,7 @@ impl FuzzerManager {
                                 .collect_vec()
                                 .join_with_commas_and_and(),
                         ),
-                        position: id_to_end_of_line(&db, id.clone()).unwrap(),
+                        position: id_to_end_of_line(db, id.clone()).unwrap(),
                     }
                 };
 
@@ -117,7 +117,7 @@ impl FuzzerManager {
                         .rev()
                         // Find the innermost panicking call that is in the
                         // function.
-                        .filter(|entry| {
+                        .find(|entry| {
                             let innermost_panicking_call_id = match entry {
                                 TraceEntry::CallStarted { id, .. } => id,
                                 TraceEntry::NeedsStarted { id, .. } => id,
@@ -126,7 +126,6 @@ impl FuzzerManager {
                             id.is_same_module_and_any_parent_of(innermost_panicking_call_id)
                                 && db.hir_to_cst_id(id.clone()).is_some()
                         })
-                        .next()
                         .expect(
                             "Fuzzer found a panicking function without an inner panicking needs",
                         );

--- a/compiler/src/language_server/hints/mod.rs
+++ b/compiler/src/language_server/hints/mod.rs
@@ -126,11 +126,10 @@ pub async fn run_server(
                     hint_group
                 })
                 // Show related hints at the same indentation.
-                .map(|mut hint_group| {
+                .flat_map(|mut hint_group| {
                     hint_group.align_hint_columns();
                     hint_group
                 })
-                .flatten()
                 .sorted_by_key(|hint| hint.position)
                 .collect_vec();
 
@@ -177,7 +176,7 @@ impl OutgoingHints {
 /// [em quad](https://en.wikipedia.org/wiki/Quad_(typography)) instead, which
 /// seems to have the same width as a normal space in VSCode.
 fn quasi_spaces(n: usize) -> String {
-    format!(" ").repeat(n)
+    " ".repeat(n)
 }
 
 trait AlignHints {

--- a/compiler/src/language_server/hints/utils.rs
+++ b/compiler/src/language_server/hints/utils.rs
@@ -20,7 +20,7 @@ pub fn id_to_end_of_line(db: &Database, id: hir::Id) -> Option<Position> {
         line_start_offsets[(line + 1) as usize] - 1
     };
     let position = db
-        .offset_to_lsp(id.input.clone(), last_character_of_line)
+        .offset_to_lsp(id.input, last_character_of_line)
         .to_position();
     Some(position)
 }

--- a/compiler/src/language_server/mod.rs
+++ b/compiler/src/language_server/mod.rs
@@ -305,7 +305,7 @@ impl CandyLanguageServer {
                 hir.collect_errors(&mut errors);
                 errors
                     .into_iter()
-                    .map(|it| it.to_diagnostic(&db, input.clone()))
+                    .map(|it| it.into_diagnostic(&db, input.clone()))
                     .collect()
             };
             self.client

--- a/compiler/src/language_server/references.rs
+++ b/compiler/src/language_server/references.rs
@@ -133,7 +133,7 @@ impl<'a> Context<'a> {
 
     fn visit_body(&mut self, body: &Body) {
         if let ReferenceQuery::Id(id) = &self.query.clone() {
-            if body.identifiers.contains_key(&id) {
+            if body.identifiers.contains_key(id) {
                 self.add_reference(id.clone(), DocumentHighlightKind::WRITE);
             }
         }

--- a/compiler/src/language_server/semantic_tokens.rs
+++ b/compiler/src/language_server/semantic_tokens.rs
@@ -28,7 +28,7 @@ fn semantic_tokens(db: &dyn SemanticTokenDb, input: Input) -> Vec<SemanticToken>
 
 lazy_static! {
     pub static ref LEGEND: SemanticTokensLegend = SemanticTokensLegend {
-        token_types: SemanticTokenType::iter().map(|it| it.to_lsp()).collect(),
+        token_types: SemanticTokenType::iter().map(|it| it.as_lsp()).collect(),
         token_modifiers: vec![
             lsp_types::SemanticTokenModifier::DEFINITION,
             lsp_types::SemanticTokenModifier::READONLY,
@@ -55,7 +55,7 @@ lazy_static! {
 }
 
 impl SemanticTokenType {
-    fn to_lsp(&self) -> lsp_types::SemanticTokenType {
+    fn as_lsp(&self) -> lsp_types::SemanticTokenType {
         match self {
             SemanticTokenType::Parameter => lsp_types::SemanticTokenType::PARAMETER,
             SemanticTokenType::Assignment => lsp_types::SemanticTokenType::VARIABLE,

--- a/compiler/src/language_server/semantic_tokens.rs
+++ b/compiler/src/language_server/semantic_tokens.rs
@@ -201,8 +201,11 @@ impl<'a> Context<'a> {
                 self.visit_cst(inner, None);
                 self.visit_cst(closing_parenthesis, None);
             }
-            CstKind::Call { name, arguments } => {
-                self.visit_cst(name, Some(SemanticTokenType::Function));
+            CstKind::Call {
+                receiver,
+                arguments,
+            } => {
+                self.visit_cst(receiver, Some(SemanticTokenType::Function));
                 self.visit_csts(arguments, None);
             }
             CstKind::Struct {

--- a/compiler/src/language_server/utils.rs
+++ b/compiler/src/language_server/utils.rs
@@ -8,7 +8,7 @@ use lsp_types::{Diagnostic, DiagnosticSeverity, Position, Url};
 use std::{ops::Range, sync::Arc};
 
 impl CompilerError {
-    pub fn to_diagnostic(self, db: &Database, input: Input) -> Diagnostic {
+    pub fn into_diagnostic(self, db: &Database, input: Input) -> Diagnostic {
         Diagnostic {
             range: lsp_types::Range {
                 start: db

--- a/compiler/src/language_server/utils.rs
+++ b/compiler/src/language_server/utils.rs
@@ -21,7 +21,7 @@ impl CompilerError {
             code_description: None,
             source: Some("🍭 Candy".to_owned()),
             message: match self.payload {
-                CompilerErrorPayload::InvalidUtf8 => format!("Invalid UTF8"),
+                CompilerErrorPayload::InvalidUtf8 => "Invalid UTF8".to_string(),
                 CompilerErrorPayload::Rcst(rcst) => format!("RCST: {rcst:?}"),
                 CompilerErrorPayload::Ast(ast) => format!("AST: {ast:?}"),
                 CompilerErrorPayload::Hir(hir) => format!("HIR: {hir:?}"),

--- a/compiler/src/main.rs
+++ b/compiler/src/main.rs
@@ -1,6 +1,5 @@
 #![feature(async_closure)]
 #![feature(label_break_value)]
-#![feature(let_chains)]
 #![feature(never_type)]
 #![feature(try_trait_v2)]
 

--- a/compiler/src/main.rs
+++ b/compiler/src/main.rs
@@ -2,6 +2,7 @@
 #![feature(label_break_value)]
 #![feature(never_type)]
 #![feature(try_trait_v2)]
+#![allow(clippy::module_inception)]
 
 mod builtin_functions;
 mod compiler;

--- a/compiler/src/vm/builtin_functions.rs
+++ b/compiler/src/vm/builtin_functions.rs
@@ -6,7 +6,6 @@ use super::{
 };
 use crate::{builtin_functions::BuiltinFunction, compiler::lir::Instruction, input::Input};
 use itertools::Itertools;
-use log;
 
 macro_rules! destructure {
     ($args:expr, $enum:pat, $body:block) => {{
@@ -131,8 +130,8 @@ impl Vm {
 
     fn struct_get(&mut self, args: Vec<Value>) -> Result<Value, String> {
         destructure!(args, [Value::Struct(struct_), key], {
-            match struct_.get(&key) {
-                Some(value) => Ok(value.clone().into()),
+            match struct_.get(key) {
+                Some(value) => Ok(value.clone()),
                 None => Err(format!("Struct does not contain key {key:?}.")),
             }
         })
@@ -200,7 +199,7 @@ impl Vm {
             return Err("couldn't import module".to_string());
         };
 
-        let module_closure = Value::Closure(Closure::of_lir(input.clone(), lir));
+        let module_closure = Value::Closure(Closure::of_lir(input, lir));
         let address = self.heap.import(module_closure);
         self.data_stack.push(address);
         self.run_instruction(use_provider, Instruction::Call { num_args: 0 });
@@ -235,7 +234,7 @@ impl UseTarget {
     fn parse(mut target: &str) -> Result<Self, String> {
         let parent_navigations = {
             let mut navigations = 0;
-            while target.chars().next() == Some(UseTarget::PARENT_NAVIGATION_CHAR) {
+            while target.starts_with(UseTarget::PARENT_NAVIGATION_CHAR) {
                 navigations += 1;
                 target = &target[UseTarget::PARENT_NAVIGATION_CHAR.len_utf8()..];
             }
@@ -297,9 +296,6 @@ impl UseTarget {
                 .chain([self.path.to_string(), ".candy".to_string()])
                 .collect_vec(),
         ];
-        Ok(possible_paths
-            .into_iter()
-            .map(|path| Input::File(path))
-            .collect_vec())
+        Ok(possible_paths.into_iter().map(Input::File).collect_vec())
     }
 }

--- a/compiler/src/vm/heap.rs
+++ b/compiler/src/vm/heap.rs
@@ -60,12 +60,12 @@ impl Heap {
     pub fn get(&self, address: ObjectPointer) -> &Object {
         self.objects
             .get(&address)
-            .expect(&format!("Couldn't get object {address}."))
+            .unwrap_or_else(|| panic!("Couldn't get object {address}."))
     }
     pub fn get_mut(&mut self, address: ObjectPointer) -> &mut Object {
         self.objects
             .get_mut(&address)
-            .expect(&format!("Couldn't get object {address}."))
+            .unwrap_or_else(|| panic!("Couldn't get object {address}."))
     }
 
     pub fn dup(&mut self, address: ObjectPointer) {

--- a/compiler/src/vm/heap.rs
+++ b/compiler/src/vm/heap.rs
@@ -1,7 +1,6 @@
 use super::value::{Closure, Value};
 use crate::{builtin_functions::BuiltinFunction, compiler::lir::Instruction};
 use itertools::Itertools;
-use log;
 use std::collections::HashMap;
 
 #[derive(Clone)]

--- a/compiler/src/vm/tracer.rs
+++ b/compiler/src/vm/tracer.rs
@@ -118,18 +118,18 @@ impl Tracer {
                         "{}, {}, {}, {}",
                         hir_id
                             .map(|id| format!("{id}"))
-                            .unwrap_or("<no hir>".to_string()),
+                            .unwrap_or_else(|| "<no hir>".to_string()),
                         ast_id
                             .map(|id| format!("{id}"))
-                            .unwrap_or("<no ast>".to_string()),
+                            .unwrap_or_else(|| "<no ast>".to_string()),
                         cst_id
                             .map(|id| format!("{id}"))
-                            .unwrap_or("<no cst>".to_string()),
+                            .unwrap_or_else(|| "<no cst>".to_string()),
                         span.map(|((start_line, start_col), (end_line, end_col))| format!(
                             "{}:{} – {}:{}",
                             start_line, start_col, end_line, end_col
                         ))
-                        .unwrap_or("<no location>".to_string())
+                        .unwrap_or_else(|| "<no location>".to_string())
                     )
                 };
                 format!("{caller_location_string:90} {call_string}")

--- a/compiler/src/vm/value.rs
+++ b/compiler/src/vm/value.rs
@@ -134,7 +134,7 @@ where
             Err(it) => ("Error".to_string(), it.into()),
         };
         Value::Struct(hashmap! {
-            Value::Symbol("Type".to_string()) => Value::Symbol(type_.to_string()),
+            Value::Symbol("Type".to_string()) => Value::Symbol(type_),
             Value::Symbol("Value".to_string()) => value,
         })
     }

--- a/compiler/src/vm/value.rs
+++ b/compiler/src/vm/value.rs
@@ -66,7 +66,7 @@ impl Closure {
                 Instruction::CreateClosure {
                     captured: vec![],
                     num_args: 0,
-                    body: lir.instructions.clone(),
+                    body: lir.instructions,
                 },
                 Instruction::Call { num_args: 0 },
                 Instruction::TraceModuleEnds,


### PR DESCRIPTION
There are a few Clippy complaints left:

* AST's `CallReceiver::Call` is not yet created while parsing, but is already handled in the HIR, hence I didn't want to remove it. The parser handling can be done separately.
* Some modules (`fuzzer`, `vm`) contain modules with the same name – do we want to give them a different name or ignore this lint?
* Two `to_*` methods are not idiomatic with respect to using a reference or consuming the value.
* and a few unused methods