### PR TITLE
More `RichIr` features

### DIFF
--- a/.github/labels.yaml
+++ b/.github/labels.yaml
@@ -8,7 +8,7 @@
   - compiler/language_server/**/*
 'P: Compiler: VM':
   - compiler/vm/**/*
+'P: Compiler: VS Code Extension':
+  - vscode_extension/**/*
 'P: Core':
   - packages/Core/**/*
-'P: VS Code Extension':
-  - vscode_extension/**/*

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -89,7 +89,7 @@ dependencies = [
  "candy_fuzzer",
  "candy_language_server",
  "candy_vm",
- "clap 4.1.7",
+ "clap 4.1.8",
  "itertools",
  "notify",
  "notify-debouncer-mini",
@@ -262,9 +262,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.1.7"
+version = "4.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f3061d6db6d8fcbbd4b05e057f2acace52e64e96b498c08c2d7a4e65addd340"
+checksum = "c3d7ae14b20b94cb02149ed21a86c423859cbe18dc7ed69845cace50e52b40a5"
 dependencies = [
  "bitflags",
  "clap_derive",
@@ -277,9 +277,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.1.7"
+version = "4.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34d122164198950ba84a918270a3bb3f7ededd25e15f7451673d986f55bd2667"
+checksum = "44bec8e5c9d09e439c4335b1af0abaab56dcf3b94999a936e1bb47b9134288f0"
 dependencies = [
  "heck 0.4.0",
  "proc-macro-error",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -89,7 +89,7 @@ dependencies = [
  "candy_fuzzer",
  "candy_language_server",
  "candy_vm",
- "clap 4.1.4",
+ "clap 4.1.7",
  "itertools",
  "notify",
  "notify-debouncer-mini",
@@ -262,9 +262,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.1.4"
+version = "4.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f13b9c79b5d1dd500d20ef541215a6423c75829ef43117e1b4d17fd8af0b5d76"
+checksum = "2f3061d6db6d8fcbbd4b05e057f2acace52e64e96b498c08c2d7a4e65addd340"
 dependencies = [
  "bitflags",
  "clap_derive",
@@ -277,9 +277,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.1.0"
+version = "4.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "684a277d672e91966334af371f1a7b5833f9aa00b07c84e92fbce95e00208ce8"
+checksum = "34d122164198950ba84a918270a3bb3f7ededd25e15f7451673d986f55bd2667"
 dependencies = [
  "heck 0.4.0",
  "proc-macro-error",

--- a/compiler/cli/Cargo.toml
+++ b/compiler/cli/Cargo.toml
@@ -13,7 +13,7 @@ candy_frontend = { path = "../frontend" }
 candy_fuzzer = { path = "../fuzzer" }
 candy_language_server = { path = "../language_server" }
 candy_vm = { path = "../vm" }
-clap = { version = "4.1.4", features = ["derive"] }
+clap = { version = "4.1.7", features = ["derive"] }
 itertools = { version = "0.10.0" }
 notify = "5.1.0"
 notify-debouncer-mini = { version = "0.2.1", default-features = false }

--- a/compiler/cli/Cargo.toml
+++ b/compiler/cli/Cargo.toml
@@ -13,7 +13,7 @@ candy_frontend = { path = "../frontend" }
 candy_fuzzer = { path = "../fuzzer" }
 candy_language_server = { path = "../language_server" }
 candy_vm = { path = "../vm" }
-clap = { version = "4.1.7", features = ["derive"] }
+clap = { version = "4.1.8", features = ["derive"] }
 itertools = { version = "0.10.0" }
 notify = "5.1.0"
 notify-debouncer-mini = { version = "0.2.1", default-features = false }

--- a/compiler/cli/src/main.rs
+++ b/compiler/cli/src/main.rs
@@ -149,13 +149,9 @@ fn raw_build(
     tracing: &TracingConfig,
     debug: bool,
 ) -> Option<Arc<Lir>> {
-    let rcst = db.rcst(module.clone()).unwrap_or_else(|err| {
-        panic!(
-            "Error parsing file `{}`: {:?}",
-            <Module as ToRichIr<Module>>::to_rich_ir(&module),
-            err,
-        )
-    });
+    let rcst = db
+        .rcst(module.clone())
+        .unwrap_or_else(|err| panic!("Error parsing file `{}`: {:?}", module.to_rich_ir(), err));
     if debug {
         module.dump_associated_debug_file("rcst", &format!("{}\n", rcst.to_rich_ir()));
     }
@@ -213,7 +209,7 @@ fn raw_build(
         let range = db.range_to_positions(module.clone(), span);
         warn!(
             "{}:{}:{} – {}:{}: {payload}",
-            <Module as ToRichIr<Module>>::to_rich_ir(&module),
+            module.to_rich_ir(),
             range.start.line,
             range.start.character,
             range.end.line,
@@ -484,10 +480,7 @@ fn fuzz(options: CandyFuzzOptions) -> ProgramResult {
         return Err(Exit::FileNotFound);
     }
 
-    debug!(
-        "Fuzzing `{}`.",
-        <Module as ToRichIr<Module>>::to_rich_ir(&module),
-    );
+    debug!("Fuzzing `{}`.", module.to_rich_ir());
     let failing_cases = candy_fuzzer::fuzz(&db, module);
 
     if failing_cases.is_empty() {

--- a/compiler/frontend/src/ast.rs
+++ b/compiler/frontend/src/ast.rs
@@ -36,12 +36,7 @@ impl Id {
 }
 impl Display for Id {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-        write!(
-            f,
-            "AstId({}:{})",
-            <Module as ToRichIr<Module>>::to_rich_ir(&self.module),
-            self.local,
-        )
+        write!(f, "AstId({}:{})", &self.module.to_rich_ir(), self.local)
     }
 }
 
@@ -388,8 +383,8 @@ impl CollectErrors for Vec<Ast> {
     }
 }
 
-impl ToRichIr<()> for Ast {
-    fn build_rich_ir(&self, builder: &mut RichIrBuilder<()>) {
+impl ToRichIr for Ast {
+    fn build_rich_ir(&self, builder: &mut RichIrBuilder) {
         match &self.kind {
             AstKind::Int(int) => int.build_rich_ir(builder),
             AstKind::Text(text) => text.build_rich_ir(builder),
@@ -416,43 +411,43 @@ impl ToRichIr<()> for Ast {
         }
     }
 }
-impl ToRichIr<()> for Int {
-    fn build_rich_ir(&self, builder: &mut RichIrBuilder<()>) {
+impl ToRichIr for Int {
+    fn build_rich_ir(&self, builder: &mut RichIrBuilder) {
         builder.push(format!("int {}", self.0), TokenType::Int, EnumSet::empty());
     }
 }
-impl ToRichIr<()> for Text {
-    fn build_rich_ir(&self, builder: &mut RichIrBuilder<()>) {
+impl ToRichIr for Text {
+    fn build_rich_ir(&self, builder: &mut RichIrBuilder) {
         builder.push("text", None, EnumSet::empty());
         builder.push_foldable(|builder| builder.push_children_multiline(&self.0));
     }
 }
-impl ToRichIr<()> for TextPart {
-    fn build_rich_ir(&self, builder: &mut RichIrBuilder<()>) {
+impl ToRichIr for TextPart {
+    fn build_rich_ir(&self, builder: &mut RichIrBuilder) {
         builder.push("textPart ", None, EnumSet::empty());
         self.0.build_rich_ir(builder);
     }
 }
-impl ToRichIr<()> for Identifier {
-    fn build_rich_ir(&self, builder: &mut RichIrBuilder<()>) {
+impl ToRichIr for Identifier {
+    fn build_rich_ir(&self, builder: &mut RichIrBuilder) {
         builder.push("identifier ", None, EnumSet::empty());
         self.0.build_rich_ir(builder);
     }
 }
-impl ToRichIr<()> for Symbol {
-    fn build_rich_ir(&self, builder: &mut RichIrBuilder<()>) {
+impl ToRichIr for Symbol {
+    fn build_rich_ir(&self, builder: &mut RichIrBuilder) {
         builder.push("symbol ", None, EnumSet::empty());
         self.0.build_rich_ir(builder);
     }
 }
-impl ToRichIr<()> for List {
-    fn build_rich_ir(&self, builder: &mut RichIrBuilder<()>) {
+impl ToRichIr for List {
+    fn build_rich_ir(&self, builder: &mut RichIrBuilder) {
         builder.push("list", None, EnumSet::empty());
         builder.push_foldable(|builder| builder.push_children_multiline(&self.0));
     }
 }
-impl ToRichIr<()> for Struct {
-    fn build_rich_ir(&self, builder: &mut RichIrBuilder<()>) {
+impl ToRichIr for Struct {
+    fn build_rich_ir(&self, builder: &mut RichIrBuilder) {
         builder.push("struct", None, EnumSet::empty());
         builder.push_foldable(|builder| {
             builder.push_children_custom_multiline(&self.fields, |builder, (key, value)| {
@@ -466,16 +461,16 @@ impl ToRichIr<()> for Struct {
         });
     }
 }
-impl ToRichIr<()> for StructAccess {
-    fn build_rich_ir(&self, builder: &mut RichIrBuilder<()>) {
+impl ToRichIr for StructAccess {
+    fn build_rich_ir(&self, builder: &mut RichIrBuilder) {
         builder.push("struct access ", None, EnumSet::empty());
         self.struct_.build_rich_ir(builder);
         builder.push(".", None, EnumSet::empty());
         self.key.build_rich_ir(builder); // TODO: `lowercase_first_letter()`?
     }
 }
-impl ToRichIr<()> for Lambda {
-    fn build_rich_ir(&self, builder: &mut RichIrBuilder<()>) {
+impl ToRichIr for Lambda {
+    fn build_rich_ir(&self, builder: &mut RichIrBuilder) {
         builder.push(
             format!(
                 "lambda ({}) {{",
@@ -502,16 +497,16 @@ impl ToRichIr<()> for Lambda {
         builder.push("}", None, EnumSet::empty());
     }
 }
-impl ToRichIr<()> for Call {
-    fn build_rich_ir(&self, builder: &mut RichIrBuilder<()>) {
+impl ToRichIr for Call {
+    fn build_rich_ir(&self, builder: &mut RichIrBuilder) {
         builder.push("call ", None, EnumSet::empty());
         self.receiver.build_rich_ir(builder);
         builder.push(" with these arguments:", None, EnumSet::empty());
         builder.push_foldable(|builder| builder.push_children_multiline(&self.arguments));
     }
 }
-impl ToRichIr<()> for Assignment {
-    fn build_rich_ir(&self, builder: &mut RichIrBuilder<()>) {
+impl ToRichIr for Assignment {
+    fn build_rich_ir(&self, builder: &mut RichIrBuilder) {
         builder.push("assignment: ", None, EnumSet::empty());
         match &self.body {
             AssignmentBody::Lambda { name, .. } => name.build_rich_ir(builder),
@@ -530,23 +525,23 @@ impl ToRichIr<()> for Assignment {
         }
     }
 }
-impl ToRichIr<()> for Match {
-    fn build_rich_ir(&self, builder: &mut RichIrBuilder<()>) {
+impl ToRichIr for Match {
+    fn build_rich_ir(&self, builder: &mut RichIrBuilder) {
         builder.push("match ", None, EnumSet::empty());
         self.expression.build_rich_ir(builder);
         builder.push(" %", None, EnumSet::empty());
         builder.push_foldable(|builder| builder.push_children_multiline(&self.cases));
     }
 }
-impl ToRichIr<()> for MatchCase {
-    fn build_rich_ir(&self, builder: &mut RichIrBuilder<()>) {
+impl ToRichIr for MatchCase {
+    fn build_rich_ir(&self, builder: &mut RichIrBuilder) {
         self.pattern.build_rich_ir(builder);
         builder.push(" -> ", None, EnumSet::empty());
         builder.push_foldable(|builder| builder.push_children_multiline(&self.body));
     }
 }
-impl ToRichIr<()> for OrPattern {
-    fn build_rich_ir(&self, builder: &mut RichIrBuilder<()>) {
+impl ToRichIr for OrPattern {
+    fn build_rich_ir(&self, builder: &mut RichIrBuilder) {
         self.0.first().unwrap().build_rich_ir(builder);
         for pattern in self.0.iter().skip(1) {
             builder.push(" | ", None, EnumSet::empty());
@@ -554,8 +549,8 @@ impl ToRichIr<()> for OrPattern {
         }
     }
 }
-impl ToRichIr<()> for AstString {
-    fn build_rich_ir(&self, builder: &mut RichIrBuilder<()>) {
+impl ToRichIr for AstString {
+    fn build_rich_ir(&self, builder: &mut RichIrBuilder) {
         builder.push(
             format!(r#"{}@"{}""#, self.id.to_short_debug_string(), self.value),
             TokenType::Text,

--- a/compiler/frontend/src/cst_to_ast.rs
+++ b/compiler/frontend/src/cst_to_ast.rs
@@ -63,14 +63,14 @@ fn ast(db: &dyn CstToAst, module: Module) -> Option<AstResult> {
         Err(InvalidModuleError::DoesNotExist) => {
             warn!(
                 "Tried to get AST of module that doesn't exist: {}.",
-                <Module as ToRichIr<Module>>::to_rich_ir(&module),
+                module.to_rich_ir(),
             );
             return None;
         }
         Err(InvalidModuleError::IsToolingModule) => {
             warn!(
                 "Tried to get AST of tooling module: {}.",
-                <Module as ToRichIr<Module>>::to_rich_ir(&module),
+                module.to_rich_ir(),
             );
             return None;
         }

--- a/compiler/frontend/src/error.rs
+++ b/compiler/frontend/src/error.rs
@@ -4,7 +4,7 @@ use super::{ast::AstError, cst, hir::HirError, rcst::RcstError};
 use crate::{
     module::Module,
     position::Offset,
-    rich_ir::{RichIrBuilder, ToRichIr},
+    rich_ir::{ReferenceKey, RichIrBuilder, ToRichIr},
 };
 use std::{fmt::Display, hash::Hash, ops::Range};
 
@@ -167,14 +167,20 @@ impl CompilerError {
 
 impl ToRichIr for CompilerError {
     fn build_rich_ir(&self, builder: &mut RichIrBuilder) {
-        self.module.build_rich_ir(builder);
-        builder.push(
+        let range = builder.push(
             format!(
-                " (span: {} – {}): {}",
-                *self.span.start, *self.span.end, self.payload,
+                "{} (span: {} – {})",
+                self.module.to_rich_ir(),
+                *self.span.start,
+                *self.span.end,
             ),
             None,
             EnumSet::empty(),
         );
+        builder.push_reference(
+            ReferenceKey::ModuleWithSpan(self.module.clone(), self.span.to_owned()),
+            range,
+        );
+        builder.push(format!(": {}", self.payload), None, EnumSet::empty());
     }
 }

--- a/compiler/frontend/src/error.rs
+++ b/compiler/frontend/src/error.rs
@@ -14,18 +14,6 @@ pub struct CompilerError {
     pub span: Range<Offset>,
     pub payload: CompilerErrorPayload,
 }
-impl Display for CompilerError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(
-            f,
-            "{} span({} – {}): {}",
-            self.module.to_rich_ir(),
-            *self.span.start,
-            *self.span.end,
-            self.payload,
-        )
-    }
-}
 
 #[derive(Debug, PartialEq, Eq, Clone, Hash)]
 pub enum CompilerErrorPayload {
@@ -179,7 +167,14 @@ impl CompilerError {
 
 impl ToRichIr for CompilerError {
     fn build_rich_ir(&self, builder: &mut RichIrBuilder) {
-        // TODO: include more rich information
-        builder.push(self.to_string(), None, EnumSet::empty());
+        self.module.build_rich_ir(builder);
+        builder.push(
+            format!(
+                " (span: {} – {}): {}",
+                *self.span.start, *self.span.end, self.payload,
+            ),
+            None,
+            EnumSet::empty(),
+        );
     }
 }

--- a/compiler/frontend/src/error.rs
+++ b/compiler/frontend/src/error.rs
@@ -19,7 +19,7 @@ impl Display for CompilerError {
         write!(
             f,
             "{} span({} – {}): {}",
-            <Module as ToRichIr<Module>>::to_rich_ir(&self.module),
+            self.module.to_rich_ir(),
             *self.span.start,
             *self.span.end,
             self.payload,
@@ -177,8 +177,8 @@ impl CompilerError {
     }
 }
 
-impl<RK: Eq + Hash> ToRichIr<RK> for CompilerError {
-    fn build_rich_ir(&self, builder: &mut RichIrBuilder<RK>) {
+impl ToRichIr for CompilerError {
+    fn build_rich_ir(&self, builder: &mut RichIrBuilder) {
         // TODO: include more rich information
         builder.push(self.to_string(), None, EnumSet::empty());
     }

--- a/compiler/frontend/src/hir.rs
+++ b/compiler/frontend/src/hir.rs
@@ -535,7 +535,7 @@ impl ToRichIr for Expression {
             } => {
                 builder.push("use module ", None, EnumSet::empty());
                 current_module.build_rich_ir(builder);
-                builder.push(" relative to", None, EnumSet::empty());
+                builder.push(" relative to ", None, EnumSet::empty());
                 relative_path.build_rich_ir(builder);
             }
             Expression::Needs { condition, reason } => {

--- a/compiler/frontend/src/hir.rs
+++ b/compiler/frontend/src/hir.rs
@@ -4,10 +4,9 @@ use crate::{
     error::CompilerError,
     id::CountableId,
     module::{Module, ModuleKind, Package},
-    rich_ir::{RichIrBuilder, ToRichIr, TokenModifier, TokenType},
+    rich_ir::{ReferenceKey, RichIrBuilder, ToRichIr, TokenModifier, TokenType},
 };
 
-use derive_more::From;
 use enumset::EnumSet;
 use itertools::Itertools;
 use linked_hash_map::LinkedHashMap;
@@ -204,7 +203,7 @@ impl Debug for Id {
         write!(
             f,
             "HirId({}:{})",
-            <Module as ToRichIr<Module>>::to_rich_ir(&self.module).text,
+            self.module.to_rich_ir(),
             self.keys.iter().join(":"),
         )
     }
@@ -214,8 +213,8 @@ impl Display for Id {
         write!(f, "{self:?}")
     }
 }
-impl ToRichIr<HirReferenceKey> for Id {
-    fn build_rich_ir(&self, builder: &mut RichIrBuilder<HirReferenceKey>) {
+impl ToRichIr for Id {
+    fn build_rich_ir(&self, builder: &mut RichIrBuilder) {
         let range = builder.push(
             self.to_short_debug_string(),
             TokenType::Variable,
@@ -296,8 +295,8 @@ impl Display for PatternIdentifierId {
         write!(f, "p${}", self.0)
     }
 }
-impl ToRichIr<HirReferenceKey> for PatternIdentifierId {
-    fn build_rich_ir(&self, builder: &mut RichIrBuilder<HirReferenceKey>) {
+impl ToRichIr for PatternIdentifierId {
+    fn build_rich_ir(&self, builder: &mut RichIrBuilder) {
         // TODO: convert to actual reference
         builder.push(self.to_string(), TokenType::Variable, EnumSet::empty());
     }
@@ -431,22 +430,12 @@ impl Body {
     }
 }
 
-#[derive(Debug, PartialEq, Eq, Hash, From)]
-pub enum HirReferenceKey {
-    Module(Module),
-    Id(Id),
-    Int(BigUint),
-    Text(String),
-    #[from(ignore)]
-    Symbol(String),
-    BuiltinFunction(BuiltinFunction),
-}
-impl ToRichIr<HirReferenceKey> for Expression {
-    fn build_rich_ir(&self, builder: &mut RichIrBuilder<HirReferenceKey>) {
+impl ToRichIr for Expression {
+    fn build_rich_ir(&self, builder: &mut RichIrBuilder) {
         match self {
             Expression::Int(int) => {
                 let range = builder.push(int.to_string(), TokenType::Int, EnumSet::empty());
-                builder.push_reference(int.to_owned(), range);
+                builder.push_reference(ReferenceKey::Int(int.to_owned().into()), range);
             }
             Expression::Text(text) => {
                 let range =
@@ -458,7 +447,7 @@ impl ToRichIr<HirReferenceKey> for Expression {
             }
             Expression::Symbol(symbol) => {
                 let range = builder.push(symbol, TokenType::Symbol, EnumSet::empty());
-                builder.push_reference(HirReferenceKey::Symbol(symbol.to_owned()), range);
+                builder.push_reference(ReferenceKey::Symbol(symbol.to_owned()), range);
             }
             Expression::List(items) => {
                 builder.push("(", None, EnumSet::empty());
@@ -561,8 +550,8 @@ impl ToRichIr<HirReferenceKey> for Expression {
         }
     }
 }
-impl ToRichIr<HirReferenceKey> for Pattern {
-    fn build_rich_ir(&self, builder: &mut RichIrBuilder<HirReferenceKey>) {
+impl ToRichIr for Pattern {
+    fn build_rich_ir(&self, builder: &mut RichIrBuilder) {
         match self {
             Pattern::Int(int) => {
                 builder.push(format!("{int}"), TokenType::Int, EnumSet::empty());
@@ -602,8 +591,8 @@ impl ToRichIr<HirReferenceKey> for Pattern {
         }
     }
 }
-fn build_errors_rich_ir<C: ToRichIr<HirReferenceKey>>(
-    builder: &mut RichIrBuilder<HirReferenceKey>,
+fn build_errors_rich_ir<C: ToRichIr>(
+    builder: &mut RichIrBuilder,
     errors: &[CompilerError],
     child: &Option<C>,
 ) {
@@ -623,8 +612,8 @@ fn build_errors_rich_ir<C: ToRichIr<HirReferenceKey>>(
         }
     });
 }
-impl ToRichIr<HirReferenceKey> for Lambda {
-    fn build_rich_ir(&self, builder: &mut RichIrBuilder<HirReferenceKey>) {
+impl ToRichIr for Lambda {
+    fn build_rich_ir(&self, builder: &mut RichIrBuilder) {
         for parameter in &self.parameters {
             let range = builder.push(
                 parameter.to_short_debug_string(),
@@ -644,9 +633,9 @@ impl ToRichIr<HirReferenceKey> for Lambda {
         });
     }
 }
-impl ToRichIr<HirReferenceKey> for Body {
-    fn build_rich_ir(&self, builder: &mut RichIrBuilder<HirReferenceKey>) {
-        fn push(builder: &mut RichIrBuilder<HirReferenceKey>, id: &Id, expression: &Expression) {
+impl ToRichIr for Body {
+    fn build_rich_ir(&self, builder: &mut RichIrBuilder) {
+        fn push(builder: &mut RichIrBuilder, id: &Id, expression: &Expression) {
             let range = builder.push(
                 id.to_short_debug_string(),
                 TokenType::Variable,

--- a/compiler/frontend/src/hir_to_mir.rs
+++ b/compiler/frontend/src/hir_to_mir.rs
@@ -901,7 +901,7 @@ impl CompilerError {
         let range = db.range_to_positions(self.module.clone(), self.span.clone());
         format!(
             "{}:{}:{} – {}:{}: {}",
-            <Module as ToRichIr<Module>>::to_rich_ir(&self.module),
+            self.module.to_rich_ir(),
             range.start.line,
             range.start.character,
             range.end.line,

--- a/compiler/frontend/src/mir/body.rs
+++ b/compiler/frontend/src/mir/body.rs
@@ -1,4 +1,4 @@
-use super::{expression::Expression, id::Id, MirReferenceKey};
+use super::{expression::Expression, id::Id};
 use crate::{
     builtin_functions::BuiltinFunction,
     hir,
@@ -439,9 +439,9 @@ impl BodyBuilder {
     }
 }
 
-impl ToRichIr<MirReferenceKey> for Body {
-    fn build_rich_ir(&self, builder: &mut RichIrBuilder<MirReferenceKey>) {
-        fn push(builder: &mut RichIrBuilder<MirReferenceKey>, id: &Id, expression: &Expression) {
+impl ToRichIr for Body {
+    fn build_rich_ir(&self, builder: &mut RichIrBuilder) {
+        fn push(builder: &mut RichIrBuilder, id: &Id, expression: &Expression) {
             let range = builder.push(
                 id.to_short_debug_string(),
                 TokenType::Variable,

--- a/compiler/frontend/src/mir/expression.rs
+++ b/compiler/frontend/src/mir/expression.rs
@@ -2,14 +2,14 @@ use crate::{
     builtin_functions::BuiltinFunction,
     hir,
     module::Module,
-    rich_ir::{RichIrBuilder, ToRichIr, TokenModifier, TokenType},
+    rich_ir::{ReferenceKey, RichIrBuilder, ToRichIr, TokenModifier, TokenType},
 };
 use enumset::EnumSet;
 use itertools::Itertools;
 use num_bigint::BigInt;
 use std::hash;
 
-use super::{body::Body, id::Id, MirReferenceKey};
+use super::{body::Body, id::Id};
 
 #[derive(Clone, PartialEq, Eq)]
 pub enum Expression {
@@ -199,8 +199,8 @@ impl hash::Hash for Expression {
         }
     }
 }
-impl ToRichIr<MirReferenceKey> for Expression {
-    fn build_rich_ir(&self, builder: &mut RichIrBuilder<MirReferenceKey>) {
+impl ToRichIr for Expression {
+    fn build_rich_ir(&self, builder: &mut RichIrBuilder) {
         match self {
             Expression::Int(int) => {
                 let range = builder.push(int.to_string(), TokenType::Int, EnumSet::empty());
@@ -213,7 +213,7 @@ impl ToRichIr<MirReferenceKey> for Expression {
             }
             Expression::Symbol(symbol) => {
                 let range = builder.push(symbol, TokenType::Symbol, EnumSet::empty());
-                builder.push_reference(MirReferenceKey::Symbol(symbol.to_owned()), range);
+                builder.push_reference(ReferenceKey::Symbol(symbol.to_owned()), range);
             }
             Expression::Builtin(builtin) => {
                 let range = builder.push(

--- a/compiler/frontend/src/mir/id.rs
+++ b/compiler/frontend/src/mir/id.rs
@@ -1,4 +1,3 @@
-use super::MirReferenceKey;
 use crate::{
     id::CountableId,
     rich_ir::{RichIrBuilder, ToRichIr, TokenType},
@@ -31,8 +30,8 @@ impl Debug for Id {
         write!(f, "{}", self.to_short_debug_string())
     }
 }
-impl ToRichIr<MirReferenceKey> for Id {
-    fn build_rich_ir(&self, builder: &mut RichIrBuilder<MirReferenceKey>) {
+impl ToRichIr for Id {
+    fn build_rich_ir(&self, builder: &mut RichIrBuilder) {
         let range = builder.push(
             self.to_short_debug_string(),
             TokenType::Variable,

--- a/compiler/frontend/src/mir/mod.rs
+++ b/compiler/frontend/src/mir/mod.rs
@@ -1,13 +1,7 @@
 use std::fmt::{self, Debug, Formatter};
 
-use derive_more::From;
-use num_bigint::BigInt;
-
 use crate::{
-    builtin_functions::BuiltinFunction,
-    hir,
     id::IdGenerator,
-    module::Module,
     rich_ir::{RichIrBuilder, ToRichIr},
 };
 
@@ -38,20 +32,8 @@ impl Debug for Mir {
         write!(f, "{}", self.body.to_rich_ir())
     }
 }
-impl ToRichIr<MirReferenceKey> for Mir {
-    fn build_rich_ir(&self, builder: &mut RichIrBuilder<MirReferenceKey>) {
+impl ToRichIr for Mir {
+    fn build_rich_ir(&self, builder: &mut RichIrBuilder) {
         self.body.build_rich_ir(builder);
     }
-}
-
-#[derive(Debug, PartialEq, Eq, Hash, From)]
-pub enum MirReferenceKey {
-    Module(Module),
-    Id(Id),
-    Int(BigInt),
-    Text(String),
-    #[from(ignore)]
-    Symbol(String),
-    BuiltinFunction(BuiltinFunction),
-    HirId(hir::Id),
 }

--- a/compiler/frontend/src/mir_optimize/mod.rs
+++ b/compiler/frontend/src/mir_optimize/mod.rs
@@ -84,10 +84,7 @@ fn mir_with_obvious_optimized(
     module: Module,
     tracing: TracingConfig,
 ) -> Option<Arc<Mir>> {
-    debug!(
-        "{}: Compiling.",
-        <Module as ToRichIr<Module>>::to_rich_ir(&module),
-    );
+    debug!("{}: Compiling.", module.to_rich_ir());
     let mir = db.mir(module.clone(), tracing.clone())?;
     let mut mir = (*mir).clone();
 
@@ -97,7 +94,7 @@ fn mir_with_obvious_optimized(
 
     debug!(
         "{}: Done. Optimized from {complexity_before} to {complexity_after}",
-        <Module as ToRichIr<Module>>::to_rich_ir(&module),
+        module.to_rich_ir(),
     );
     Some(Arc::new(mir))
 }

--- a/compiler/frontend/src/mir_optimize/module_folding.rs
+++ b/compiler/frontend/src/mir_optimize/module_folding.rs
@@ -30,7 +30,7 @@
 use crate::{
     mir::{Expression, Id, Mir},
     mir_optimize::OptimizeMir,
-    module::{Module, UsePath},
+    module::UsePath,
     rich_ir::ToRichIr,
     tracing::TracingConfig,
 };
@@ -57,7 +57,7 @@ impl Mir {
                 let Ok(module_to_import) = path.resolve_relative_to(current_module.clone()) else {
                     warn!(
                         "`use` called with a path that doesn't refer to a module: `\"{path:?}\"` relative to {}.",
-                        <Module as ToRichIr<Module>>::to_rich_ir(current_module),
+                        current_module.to_rich_ir(),
                     );
                     return; // TODO: Replace with a panic.
                 };
@@ -69,7 +69,7 @@ impl Mir {
                 let Some(mir) = mir else {
                     warn!(
                         "Module {} not found.",
-                        <Module as ToRichIr<Module>>::to_rich_ir(&module_to_import),
+                        module_to_import.to_rich_ir(),
                     );
                     return; // TODO: Replace with a panic.
                 };

--- a/compiler/frontend/src/module/module.rs
+++ b/compiler/frontend/src/module/module.rs
@@ -97,7 +97,7 @@ impl Module {
         let paths = self.to_possible_paths().unwrap_or_else(|| {
             panic!(
                 "Tried to get content of anonymous module {} that is not cached by the language server.",
-                <Module as ToRichIr<Module>>::to_rich_ir(self).text,
+                self.to_rich_ir(),
             )
         });
         for path in paths {
@@ -122,8 +122,8 @@ impl Module {
         });
     }
 }
-impl<RK: Eq + From<Module> + Hash> ToRichIr<RK> for Module {
-    fn build_rich_ir(&self, builder: &mut RichIrBuilder<RK>) {
+impl ToRichIr for Module {
+    fn build_rich_ir(&self, builder: &mut RichIrBuilder) {
         let range = builder.push(
             format!(
                 "{}:{}",

--- a/compiler/frontend/src/module/module_provider.rs
+++ b/compiler/frontend/src/module/module_provider.rs
@@ -56,7 +56,7 @@ impl ModuleProvider for FileSystemModuleProvider {
         let paths = module.to_possible_paths().unwrap_or_else(|| {
             panic!(
                 "Tried to get content of anonymous module {} that is not cached by the language server.",
-                <Module as ToRichIr<Module>>::to_rich_ir(module),
+                module.to_rich_ir(),
             )
         });
         for path in paths {

--- a/compiler/frontend/src/rcst.rs
+++ b/compiler/frontend/src/rcst.rs
@@ -160,8 +160,8 @@ pub enum RcstError {
     WeirdWhitespaceInIndentation,
 }
 
-impl ToRichIr<()> for Rcst {
-    fn build_rich_ir(&self, builder: &mut RichIrBuilder<()>) {
+impl ToRichIr for Rcst {
+    fn build_rich_ir(&self, builder: &mut RichIrBuilder) {
         builder.push(format!("{self:?}"), None, EnumSet::empty());
     }
 }

--- a/compiler/frontend/src/rich_ir.rs
+++ b/compiler/frontend/src/rich_ir.rs
@@ -22,7 +22,7 @@ impl Display for RichIr {
     }
 }
 
-#[derive(Debug, Eq, From, Hash, PartialEq)]
+#[derive(Clone, Debug, Eq, From, Hash, PartialEq)]
 pub enum ReferenceKey {
     Int(BigInt),
     Text(String),

--- a/compiler/frontend/src/rich_ir.rs
+++ b/compiler/frontend/src/rich_ir.rs
@@ -30,6 +30,8 @@ pub enum ReferenceKey {
     Symbol(String),
     BuiltinFunction(BuiltinFunction),
     Module(Module),
+    #[from(ignore)]
+    ModuleWithSpan(Module, Range<Offset>),
     HirId(hir::Id),
     MirId(mir::Id),
 }

--- a/compiler/language_server/src/features.rs
+++ b/compiler/language_server/src/features.rs
@@ -2,9 +2,9 @@ use std::path::Path;
 
 use async_trait::async_trait;
 use lsp_types::{
-    self, DocumentHighlight, FoldingRange, LocationLink, SemanticToken,
-    TextDocumentContentChangeEvent, Url,
+    self, FoldingRange, LocationLink, SemanticToken, TextDocumentContentChangeEvent, Url,
 };
+use rustc_hash::FxHashMap;
 use tokio::sync::Mutex;
 
 use crate::database::Database;
@@ -84,8 +84,9 @@ pub trait LanguageFeatures: Send + Sync {
         _project_directory: &Path,
         _uri: Url,
         _position: lsp_types::Position,
+        _only_in_same_document: bool,
         _include_declaration: bool,
-    ) -> Option<Vec<DocumentHighlight>> {
+    ) -> FxHashMap<Url, Vec<Reference>> {
         unimplemented!()
     }
 
@@ -100,4 +101,9 @@ pub trait LanguageFeatures: Send + Sync {
     ) -> Vec<SemanticToken> {
         unimplemented!()
     }
+}
+
+pub struct Reference {
+    pub range: lsp_types::Range,
+    pub is_write: bool,
 }

--- a/compiler/language_server/src/features_candy/hints/constant_evaluator.rs
+++ b/compiler/language_server/src/features_candy/hints/constant_evaluator.rs
@@ -100,7 +100,7 @@ impl ConstantEvaluator {
     where
         DB: AstDb + AstToHir + HirDb + ModuleDb + PositionConversionDb,
     {
-        let module_string = <Module as ToRichIr<Module>>::to_rich_ir(module).text;
+        let module_string = module.to_rich_ir().text;
         let span = span!(Level::DEBUG, "Calculating hints", %module_string);
         let _enter = span.enter();
 

--- a/compiler/language_server/src/features_candy/hints/mod.rs
+++ b/compiler/language_server/src/features_candy/hints/mod.rs
@@ -108,17 +108,14 @@ pub async fn run_server(
                 fuzzer.update_module(module.clone(), &heap, &closures);
                 debug!(
                     "The constant evaluator made progress in {}.",
-                    <Module as ToRichIr<Module>>::to_rich_ir(&module),
+                    module.to_rich_ir(),
                 );
                 break 'new_insight Some(module);
             }
             // For fuzzing, we're a bit more resource-conscious.
             sleep(Duration::from_millis(200)).await;
             if let Some(module) = fuzzer.run(&db) {
-                debug!(
-                    "The fuzzer made progress in {}.",
-                    <Module as ToRichIr<Module>>::to_rich_ir(&module),
-                );
+                debug!("The fuzzer made progress in {}.", module.to_rich_ir());
                 break 'new_insight Some(module);
             }
             None
@@ -164,10 +161,7 @@ impl OutgoingHints {
     }
 
     async fn report_hints(&mut self, module: Module, hints: Vec<Hint>) {
-        debug!(
-            "Reporting hints for {}:\n{hints:?}",
-            <Module as ToRichIr<Module>>::to_rich_ir(&module),
-        );
+        debug!("Reporting hints for {}:\n{hints:?}", module.to_rich_ir());
         if self.last_sent.get(&module) != Some(&hints) {
             self.last_sent.insert(module.clone(), hints.clone());
             self.sender.send((module, hints)).await.unwrap();

--- a/compiler/language_server/src/features_candy/mod.rs
+++ b/compiler/language_server/src/features_candy/mod.rs
@@ -63,10 +63,7 @@ impl CandyFeatures {
             } else {
                 "modules"
             },
-            modules
-                .iter()
-                .map(<Module as ToRichIr<Module>>::to_rich_ir)
-                .join(", "),
+            modules.iter().map(Module::to_rich_ir).join(", "),
         );
 
         for module in modules {

--- a/compiler/language_server/src/features_ir.rs
+++ b/compiler/language_server/src/features_ir.rs
@@ -66,12 +66,9 @@ impl Server {
                     .map(|mir| Self::rich_ir_for_lir(&config.module, mir, tracing_config)),
             };
             rich_ir.unwrap_or_else(|| {
-                let mut builder = RichIrBuilder::<()>::default();
+                let mut builder = RichIrBuilder::default();
                 builder.push(
-                    format!(
-                        "# Module does not exist: {}",
-                        <Module as ToRichIr<Module>>::to_rich_ir(&config.module)
-                    ),
+                    format!("# Module does not exist: {}", config.module.to_rich_ir()),
                     TokenType::Comment,
                     EnumSet::empty(),
                 );
@@ -132,10 +129,7 @@ impl Server {
     fn rich_ir_for_rcst(module: &Module, rcst: RcstResult) -> Option<RichIr> {
         let mut builder = RichIrBuilder::default();
         builder.push(
-            format!(
-                "# RCST for module {}",
-                <Module as ToRichIr<Module>>::to_rich_ir(module)
-            ),
+            format!("# RCST for module {}", module.to_rich_ir()),
             TokenType::Comment,
             EnumSet::empty(),
         );
@@ -159,10 +153,7 @@ impl Server {
     fn rich_ir_for_ast(module: &Module, asts: Arc<Vec<Ast>>) -> RichIr {
         let mut builder = RichIrBuilder::default();
         builder.push(
-            format!(
-                "# AST for module {}",
-                <Module as ToRichIr<Module>>::to_rich_ir(module)
-            ),
+            format!("# AST for module {}", module.to_rich_ir()),
             TokenType::Comment,
             EnumSet::empty(),
         );
@@ -173,10 +164,7 @@ impl Server {
     fn rich_ir_for_hir(module: &Module, body: Arc<hir::Body>) -> RichIr {
         let mut builder = RichIrBuilder::default();
         builder.push(
-            format!(
-                "# HIR for module {}",
-                <Module as ToRichIr<Module>>::to_rich_ir(module)
-            ),
+            format!("# HIR for module {}", module.to_rich_ir()),
             TokenType::Comment,
             EnumSet::empty(),
         );
@@ -187,10 +175,7 @@ impl Server {
     fn rich_ir_for_mir(module: &Module, mir: Arc<Mir>, tracing_config: &TracingConfig) -> RichIr {
         let mut builder = RichIrBuilder::default();
         builder.push(
-            format!(
-                "# MIR for module {}",
-                <Module as ToRichIr<Module>>::to_rich_ir(module)
-            ),
+            format!("# MIR for module {}", module.to_rich_ir()),
             TokenType::Comment,
             EnumSet::empty(),
         );
@@ -207,10 +192,7 @@ impl Server {
     ) -> RichIr {
         let mut builder = RichIrBuilder::default();
         builder.push(
-            format!(
-                "# Optimized MIR for module {}",
-                <Module as ToRichIr<Module>>::to_rich_ir(module)
-            ),
+            format!("# Optimized MIR for module {}", module.to_rich_ir()),
             TokenType::Comment,
             EnumSet::empty(),
         );
@@ -223,10 +205,7 @@ impl Server {
     fn rich_ir_for_lir(module: &Module, lir: Arc<Lir>, tracing_config: &TracingConfig) -> RichIr {
         let mut builder = RichIrBuilder::default();
         builder.push(
-            format!(
-                "# LIR for module {}",
-                <Module as ToRichIr<Module>>::to_rich_ir(module)
-            ),
+            format!("# LIR for module {}", module.to_rich_ir()),
             TokenType::Comment,
             EnumSet::empty(),
         );
@@ -237,11 +216,8 @@ impl Server {
         builder.finish()
     }
 }
-fn push_tracing_config<RK: Eq + Hash>(
-    builder: &mut RichIrBuilder<RK>,
-    tracing_config: &TracingConfig,
-) {
-    fn push_mode<RK: Eq + Hash>(builder: &mut RichIrBuilder<RK>, title: &str, mode: &TracingMode) {
+fn push_tracing_config(builder: &mut RichIrBuilder, tracing_config: &TracingConfig) {
+    fn push_mode(builder: &mut RichIrBuilder, title: &str, mode: &TracingMode) {
         builder.push_comment_line(format!(
             "• {title} {}",
             match mode {

--- a/compiler/language_server/src/features_ir.rs
+++ b/compiler/language_server/src/features_ir.rs
@@ -133,7 +133,7 @@ impl Server {
         let mut builder = RichIrBuilder::default();
         builder.push(
             format!(
-                "# AST for module {}",
+                "# RCST for module {}",
                 <Module as ToRichIr<Module>>::to_rich_ir(module)
             ),
             TokenType::Comment,

--- a/compiler/vm/src/lir.rs
+++ b/compiler/vm/src/lir.rs
@@ -5,7 +5,6 @@ use candy_frontend::{
     module::Module,
     rich_ir::{RichIrBuilder, ToRichIr, TokenType},
 };
-use derive_more::From;
 use enumset::EnumSet;
 use itertools::Itertools;
 use num_bigint::BigInt;
@@ -244,20 +243,8 @@ impl StackExt for Vec<Id> {
     }
 }
 
-#[derive(Debug, PartialEq, Eq, Hash, From)]
-pub enum LirReferenceKey {
-    Module(Module),
-    Id(Id),
-    Int(BigInt),
-    Text(String),
-    #[from(ignore)]
-    Symbol(String),
-    BuiltinFunction(BuiltinFunction),
-    HirIr(hir::Id),
-    InstructionDiscriminant(InstructionDiscriminants),
-}
-impl ToRichIr<LirReferenceKey> for Lir {
-    fn build_rich_ir(&self, builder: &mut RichIrBuilder<LirReferenceKey>) {
+impl ToRichIr for Lir {
+    fn build_rich_ir(&self, builder: &mut RichIrBuilder) {
         let mut iterator = self.instructions.iter();
         if let Some(instruction) = iterator.next() {
             instruction.build_rich_ir(builder);
@@ -268,11 +255,10 @@ impl ToRichIr<LirReferenceKey> for Lir {
         }
     }
 }
-impl ToRichIr<LirReferenceKey> for Instruction {
-    fn build_rich_ir(&self, builder: &mut RichIrBuilder<LirReferenceKey>) {
+impl ToRichIr for Instruction {
+    fn build_rich_ir(&self, builder: &mut RichIrBuilder) {
         let discriminant: InstructionDiscriminants = self.into();
-        let range = builder.push::<&'static str, _>(discriminant.into(), None, EnumSet::empty());
-        builder.push_reference(discriminant, range);
+        builder.push::<&'static str, _>(discriminant.into(), None, EnumSet::empty());
 
         match self {
             Instruction::CreateInt(int) => {

--- a/compiler/vm/src/use_module.rs
+++ b/compiler/vm/src/use_module.rs
@@ -29,7 +29,7 @@ impl Fiber {
         let lir = use_provider.use_module(module.clone()).ok_or_else(|| {
             format!(
                 "`use` couldn't import the module `{}`.",
-                <Module as ToRichIr<Module>>::to_rich_ir(&module),
+                module.to_rich_ir(),
             )
         })?;
         let closure = self

--- a/vscode_extension/src/debug_irs.ts
+++ b/vscode_extension/src/debug_irs.ts
@@ -78,7 +78,7 @@ function registerDocumentProvider(
       const { ir, originalUri } = decodeUri(uri);
       return vscode.window.withProgress(
         {
-          location: vscode.ProgressLocation.Notification,
+          location: vscode.ProgressLocation.Window,
           title: `Loading ${getIrTitle(ir.type)} of ${originalUri}…`,
           cancellable: true,
         },


### PR DESCRIPTION
<!-- Please enter the corresponding issue ID: -->


<!-- Please summarize your changes: -->
- “Find references” works across all opened IRs
- “Go to definition” works for modules
- “Go to definition” on a HIR ID opens that HIR if it's not open already
- <kbd>Ctrl</kbd>+click on the span of a compiler error within an opened IR to navigate to the source code:
  ![image](https://user-images.githubusercontent.com/19330937/221533985-ccff6d56-4113-4832-923e-efd829103abd.png)



### Checklist
<!-- Please check if your PR fulfills the following requirements: -->

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
