### PR TITLE
Preserve necessary parentheses in BinaryBar's left during formatting

### DIFF
--- a/compiler/formatter/src/format.rs
+++ b/compiler/formatter/src/format.rs
@@ -350,7 +350,7 @@ pub(crate) fn format_cst<'a>(
                     + right_first_line_width)
                 .fits(info.indentation)
             {
-                left.into_trailing_with_space(edits).into()
+                left.into_trailing_with_space(edits)
             } else {
                 left.into_trailing_with_indentation(edits, info.indentation)
             };


### PR DESCRIPTION
<!-- Please enter the corresponding issue ID: -->


<!-- Please summarize your changes: -->
Fixes this problem for call and BinaryBar: https://github.com/candy-lang/candy/pull/394/files#diff-beeae35894a95347e8b0bf5f6898590f32093763f1434820c0c279f3b8f4e025R26-R28


### Checklist
<!-- Please check if your PR fulfills the following requirements: -->

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
