### PR TITLE
Migrate to dtolnay/rust-toolchain and Swatinem/rust-cache; use exact Action versions

### DIFF
--- a/.github/workflows/compiler.yaml
+++ b/.github/workflows/compiler.yaml
@@ -21,12 +21,10 @@ jobs:
       - uses: Swatinem/rust-cache@v2.2.1
 
       # Compiler
-      - name: 'Compiler: check'
-        run: caro check --workspace
-      - name: 'Compiler: test'
-        run: caro test --workspace
       - name: 'Compiler: clippy'
         run: caro clippy -- --deny warnings
+      - name: 'Compiler: test'
+        run: caro test --workspace
       - name: 'Compiler: fmt'
         run: caro fmt --check
 

--- a/.github/workflows/compiler.yaml
+++ b/.github/workflows/compiler.yaml
@@ -18,18 +18,7 @@ jobs:
         with:
           toolchain: ${{ env.RUST_VERSION }}
           components: clippy, rustfmt
-
-      - name: Cache Rust dependencies and build
-        uses: actions/cache@v3
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/git/db/
-            ~/.cargo/registry/cache/
-            ~/.cargo/registry/index/
-            target/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: ${{ runner.os }}-cargo-
+      - uses: Swatinem/rust-cache@v2.2.1
 
       # Compiler
       - name: 'Compiler: check'
@@ -53,18 +42,7 @@ jobs:
   #     - uses: dtolnay/rust-toolchain@b44cb146d03e8d870c57ab64b80f04586349ca5d
   #       with:
   #         toolchain: ${{ env.RUST_VERSION }}
-  
-  #     - name: Cache Rust dependencies and build
-  #       uses: actions/cache@v3
-  #       with:
-  #         path: |
-  #           ~/.cargo/bin/
-  #           ~/.cargo/git/db/
-  #           ~/.cargo/registry/cache/
-  #           ~/.cargo/registry/index/
-  #           target/
-  #         key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-  #         restore-keys: ${{ runner.os }}-cargo-
+  #     - uses: Swatinem/rust-cache@v2.2.1
   
   #     - run: cargo run --release -- fuzz packages/Benchmark.candy
 
@@ -76,18 +54,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@b44cb146d03e8d870c57ab64b80f04586349ca5d
         with:
           toolchain: ${{ env.RUST_VERSION }}
-
-      - name: Cache Rust dependencies and build
-        uses: actions/cache@v3
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/git/db/
-            ~/.cargo/registry/cache/
-            ~/.cargo/registry/index/
-            target/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: ${{ runner.os }}-cargo-
+      - uses: Swatinem/rust-cache@v2.2.1
 
       - name: Run benchmark
         working-directory: compiler/vm/

--- a/.github/workflows/compiler.yaml
+++ b/.github/workflows/compiler.yaml
@@ -22,11 +22,11 @@ jobs:
 
       # Compiler
       - name: 'Compiler: clippy'
-        run: caro clippy -- --deny warnings
+        run: cargo clippy -- --deny warnings
       - name: 'Compiler: test'
-        run: caro test --workspace
+        run: cargo test --workspace
       - name: 'Compiler: fmt'
-        run: caro fmt --check
+        run: cargo fmt --check
 
       # Core
       - name: 'Core: run'

--- a/.github/workflows/compiler.yaml
+++ b/.github/workflows/compiler.yaml
@@ -13,7 +13,7 @@ jobs:
     name: Check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v3.5.2
       - uses: dtolnay/rust-toolchain@b44cb146d03e8d870c57ab64b80f04586349ca5d
         with:
           toolchain: ${{ env.RUST_VERSION }}
@@ -38,7 +38,7 @@ jobs:
   #   name: Fuzzing
   #   runs-on: ubuntu-latest
   #   steps:
-  #     - uses: actions/checkout@v3
+  #     - uses: actions/checkout@v3.5.2
   #     - uses: dtolnay/rust-toolchain@b44cb146d03e8d870c57ab64b80f04586349ca5d
   #       with:
   #         toolchain: ${{ env.RUST_VERSION }}
@@ -50,7 +50,7 @@ jobs:
     name: Benchmark
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v3.5.2
       - uses: dtolnay/rust-toolchain@b44cb146d03e8d870c57ab64b80f04586349ca5d
         with:
           toolchain: ${{ env.RUST_VERSION }}

--- a/.github/workflows/compiler.yaml
+++ b/.github/workflows/compiler.yaml
@@ -14,11 +14,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@b44cb146d03e8d870c57ab64b80f04586349ca5d
         with:
-          profile: minimal
           toolchain: ${{ env.RUST_VERSION }}
-          override: true
           components: clippy, rustfmt
 
       - name: Cache Rust dependencies and build
@@ -35,42 +33,27 @@ jobs:
 
       # Compiler
       - name: 'Compiler: check'
-        uses: actions-rs/cargo@v1
-        with:
-          command: check
+        run: caro check --workspace
       - name: 'Compiler: test'
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
+        run: caro test --workspace
       - name: 'Compiler: clippy'
-        uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: -- --deny warnings
+        run: caro clippy -- --deny warnings
       - name: 'Compiler: fmt'
-        uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --check
+        run: caro fmt --check
 
       # Core
       - name: 'Core: run'
-        uses: actions-rs/cargo@v1
-        with:
-          command: run
-          args: --release --manifest-path=compiler/cli/Cargo.toml -- build --debug packages/Core/_.candy
+        run: cargo run --release -- build --debug packages/Core/_.candy
 
   # fuzzing:
   #   name: Fuzzing
   #   runs-on: ubuntu-latest
   #   steps:
   #     - uses: actions/checkout@v3
-  #     - uses: actions-rs/toolchain@v1
+  #     - uses: dtolnay/rust-toolchain@b44cb146d03e8d870c57ab64b80f04586349ca5d
   #       with:
-  #         profile: minimal
   #         toolchain: ${{ env.RUST_VERSION }}
-  #         override: true
-  #
+  
   #     - name: Cache Rust dependencies and build
   #       uses: actions/cache@v3
   #       with:
@@ -82,22 +65,17 @@ jobs:
   #           target/
   #         key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
   #         restore-keys: ${{ runner.os }}-cargo-
-  #
-  #     - uses: actions-rs/cargo@v1
-  #       with:
-  #         command: run
-  #         args: --manifest-path compiler/Cargo.toml -- fuzz packages/Benchmark.candy
+  
+  #     - run: cargo run --release -- fuzz packages/Benchmark.candy
 
   benchmark:
     name: Benchmark
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@b44cb146d03e8d870c57ab64b80f04586349ca5d
         with:
-          profile: minimal
           toolchain: ${{ env.RUST_VERSION }}
-          override: true
 
       - name: Cache Rust dependencies and build
         uses: actions/cache@v3

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -9,7 +9,7 @@ jobs:
       contents: read
       pull-requests: write
     steps:
-      - uses: actions/labeler@v4
+      - uses: actions/labeler@v4.0.3
         with:
           configuration-path: .github/labels.yaml
           repo-token: ${{ secrets.BOT_TOKEN }}
@@ -20,6 +20,6 @@ jobs:
     if: github.event.action == 'opened'
     runs-on: ubuntu-latest
     steps:
-      - uses: samspills/assign-pr-to-author@v1.0
+      - uses: samspills/assign-pr-to-author@v1.0.2
         with:
           repo-token: ${{ secrets.BOT_TOKEN }}


### PR DESCRIPTION
<!-- Please enter the corresponding issue ID: -->


<!-- Please summarize your changes: -->
We now use [dtolnay/rust-toolchain](https://github.com/dtolnay/rust-toolchain) instead of [actions-rs](https://github.com/actions-rs) (unmaintained: https://github.com/actions-rs/toolchain/issues/216) and [Swatinem/rust-cache](https://github.com/Swatinem/rust-cache) for caching (instead of [actions/cache](https://github.com/actions/cache) directly). Also, all Actions used are pinned to a specific version tag.


### Checklist
<!-- Please check if your PR fulfills the following requirements: -->

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
