### PR TITLE
Make debug outputs more concise

### DIFF
--- a/compiler/src/compiler/ast.rs
+++ b/compiler/src/compiler/ast.rs
@@ -420,6 +420,6 @@ impl Display for Call {
 }
 impl Display for AstString {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        write!(f, #"{}@"{}""#, self.id.to_short_debug_string(), self.value)
+        write!(f, r#"{}@"{}""#, self.id.to_short_debug_string(), self.value)
     }
 }

--- a/compiler/src/compiler/ast.rs
+++ b/compiler/src/compiler/ast.rs
@@ -25,6 +25,9 @@ impl Id {
     pub fn new(module: Module, local: usize) -> Self {
         Self { module, local }
     }
+    pub fn to_short_debug_string(&self) -> String {
+        format!("${}", self.local)
+    }
 }
 impl Display for Id {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
@@ -276,7 +279,7 @@ impl CollectErrors for Vec<Ast> {
 
 impl Display for Ast {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        write!(f, "{}: ", self.id)?;
+        write!(f, "{}: ", self.id.to_short_debug_string())?;
         match &self.kind {
             AstKind::Int(Int(int)) => write!(f, "int {}", int),
             AstKind::Text(Text(parts)) => {
@@ -371,7 +374,14 @@ impl Display for Lambda {
             } else {
                 "non-fuzzable"
             },
-            self.parameters.iter().map(|it| format!("{it}")).join(" "),
+            if self.parameters.is_empty() {
+                "".to_string()
+            } else {
+                format!(
+                    "{} ->",
+                    self.parameters.iter().map(|it| format!("{it}")).join(" ")
+                )
+            },
             self.body
                 .iter()
                 .map(|it| format!("{it}"))
@@ -400,13 +410,16 @@ impl Display for Call {
             self.receiver,
             self.arguments
                 .iter()
-                .map(|argument| format!("  {argument}"))
+                .map(|argument| format!("{argument}"))
+                .join("\n")
+                .lines()
+                .map(|line| format!("  {line}"))
                 .join("\n")
         )
     }
 }
 impl Display for AstString {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        write!(f, "{}@\"{}\"", self.id, self.value)
+        write!(f, "{}@\"{}\"", self.id.to_short_debug_string(), self.value)
     }
 }

--- a/compiler/src/compiler/ast.rs
+++ b/compiler/src/compiler/ast.rs
@@ -379,7 +379,7 @@ impl Display for Lambda {
             } else {
                 format!(
                     "{} ->",
-                    self.parameters.iter().map(|it| format!("{it}")).join(" ")
+                    self.parameters.iter().map(|it| format!("{it}")).join(" "),
                 )
             },
             self.body
@@ -420,6 +420,6 @@ impl Display for Call {
 }
 impl Display for AstString {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        write!(f, "{}@\"{}\"", self.id.to_short_debug_string(), self.value)
+        write!(f, #"{}@"{}""#, self.id.to_short_debug_string(), self.value)
     }
 }

--- a/compiler/src/compiler/hir.rs
+++ b/compiler/src/compiler/hir.rs
@@ -156,6 +156,10 @@ impl Id {
         Self::tooling("complicated-responsibility".to_string())
     }
 
+    pub fn to_short_debug_string(&self) -> String {
+        format!("${}", self.keys.iter().join(":"))
+    }
+
     pub fn is_root(&self) -> bool {
         self.keys.is_empty()
     }
@@ -317,13 +321,18 @@ impl fmt::Display for Expression {
         match self {
             Expression::Int(int) => write!(f, "int {int}"),
             Expression::Text(text) => write!(f, "text {text:?}"),
-            Expression::Reference(reference) => write!(f, "reference {reference}"),
+            Expression::Reference(reference) => {
+                write!(f, "reference {}", reference.to_short_debug_string())
+            }
             Expression::Symbol(symbol) => write!(f, "symbol {symbol}"),
             Expression::List(items) => {
                 write!(
                     f,
                     "list (\n{}\n)",
-                    items.iter().map(|item| format!("  {item},")).join("\n"),
+                    items
+                        .iter()
+                        .map(|item| format!("  {},", item.to_short_debug_string()))
+                        .join("\n"),
                 )
             }
             Expression::Struct(entries) => {
@@ -332,21 +341,30 @@ impl fmt::Display for Expression {
                     "struct [\n{}\n]",
                     entries
                         .iter()
-                        .map(|(key, value)| format!("  {key}: {value},"))
+                        .map(|(key, value)| format!(
+                            "  {}: {},",
+                            key.to_short_debug_string(),
+                            value.to_short_debug_string()
+                        ))
                         .join("\n"),
                 )
             }
             Expression::Destructure {
                 expression,
                 pattern,
-            } => write!(f, "destructure {expression} into {pattern}"),
+            } => write!(
+                f,
+                "destructure {} into {pattern}",
+                expression.to_short_debug_string()
+            ),
             Expression::PatternIdentifierReference {
                 destructuring,
                 identifier_id,
             } => write!(
                 f,
-                "get destructured p${} from {destructuring}",
-                identifier_id.0
+                "get destructured p${} from {}",
+                identifier_id.0,
+                destructuring.to_short_debug_string(),
             ),
             Expression::Lambda(lambda) => {
                 write!(
@@ -375,10 +393,11 @@ impl fmt::Display for Expression {
                 assert!(!arguments.is_empty(), "A call needs to have arguments.");
                 write!(
                     f,
-                    "call {function} with these arguments:\n{}",
+                    "call {} with these arguments:\n{}",
+                    function.to_short_debug_string(),
                     arguments
                         .iter()
-                        .map(|argument| format!("  {argument}"))
+                        .map(|argument| format!("  {}", argument.to_short_debug_string()))
                         .join("\n")
                 )
             }
@@ -388,10 +407,16 @@ impl fmt::Display for Expression {
             } => write!(
                 f,
                 "use module {} relative to {}",
-                relative_path, current_module
+                relative_path.to_short_debug_string(),
+                current_module
             ),
             Expression::Needs { condition, reason } => {
-                write!(f, "needs {condition} with reason {reason}")
+                write!(
+                    f,
+                    "needs {} with reason {}",
+                    condition.to_short_debug_string(),
+                    reason.to_short_debug_string(),
+                )
             }
             Expression::Error { child, errors } => {
                 write!(f, "{}", if errors.len() == 1 { "error" } else { "errors" })?;
@@ -454,7 +479,7 @@ impl fmt::Display for Lambda {
             "{} ->",
             self.parameters
                 .iter()
-                .map(|parameter| format!("{parameter}"))
+                .map(|parameter| parameter.to_short_debug_string())
                 .join(" "),
         )?;
         write!(f, "{}", self.body)?;
@@ -464,7 +489,7 @@ impl fmt::Display for Lambda {
 impl fmt::Display for Body {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         for (id, expression) in &self.expressions {
-            writeln!(f, "{id} = {expression}")?;
+            writeln!(f, "{} = {expression}", id.to_short_debug_string())?;
         }
         Ok(())
     }

--- a/compiler/src/compiler/hir.rs
+++ b/compiler/src/compiler/hir.rs
@@ -344,7 +344,7 @@ impl fmt::Display for Expression {
                         .map(|(key, value)| format!(
                             "  {}: {},",
                             key.to_short_debug_string(),
-                            value.to_short_debug_string()
+                            value.to_short_debug_string(),
                         ))
                         .join("\n"),
                 )
@@ -355,7 +355,7 @@ impl fmt::Display for Expression {
             } => write!(
                 f,
                 "destructure {} into {pattern}",
-                expression.to_short_debug_string()
+                expression.to_short_debug_string(),
             ),
             Expression::PatternIdentifierReference {
                 destructuring,
@@ -398,7 +398,7 @@ impl fmt::Display for Expression {
                     arguments
                         .iter()
                         .map(|argument| format!("  {}", argument.to_short_debug_string()))
-                        .join("\n")
+                        .join("\n"),
                 )
             }
             Expression::UseModule {
@@ -408,7 +408,7 @@ impl fmt::Display for Expression {
                 f,
                 "use module {} relative to {}",
                 relative_path.to_short_debug_string(),
-                current_module
+                current_module,
             ),
             Expression::Needs { condition, reason } => {
                 write!(

--- a/compiler/src/main.rs
+++ b/compiler/src/main.rs
@@ -185,7 +185,13 @@ fn raw_build(
             &ast_cst_id_map
                 .keys()
                 .sorted_by_key(|it| it.local)
-                .map(|key| format!("{key} -> {}\n", ast_cst_id_map[key].0))
+                .map(|key| {
+                    format!(
+                        "{} -> {}\n",
+                        key.to_short_debug_string(),
+                        ast_cst_id_map[key].0,
+                    )
+                })
                 .join(""),
         );
     }
@@ -197,7 +203,13 @@ fn raw_build(
             "hir_to_ast_ids",
             &hir_ast_id_map
                 .keys()
-                .map(|key| format!("{key} -> {}\n", hir_ast_id_map[key]))
+                .map(|key| {
+                    format!(
+                        "{} -> {}\n",
+                        key.to_short_debug_string(),
+                        hir_ast_id_map[key].to_short_debug_string(),
+                    )
+                })
                 .join(""),
         );
     }


### PR DESCRIPTION
This PR adds short stringifications for AST and HIR IDs so that the debug outputs are more readable