### PR TITLE
Parse function declaration with doc comment but no code

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,6 @@ We already have a language server that provides some tooling.
 - fuzz parser
 - remove builtinPrint
 - optimize: tail call optimization
-- parse function declaration with doc comment but no code
 - tracing visualization
 - distinguish packages from normal modules
 - complain about comment lines with too much indentation

--- a/compiler/src/compiler/string_to_rcst.rs
+++ b/compiler/src/compiler/string_to_rcst.rs
@@ -2160,5 +2160,89 @@ mod parse {
                 }
             ))
         );
+        assert_eq!(
+            assignment("foo = # comment\n", 0),
+            Some((
+                "\n",
+                Rcst::Assignment {
+                    name: Box::new(Rcst::TrailingWhitespace {
+                        child: Box::new(Rcst::Identifier("foo".to_string())),
+                        whitespace: vec![Rcst::Whitespace(" ".to_string())],
+                    }),
+                    parameters: vec![],
+                    assignment_sign: Box::new(Rcst::TrailingWhitespace {
+                        child: Box::new(Rcst::EqualsSign),
+                        whitespace: vec![Rcst::Whitespace(" ".to_string())],
+                    }),
+                    body: vec![Rcst::Comment {
+                        octothorpe: Box::new(Rcst::Octothorpe),
+                        comment: " comment".to_string()
+                    }],
+                }
+            ))
+        );
+        // foo =
+        //   # comment
+        // 3
+        assert_eq!(
+            assignment("foo =\n  # comment\n3", 0),
+            Some((
+                "\n3",
+                Rcst::Assignment {
+                    name: Box::new(Rcst::TrailingWhitespace {
+                        child: Box::new(Rcst::Identifier("foo".to_string())),
+                        whitespace: vec![Rcst::Whitespace(" ".to_string())],
+                    }),
+                    parameters: vec![],
+                    assignment_sign: Box::new(Rcst::TrailingWhitespace {
+                        child: Box::new(Rcst::EqualsSign),
+                        whitespace: vec![
+                            Rcst::Newline("\n".to_string()),
+                            Rcst::Whitespace("  ".to_string())
+                        ],
+                    }),
+                    body: vec![Rcst::Comment {
+                        octothorpe: Box::new(Rcst::Octothorpe),
+                        comment: " comment".to_string()
+                    }],
+                }
+            ))
+        );
+        // foo =
+        //   # comment
+        //   5
+        // 3
+        assert_eq!(
+            assignment("foo =\n  # comment\n  5\n3", 0),
+            Some((
+                "\n3",
+                Rcst::Assignment {
+                    name: Box::new(Rcst::TrailingWhitespace {
+                        child: Box::new(Rcst::Identifier("foo".to_string())),
+                        whitespace: vec![Rcst::Whitespace(" ".to_string())],
+                    }),
+                    parameters: vec![],
+                    assignment_sign: Box::new(Rcst::TrailingWhitespace {
+                        child: Box::new(Rcst::EqualsSign),
+                        whitespace: vec![
+                            Rcst::Newline("\n".to_string()),
+                            Rcst::Whitespace("  ".to_string())
+                        ],
+                    }),
+                    body: vec![
+                        Rcst::Comment {
+                            octothorpe: Box::new(Rcst::Octothorpe),
+                            comment: " comment".to_string()
+                        },
+                        Rcst::Newline("\n".to_string()),
+                        Rcst::Whitespace("  ".to_string()),
+                        Rcst::Int {
+                            value: 5u8.into(),
+                            string: "5".to_string()
+                        }
+                    ],
+                }
+            ))
+        );
     }
 }

--- a/compiler/src/compiler/string_to_rcst.rs
+++ b/compiler/src/compiler/string_to_rcst.rs
@@ -2016,7 +2016,7 @@ mod parse {
         let original_assignment_sign = assignment_sign.clone();
         let input_after_assignment_sign = input;
 
-        let (input, more_whitespace) = whitespaces_and_newlines(input, indentation + 1, true);
+        let (input, more_whitespace) = whitespaces_and_newlines(input, indentation + 1, false);
         assignment_sign = assignment_sign.wrap_in_whitespace(more_whitespace.clone());
 
         let is_multiline = name.is_multiline()
@@ -2035,7 +2035,7 @@ mod parse {
                 (input, assignment_sign, body)
             }
         } else {
-            match expression(input, indentation, true, true) {
+            match comment(input).or_else(|| expression(input, indentation, true, true)) {
                 Some((input, expression)) => (input, assignment_sign, vec![expression]),
                 None => (
                     input_after_assignment_sign,


### PR DESCRIPTION
This adds test cases for functions with a doc comment and no code and improves the parser to correctly parse such functions.

![image](https://user-images.githubusercontent.com/81387843/205043356-dba52636-b6fd-46dc-a0d3-0adba692b796.png)

### Checklist
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
