### PR TITLE
Performance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,9 @@ target
 **/perf.data
 **/perf.data.old
 
+# Flamegraph
+*.svg
+
 # Dart/Pub
 **/doc/api/
 .dart_tool/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -140,6 +140,7 @@ dependencies = [
  "num-integer",
  "num-traits",
  "pad",
+ "paste",
  "proptest",
  "rand",
  "regex",
@@ -1049,6 +1050,12 @@ dependencies = [
  "smallvec",
  "windows-sys",
 ]
+
+[[package]]
+name = "paste"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d01a5bd0424d00070b0098dd17ebca6f961a959dead1dbcbbbc1d1cd8d3deeba"
 
 [[package]]
 name = "percent-encoding"

--- a/compiler/Cargo.toml
+++ b/compiler/Cargo.toml
@@ -19,6 +19,7 @@ num-bigint = { version = "0.4.3", features = ["rand"] }
 num-integer = { version = "0.1.45", features = ["i128"] }
 num-traits = { version = "0.2.15", features = ["i128"] }
 pad = "0.1.6"
+paste = "1.0.11"
 proptest = "1.0.0"
 rand = "0.8.5"
 regex = "1.5.5"

--- a/compiler/src/compiler/ast_to_hir.rs
+++ b/compiler/src/compiler/ast_to_hir.rs
@@ -27,8 +27,9 @@ pub trait AstToHir: CstDb + CstToAst {
     fn ast_to_hir_id(&self, id: ast::Id) -> Option<hir::Id>;
     fn cst_to_hir_id(&self, module: Module, id: cst::Id) -> Option<hir::Id>;
 
-    fn hir(&self, module: Module) -> Option<(Arc<Body>, HashMap<hir::Id, ast::Id>)>;
+    fn hir(&self, module: Module) -> Option<HirResult>;
 }
+type HirResult = (Arc<Body>, Arc<HashMap<hir::Id, ast::Id>>);
 
 fn hir_to_ast_id(db: &dyn AstToHir, id: hir::Id) -> Option<ast::Id> {
     let (_, hir_to_ast_id_mapping) = db.hir(id.module.clone()).unwrap();
@@ -57,10 +58,10 @@ fn cst_to_hir_id(db: &dyn AstToHir, module: Module, id: cst::Id) -> Option<hir::
     db.ast_to_hir_id(id)
 }
 
-fn hir(db: &dyn AstToHir, module: Module) -> Option<(Arc<Body>, HashMap<hir::Id, ast::Id>)> {
+fn hir(db: &dyn AstToHir, module: Module) -> Option<HirResult> {
     let (ast, _) = db.ast(module.clone())?;
     let (body, id_mapping) = compile_top_level(db, module, &ast);
-    Some((Arc::new(body), id_mapping))
+    Some((Arc::new(body), Arc::new(id_mapping)))
 }
 
 fn compile_top_level(

--- a/compiler/src/compiler/cst_to_ast.rs
+++ b/compiler/src/compiler/cst_to_ast.rs
@@ -28,7 +28,7 @@ pub trait CstToAst: CstDb + RcstToCst {
     fn ast(&self, module: Module) -> Option<AstResult>;
 }
 
-type AstResult = (Arc<Vec<Ast>>, HashMap<ast::Id, cst::Id>);
+type AstResult = (Arc<Vec<Ast>>, Arc<HashMap<ast::Id, cst::Id>>);
 
 fn ast_to_cst_id(db: &dyn CstToAst, id: ast::Id) -> Option<cst::Id> {
     let (_, ast_to_cst_id_mapping) = db.ast(id.module.clone()).unwrap();
@@ -82,7 +82,7 @@ fn ast(db: &dyn CstToAst, module: Module) -> Option<AstResult> {
         }
     };
 
-    Some((Arc::new(asts), context.id_mapping))
+    Some((Arc::new(asts), Arc::new(context.id_mapping)))
 }
 
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]

--- a/compiler/src/lib.rs
+++ b/compiler/src/lib.rs
@@ -1,6 +1,7 @@
 // Keep these in sync with `main.rs`!
 #![feature(async_closure)]
 #![feature(box_patterns)]
+#![feature(entry_insert)]
 #![feature(let_chains)]
 #![feature(never_type)]
 #![feature(try_trait_v2)]

--- a/compiler/src/main.rs
+++ b/compiler/src/main.rs
@@ -1,6 +1,7 @@
 // Keep these in sync with `lib.rs`!
 #![feature(async_closure)]
 #![feature(box_patterns)]
+#![feature(entry_insert)]
 #![feature(let_chains)]
 #![feature(never_type)]
 #![feature(try_trait_v2)]

--- a/compiler/src/vm/builtin_functions.rs
+++ b/compiler/src/vm/builtin_functions.rs
@@ -424,7 +424,7 @@ impl Heap {
 
     fn text_characters(&mut self, args: &[Pointer]) -> BuiltinResult {
         unpack_and_later_drop!(self, args, |text: &Text| {
-            let text = text.value.clone(); // FIXME: remove clone
+            let text = text.value.clone();
             let character_addresses = text
                 .graphemes(true)
                 .map(|it| self.create_text(it.to_string()))

--- a/compiler/src/vm/builtin_functions.rs
+++ b/compiler/src/vm/builtin_functions.rs
@@ -10,6 +10,7 @@ use itertools::Itertools;
 use num_bigint::BigInt;
 use num_integer::Integer;
 use num_traits::ToPrimitive;
+use paste::paste;
 use std::{ops::Deref, str::FromStr};
 use tracing::{info, span, Level};
 use unicode_segmentation::UnicodeSegmentation;
@@ -130,7 +131,7 @@ macro_rules! unpack {
             let ( $( $arg, )+ ): ( $( UnpackedData<$type>, )+ ) = ( $(
                 UnpackedData {
                     address: $arg,
-                    data: $heap.get($arg).data.clone().try_into()?,
+                    data: (&$heap.get($arg).data).try_into()?,
                 },
             )+ );
 
@@ -151,12 +152,18 @@ macro_rules! unpack_and_later_drop {
             let ( $( $arg, )+ ): ( $( UnpackedData<$type>, )+ ) = ( $(
                 UnpackedData {
                     address: $arg,
-                    data: $heap.get($arg).data.clone().try_into()?,
+                    data: (&$heap.get($arg).data).try_into()?,
                 },
             )+ );
 
+            // Structs are called `struct_`, so we sometimes generate
+            // identifiers containing a double underscore.
+            #[allow(non_snake_case)]
+            $( let paste!([< $arg _address >]) = $arg.address; )+
+
             let result = $body;
-            $( $heap.drop($arg.address); )+
+
+            $( $heap.drop(paste!([< $arg _address >])); )+
             result.into()
         }
     };
@@ -164,7 +171,7 @@ macro_rules! unpack_and_later_drop {
 
 impl Heap {
     fn channel_create(&mut self, args: &[Pointer]) -> BuiltinResult {
-        unpack_and_later_drop!(self, args, |capacity: Int| {
+        unpack_and_later_drop!(self, args, |capacity: &Int| {
             match capacity.value.clone().try_into() {
                 Ok(capacity) => CreateChannel { capacity },
                 Err(_) => return Err("You tried to create a channel with a capacity that is either negative or bigger than the maximum usize.".to_string()),
@@ -173,7 +180,7 @@ impl Heap {
     }
 
     fn channel_send(&mut self, args: &[Pointer]) -> BuiltinResult {
-        unpack_and_later_drop!(self, args, |port: SendPort, packet: Any| {
+        unpack_and_later_drop!(self, args, |port: &SendPort, packet: Any| {
             let mut heap = Heap::default();
             let address = self.clone_single_to_other_heap(&mut heap, packet.address);
             Send {
@@ -184,7 +191,7 @@ impl Heap {
     }
 
     fn channel_receive(&mut self, args: &[Pointer]) -> BuiltinResult {
-        unpack_and_later_drop!(self, args, |port: ReceivePort| {
+        unpack_and_later_drop!(self, args, |port: &ReceivePort| {
             Receive {
                 channel: port.channel,
             }
@@ -199,7 +206,7 @@ impl Heap {
     }
 
     fn function_run(&mut self, args: &[Pointer], responsible: Pointer) -> BuiltinResult {
-        unpack!(self, args, |closure: Closure| {
+        unpack!(self, args, |closure: &Closure| {
             closure.should_take_no_arguments()?;
             DivergeControlFlow {
                 closure: closure.address,
@@ -209,76 +216,82 @@ impl Heap {
     }
 
     fn get_argument_count(&mut self, args: &[Pointer]) -> BuiltinResult {
-        unpack_and_later_drop!(self, args, |closure: Closure| {
-            Return(self.create_int(closure.num_args.into()))
+        unpack_and_later_drop!(self, args, |closure: &Closure| {
+            let num_args = closure.num_args.into();
+            Return(self.create_int(num_args))
         })
     }
 
     fn if_else(&mut self, args: &[Pointer], responsible: Pointer) -> BuiltinResult {
         unpack!(self, args, |condition: bool,
-                             then: Closure,
-                             else_: Closure| {
+                             then: &Closure,
+                             else_: &Closure| {
             let (run, dont_run) = if *condition {
                 (then, else_)
             } else {
                 (else_, then)
             };
-            self.drop(condition.address);
-            self.drop(dont_run.address);
+
+            let condition_address = condition.address;
+            let run_address = run.address;
+            let dont_run_address = dont_run.address;
+            self.drop(condition_address);
+            self.drop(dont_run_address);
+
             DivergeControlFlow {
-                closure: run.address,
+                closure: run_address,
                 responsible,
             }
         })
     }
 
     fn int_add(&mut self, args: &[Pointer]) -> BuiltinResult {
-        unpack_and_later_drop!(self, args, |a: Int, b: Int| {
+        unpack_and_later_drop!(self, args, |a: &Int, b: &Int| {
             Return(self.create_int(&a.value + &b.value))
         })
     }
     fn int_bit_length(&mut self, args: &[Pointer]) -> BuiltinResult {
-        unpack_and_later_drop!(self, args, |a: Int| {
+        unpack_and_later_drop!(self, args, |a: &Int| {
             Return(self.create_int(a.value.bits().into()))
         })
     }
     fn int_bitwise_and(&mut self, args: &[Pointer]) -> BuiltinResult {
-        unpack_and_later_drop!(self, args, |a: Int, b: Int| {
+        unpack_and_later_drop!(self, args, |a: &Int, b: &Int| {
             Return(self.create_int(&a.value & &b.value))
         })
     }
     fn int_bitwise_or(&mut self, args: &[Pointer]) -> BuiltinResult {
-        unpack_and_later_drop!(self, args, |a: Int, b: Int| {
+        unpack_and_later_drop!(self, args, |a: &Int, b: &Int| {
             Return(self.create_int(&a.value | &b.value))
         })
     }
     fn int_bitwise_xor(&mut self, args: &[Pointer]) -> BuiltinResult {
-        unpack_and_later_drop!(self, args, |a: Int, b: Int| {
+        unpack_and_later_drop!(self, args, |a: &Int, b: &Int| {
             Return(self.create_int(&a.value ^ &b.value))
         })
     }
     fn int_compare_to(&mut self, args: &[Pointer]) -> BuiltinResult {
-        unpack_and_later_drop!(self, args, |a: Int, b: Int| {
+        unpack_and_later_drop!(self, args, |a: &Int, b: &Int| {
             Return(self.create_ordering(a.value.cmp(&b.value)))
         })
     }
     fn int_divide_truncating(&mut self, args: &[Pointer]) -> BuiltinResult {
-        unpack_and_later_drop!(self, args, |dividend: Int, divisor: Int| {
+        unpack_and_later_drop!(self, args, |dividend: &Int, divisor: &Int| {
             Return(self.create_int(&dividend.value / &divisor.value))
         })
     }
     fn int_modulo(&mut self, args: &[Pointer]) -> BuiltinResult {
-        unpack_and_later_drop!(self, args, |dividend: Int, divisor: Int| {
+        unpack_and_later_drop!(self, args, |dividend: &Int, divisor: &Int| {
             Return(self.create_int(dividend.value.mod_floor(&divisor.value)))
         })
     }
     fn int_multiply(&mut self, args: &[Pointer]) -> BuiltinResult {
-        unpack_and_later_drop!(self, args, |factor_a: Int, factor_b: Int| {
+        unpack_and_later_drop!(self, args, |factor_a: &Int, factor_b: &Int| {
             Return(self.create_int(&factor_a.value * &factor_b.value))
         })
     }
     fn int_parse(&mut self, args: &[Pointer]) -> BuiltinResult {
-        unpack_and_later_drop!(self, args, |text: Text| {
+        unpack_and_later_drop!(self, args, |text: &Text| {
             let result = match BigInt::from_str(&text.value) {
                 Ok(int) => Ok(self.create_int(int)),
                 Err(err) => Err(self.create_text(format!("{err}"))),
@@ -287,37 +300,38 @@ impl Heap {
         })
     }
     fn int_remainder(&mut self, args: &[Pointer]) -> BuiltinResult {
-        unpack_and_later_drop!(self, args, |dividend: Int, divisor: Int| {
+        unpack_and_later_drop!(self, args, |dividend: &Int, divisor: &Int| {
             Return(self.create_int(&dividend.value % &divisor.value))
         })
     }
     fn int_shift_left(&mut self, args: &[Pointer]) -> BuiltinResult {
-        unpack_and_later_drop!(self, args, |value: Int, amount: Int| {
+        unpack_and_later_drop!(self, args, |value: &Int, amount: &Int| {
             let amount = amount.value.to_u128().unwrap();
             Return(self.create_int(&value.value << amount))
         })
     }
     fn int_shift_right(&mut self, args: &[Pointer]) -> BuiltinResult {
-        unpack_and_later_drop!(self, args, |value: Int, amount: Int| {
+        unpack_and_later_drop!(self, args, |value: &Int, amount: &Int| {
             let amount = amount.value.to_u128().unwrap();
             Return(self.create_int(&value.value >> amount))
         })
     }
     fn int_subtract(&mut self, args: &[Pointer]) -> BuiltinResult {
-        unpack_and_later_drop!(self, args, |minuend: Int, subtrahend: Int| {
+        unpack_and_later_drop!(self, args, |minuend: &Int, subtrahend: &Int| {
             Return(self.create_int(&minuend.value - &subtrahend.value))
         })
     }
 
     fn list_filled(&mut self, args: &[Pointer]) -> BuiltinResult {
-        unpack_and_later_drop!(self, args, |length: Int, item: Any| {
+        unpack_and_later_drop!(self, args, |length: &Int, item: Any| {
             let length = length.value.to_usize().unwrap();
+            let item_address = item.address;
             self.dup_by(item.address, length);
-            Return(self.create_list(vec![item.address; length]))
+            Return(self.create_list(vec![item_address; length]))
         })
     }
     fn list_get(&mut self, args: &[Pointer]) -> BuiltinResult {
-        unpack_and_later_drop!(self, args, |list: List, index: Int| {
+        unpack_and_later_drop!(self, args, |list: &List, index: &Int| {
             let index = index.value.to_usize().unwrap();
             let item = list.items[index];
             self.dup(item);
@@ -325,23 +339,24 @@ impl Heap {
         })
     }
     fn list_insert(&mut self, args: &[Pointer]) -> BuiltinResult {
-        unpack_and_later_drop!(self, args, |list: List, index: Int, item: Any| {
+        unpack_and_later_drop!(self, args, |list: &List, index: &Int, item: Any| {
             let mut new_list = list.items.clone();
 
             let index = index.value.to_usize().unwrap();
+            let item_address = item.address;
             self.dup(item.address);
-            new_list.insert(index, item.address);
+            new_list.insert(index, item_address);
 
             Return(self.create_list(new_list))
         })
     }
     fn list_length(&mut self, args: &[Pointer]) -> BuiltinResult {
-        unpack_and_later_drop!(self, args, |list: List| {
+        unpack_and_later_drop!(self, args, |list: &List| {
             Return(self.create_int(list.items.len().into()))
         })
     }
     fn list_remove_at(&mut self, args: &[Pointer]) -> BuiltinResult {
-        unpack_and_later_drop!(self, args, |list: List, index: Int| {
+        unpack_and_later_drop!(self, args, |list: &List, index: &Int| {
             let mut new_list = list.items.clone();
 
             let index = index.value.to_usize().unwrap();
@@ -351,19 +366,20 @@ impl Heap {
         })
     }
     fn list_replace(&mut self, args: &[Pointer]) -> BuiltinResult {
-        unpack_and_later_drop!(self, args, |list: List, index: Int, new_item: Any| {
+        unpack_and_later_drop!(self, args, |list: &List, index: &Int, new_item: Any| {
             let mut new_list = list.items.clone();
 
             let index = index.value.to_usize().unwrap();
+            let new_item_address = new_item.address;
             self.dup(new_item.address);
-            new_list[index] = new_item.address;
+            new_list[index] = new_item_address;
 
             Return(self.create_list(new_list))
         })
     }
 
     fn parallel(&mut self, args: &[Pointer]) -> BuiltinResult {
-        unpack!(self, args, |body_taking_nursery: Closure| {
+        unpack!(self, args, |body_taking_nursery: &Closure| {
             if body_taking_nursery.num_args != 1 {
                 return Err("`parallel` expects a closure taking a nursery.".to_string());
             }
@@ -381,7 +397,7 @@ impl Heap {
     }
 
     fn struct_get(&mut self, args: &[Pointer]) -> BuiltinResult {
-        unpack_and_later_drop!(self, args, |struct_: Struct, key: Any| {
+        unpack_and_later_drop!(self, args, |struct_: &Struct, key: Any| {
             match struct_.get(self, key.address) {
                 Some(value) => {
                     self.dup(value);
@@ -395,21 +411,21 @@ impl Heap {
         })
     }
     fn struct_get_keys(&mut self, args: &[Pointer]) -> BuiltinResult {
-        unpack_and_later_drop!(self, args, |struct_: Struct| {
+        unpack_and_later_drop!(self, args, |struct_: &Struct| {
             Return(self.create_list(struct_.iter().map(|(key, _)| key).collect_vec()))
         })
     }
     fn struct_has_key(&mut self, args: &[Pointer]) -> BuiltinResult {
-        unpack_and_later_drop!(self, args, |struct_: Struct, key: Any| {
+        unpack_and_later_drop!(self, args, |struct_: &Struct, key: Any| {
             let has_key = struct_.get(self, key.address).is_some();
             Return(self.create_bool(has_key))
         })
     }
 
     fn text_characters(&mut self, args: &[Pointer]) -> BuiltinResult {
-        unpack_and_later_drop!(self, args, |text: Text| {
+        unpack_and_later_drop!(self, args, |text: &Text| {
+            let text = text.value.clone(); // FIXME: remove clone
             let character_addresses = text
-                .value
                 .graphemes(true)
                 .map(|it| self.create_text(it.to_string()))
                 .collect_vec();
@@ -417,22 +433,22 @@ impl Heap {
         })
     }
     fn text_concatenate(&mut self, args: &[Pointer]) -> BuiltinResult {
-        unpack_and_later_drop!(self, args, |text_a: Text, text_b: Text| {
+        unpack_and_later_drop!(self, args, |text_a: &Text, text_b: &Text| {
             Return(self.create_text(format!("{}{}", text_a.value, text_b.value)))
         })
     }
     fn text_contains(&mut self, args: &[Pointer]) -> BuiltinResult {
-        unpack_and_later_drop!(self, args, |text: Text, pattern: Text| {
+        unpack_and_later_drop!(self, args, |text: &Text, pattern: &Text| {
             Return(self.create_bool(text.value.contains(&pattern.value)))
         })
     }
     fn text_ends_with(&mut self, args: &[Pointer]) -> BuiltinResult {
-        unpack_and_later_drop!(self, args, |text: Text, suffix: Text| {
+        unpack_and_later_drop!(self, args, |text: &Text, suffix: &Text| {
             Return(self.create_bool(text.value.ends_with(&suffix.value)))
         })
     }
     fn text_from_utf8(&mut self, args: &[Pointer]) -> BuiltinResult {
-        unpack_and_later_drop!(self, args, |bytes: List| {
+        unpack_and_later_drop!(self, args, |bytes: &List| {
             let bytes = bytes
                 .items
                 .iter()
@@ -453,7 +469,7 @@ impl Heap {
         unpack_and_later_drop!(
             self,
             args,
-            |text: Text, start_inclusive: Int, end_exclusive: Int| {
+            |text: &Text, start_inclusive: &Int, end_exclusive: &Int| {
                 let start_inclusive = start_inclusive.value.to_usize().expect(
                     "Tried to get a range from a text with an index that's too large for usize.",
                 );
@@ -471,28 +487,28 @@ impl Heap {
         )
     }
     fn text_is_empty(&mut self, args: &[Pointer]) -> BuiltinResult {
-        unpack_and_later_drop!(self, args, |text: Text| {
+        unpack_and_later_drop!(self, args, |text: &Text| {
             Return(self.create_bool(text.value.is_empty()))
         })
     }
     fn text_length(&mut self, args: &[Pointer]) -> BuiltinResult {
-        unpack_and_later_drop!(self, args, |text: Text| {
+        unpack_and_later_drop!(self, args, |text: &Text| {
             let length = text.value.graphemes(true).count().into();
             Return(self.create_int(length))
         })
     }
     fn text_starts_with(&mut self, args: &[Pointer]) -> BuiltinResult {
-        unpack_and_later_drop!(self, args, |text: Text, prefix: Text| {
+        unpack_and_later_drop!(self, args, |text: &Text, prefix: &Text| {
             Return(self.create_bool(text.value.starts_with(&prefix.value)))
         })
     }
     fn text_trim_end(&mut self, args: &[Pointer]) -> BuiltinResult {
-        unpack_and_later_drop!(self, args, |text: Text| {
+        unpack_and_later_drop!(self, args, |text: &Text| {
             Return(self.create_text(text.value.trim_end().to_string()))
         })
     }
     fn text_trim_start(&mut self, args: &[Pointer]) -> BuiltinResult {
-        unpack_and_later_drop!(self, args, |text: Text| {
+        unpack_and_later_drop!(self, args, |text: &Text| {
             Return(self.create_text(text.value.trim_start().to_string()))
         })
     }
@@ -505,7 +521,7 @@ impl Heap {
     }
 
     fn try_(&mut self, args: &[Pointer]) -> BuiltinResult {
-        unpack!(self, args, |body: Closure| { Try { body: body.address } })
+        unpack!(self, args, |body: &Closure| { Try { body: body.address } })
     }
 
     fn type_of(&mut self, args: &[Pointer]) -> BuiltinResult {
@@ -548,21 +564,21 @@ impl<T> Deref for UnpackedData<T> {
     }
 }
 
-struct Any {
-    data: Data,
+struct Any<'a> {
+    data: &'a Data,
 }
-impl Deref for Any {
+impl<'a> Deref for Any<'a> {
     type Target = Data;
 
     fn deref(&self) -> &Self::Target {
-        &self.data
+        self.data
     }
 }
 
-impl TryInto<Any> for Data {
+impl<'a> TryInto<Any<'a>> for &'a Data {
     type Error = String;
 
-    fn try_into(self) -> Result<Any, Self::Error> {
+    fn try_into(self) -> Result<Any<'a>, Self::Error> {
         Ok(Any { data: self })
     }
 }

--- a/compiler/src/vm/heap/mod.rs
+++ b/compiler/src/vm/heap/mod.rs
@@ -87,14 +87,9 @@ impl Heap {
         self.dup_by(address, 1);
     }
     pub fn dup_by(&mut self, address: Pointer, amount: usize) {
-        self.get_mut(address).reference_count += amount;
-
-        let object = self.get(address);
-        trace!(
-            "RefCount of {address} increased to {}. Value: {}",
-            object.reference_count,
-            address.format_debug(self),
-        );
+        let object = self.get_mut(address);
+        object.reference_count += amount;
+        let new_reference_count = object.reference_count;
 
         if let Some(channel) = object.data.channel() {
             *self
@@ -103,6 +98,12 @@ impl Heap {
                 .or_insert_with(|| panic!("Called `dup_by` on a channel that doesn't exist.")) +=
                 amount;
         };
+
+        trace!(
+            "RefCount of {address} increased to {}. Value: {}",
+            new_reference_count,
+            address.format_debug(self),
+        );
     }
     pub fn drop(&mut self, address: Pointer) {
         trace!(

--- a/compiler/src/vm/heap/mod.rs
+++ b/compiler/src/vm/heap/mod.rs
@@ -11,10 +11,7 @@ use super::ids::ChannelId;
 use crate::{builtin_functions::BuiltinFunction, compiler::hir::Id};
 use itertools::Itertools;
 use num_bigint::BigInt;
-use std::{
-    cmp::Ordering,
-    collections::{HashMap, HashSet},
-};
+use std::{cmp::Ordering, collections::HashMap};
 
 const TRACE: bool = false;
 
@@ -39,6 +36,7 @@ macro_rules! trace {
 #[derive(Clone)]
 pub struct Heap {
     objects: HashMap<Pointer, Object>,
+    channel_refcounts: HashMap<ChannelId, usize>,
     next_address: Pointer,
 }
 
@@ -64,6 +62,7 @@ impl Default for Heap {
     fn default() -> Self {
         Self {
             objects: HashMap::new(),
+            channel_refcounts: HashMap::new(),
             next_address: Pointer::from_raw(1),
         }
     }
@@ -96,6 +95,14 @@ impl Heap {
             object.reference_count,
             address.format_debug(self),
         );
+
+        if let Some(channel) = object.data.channel() {
+            *self
+                .channel_refcounts
+                .entry(channel)
+                .or_insert_with(|| panic!("Called `dup_by` on a channel that doesn't exist.")) +=
+                amount;
+        };
     }
     pub fn drop(&mut self, address: Pointer) {
         trace!(
@@ -105,8 +112,22 @@ impl Heap {
         );
 
         let object = self.get_mut(address);
+
         object.reference_count -= 1;
-        if object.reference_count == 0 {
+        let new_reference_count = object.reference_count;
+
+        if let Some(channel) = object.data.channel() {
+            let channel_refcount = self
+                .channel_refcounts
+                .entry(channel)
+                .or_insert_with(|| panic!("Called `drop` on a channel that doesn't exist."));
+            *channel_refcount -= 1;
+            if *channel_refcount == 0 {
+                self.channel_refcounts.remove(&channel).unwrap();
+            }
+        };
+
+        if new_reference_count == 0 {
             self.free(address);
         }
     }
@@ -231,14 +252,8 @@ impl Heap {
         self.clone_single_to_other_heap_with_existing_mapping(other, address, &mut HashMap::new())
     }
 
-    pub fn known_channels(&self) -> HashSet<ChannelId> {
-        let mut known = HashSet::new();
-        for object in self.objects.values() {
-            if let Some(channel) = object.data.channel() {
-                known.insert(channel);
-            }
-        }
-        known
+    pub fn known_channels(&self) -> impl IntoIterator<Item = ChannelId> + '_ {
+        self.channel_refcounts.keys().copied()
     }
 
     pub fn create_int(&mut self, int: BigInt) -> Pointer {
@@ -263,9 +278,13 @@ impl Heap {
         self.create(Data::Builtin(Builtin { function: builtin }))
     }
     pub fn create_send_port(&mut self, channel: ChannelId) -> Pointer {
+        let existing_count = self.channel_refcounts.insert(channel, 1);
+        assert!(existing_count.is_none());
         self.create(Data::SendPort(SendPort::new(channel)))
     }
     pub fn create_receive_port(&mut self, channel: ChannelId) -> Pointer {
+        let existing_count = self.channel_refcounts.insert(channel, 1);
+        assert!(existing_count.is_none());
         self.create(Data::ReceivePort(ReceivePort::new(channel)))
     }
     pub fn create_nothing(&mut self) -> Pointer {

--- a/compiler/src/vm/heap/object.rs
+++ b/compiler/src/vm/heap/object.rs
@@ -347,6 +347,16 @@ macro_rules! impl_data_try_into_type {
                 }
             }
         }
+        impl<'a> TryInto<&'a $type> for &'a Data {
+            type Error = String;
+
+            fn try_into(self) -> Result<&'a $type, Self::Error> {
+                match &self {
+                    Data::$variant(it) => Ok(it),
+                    _ => Err($error_message.to_string()),
+                }
+            }
+        }
     };
 }
 impl_data_try_into_type!(Int, Int, "Expected an int.");
@@ -359,11 +369,11 @@ impl_data_try_into_type!(Closure, Closure, "Expected a closure.");
 impl_data_try_into_type!(SendPort, SendPort, "Expected a send port.");
 impl_data_try_into_type!(ReceivePort, ReceivePort, "Expected a receive port.");
 
-impl TryInto<bool> for Data {
+impl TryInto<bool> for &Data {
     type Error = String;
 
     fn try_into(self) -> Result<bool, Self::Error> {
-        let symbol: Symbol = self.try_into()?;
+        let symbol: &Symbol = self.try_into()?;
         match symbol.value.as_str() {
             "True" => Ok(true),
             "False" => Ok(false),

--- a/compiler/src/vm/heap/object.rs
+++ b/compiler/src/vm/heap/object.rs
@@ -258,6 +258,13 @@ impl Data {
         }
     }
 
+    pub fn closure(&self) -> Option<&Closure> {
+        if let Data::Closure(closure) = self {
+            Some(closure)
+        } else {
+            None
+        }
+    }
     pub fn channel(&self) -> Option<ChannelId> {
         if let Data::SendPort(SendPort { channel }) | Data::ReceivePort(ReceivePort { channel }) =
             self

--- a/compiler/src/vm/mod.rs
+++ b/compiler/src/vm/mod.rs
@@ -472,7 +472,7 @@ impl Vm {
         let mut known_channels = HashSet::new();
         for fiber in self.fibers.values() {
             if let Some(single) = fiber.as_single() {
-                known_channels.extend(single.fiber.heap.known_channels().into_iter());
+                known_channels.extend(single.fiber.heap.known_channels());
             }
         }
         // Because we don't track yet which channels have leaked to the outside


### PR DESCRIPTION
<!-- Please enter the corresponding issue ID: -->

<!-- Add the breaking label (PR: BREAKING) if applicable. -->

<!-- Please summarize your changes: -->
These performance improvements affect both the compilation and execution time. Detailed information can be found in the commit messages. Here's an overview of `hyperfine "cargo run --release --manifest-path=compiler/Cargo.toml -- run packages/examples/fibonacci.candy"` of Fibonacci calculation after these optimizations:

`fibonacci 8`, initial

```
Time (mean ± σ):      1.001 s ±  0.049 s    [User: 0.928 s, System: 0.066 s]
Range (min … max):    0.962 s …  1.099 s    10 runs
```

HIR/AST/CST ID mapping `Arc`

```
Time (mean ± σ):     933.9 ms ±  25.9 ms    [User: 867.5 ms, System: 65.6 ms]
Range (min … max):   904.3 ms … 973.4 ms    10 runs
```

Then, I changed the calculation to `fibonacci 15`.


```
Time (mean ± σ):      2.428 s ±  0.120 s    [User: 2.343 s, System: 0.076 s]
Range (min … max):    2.279 s …  2.658 s    10 runs
```

Channel refcounts

```
Time (mean ± σ):      1.584 s ±  0.092 s    [User: 1.501 s, System: 0.075 s]
Range (min … max):    1.499 s …  1.820 s    10 runs
```

Duplicate lookup in `dup_by`

```
Time (mean ± σ):      1.406 s ±  0.075 s    [User: 1.335 s, System: 0.070 s]
Range (min … max):    1.349 s …  1.605 s    10 runs
```

Cloning arguments in builtin functions

```
Time (mean ± σ):      1.342 s ±  0.062 s    [User: 1.268 s, System: 0.071 s]
Range (min … max):    1.273 s …  1.471 s    10 runs
```

Duplicate lookup in CSE

```
Time (mean ± σ):      1.310 s ±  0.062 s    [User: 1.238 s, System: 0.070 s]
Range (min … max):    1.235 s …  1.418 s    10 runs
```



### Checklist
<!-- Please check if your PR fulfills the following requirements: -->

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
