### PR TITLE
Add coverage-guided fuzzing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -79,6 +79,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "bitvec"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
+dependencies = [
+ "funty",
+ "radium",
+ "tap",
+ "wyz",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -153,6 +165,7 @@ dependencies = [
 name = "candy_fuzzer"
 version = "0.1.0"
 dependencies = [
+ "bitvec",
  "candy_frontend",
  "candy_vm",
  "itertools",
@@ -633,6 +646,12 @@ checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "funty"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futures"
@@ -1291,6 +1310,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "radium"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
+
+[[package]]
 name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1621,6 +1646,12 @@ dependencies = [
  "quote",
  "unicode-ident",
 ]
+
+[[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "termcolor"
@@ -2121,3 +2152,12 @@ name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
+
+[[package]]
+name = "wyz"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
+dependencies = [
+ "tap",
+]

--- a/compiler/cli/src/fuzz.rs
+++ b/compiler/cli/src/fuzz.rs
@@ -37,11 +37,11 @@ pub(crate) fn fuzz(options: Options) -> ProgramResult {
     } else {
         error!("");
         error!("Finished fuzzing.");
-        // error!("These are the failing cases:");
-        // for case in failing_cases {
-        //     error!("");
-        //     case.dump(&db);
-        // }
+        error!("These are the failing cases:");
+        for case in failing_cases {
+            error!("");
+            case.dump(&db);
+        }
         Err(Exit::FuzzingFoundFailingCases)
     }
 }

--- a/compiler/fuzzer/Cargo.toml
+++ b/compiler/fuzzer/Cargo.toml
@@ -7,6 +7,7 @@ rust-version = "1.56"
 [lib]
 
 [dependencies]
+bitvec = "1.0.1"
 candy_frontend = { path = "../frontend" }
 candy_vm = { path = "../vm" }
 itertools = "0.10.0"

--- a/compiler/fuzzer/src/coverage.rs
+++ b/compiler/fuzzer/src/coverage.rs
@@ -1,0 +1,40 @@
+use candy_vm::fiber::InstructionPointer;
+use itertools::Itertools;
+use std::{fmt, ops::Range};
+
+pub struct Coverage {
+    visited: Vec<bool>,
+}
+impl Coverage {
+    pub fn none() -> Self {
+        Self { visited: vec![] }
+    }
+
+    pub fn add(&mut self, ip: InstructionPointer) {
+        if *ip > self.visited.len() {
+            self.visited
+                .extend([false].repeat(*ip - self.visited.len()));
+        }
+        self.visited[*ip] = true;
+    }
+
+    fn format_range(&self, range: Range<InstructionPointer>) -> String {
+        let mut s = vec![];
+
+        s.push('[');
+        for visited in &self.visited[*range.start..*range.end] {
+            s.push(if *visited { '*' } else { ' ' });
+        }
+        s.push(']');
+        s.into_iter().join("")
+    }
+}
+impl fmt::Debug for Coverage {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "{}",
+            self.format_range(0.into()..self.visited.len().into())
+        )
+    }
+}

--- a/compiler/fuzzer/src/coverage.rs
+++ b/compiler/fuzzer/src/coverage.rs
@@ -77,6 +77,6 @@ impl Coverage {
 }
 impl fmt::Debug for Coverage {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self.format_range(0.into()..self.0.len().into()),)
+        write!(f, "{}", self.format_range(0.into()..self.0.len().into()))
     }
 }

--- a/compiler/fuzzer/src/coverage.rs
+++ b/compiler/fuzzer/src/coverage.rs
@@ -1,6 +1,5 @@
 use bitvec::prelude::*;
 use candy_vm::fiber::InstructionPointer;
-use itertools::Itertools;
 use std::{
     fmt,
     ops::{Add, Range},

--- a/compiler/fuzzer/src/coverage.rs
+++ b/compiler/fuzzer/src/coverage.rs
@@ -50,7 +50,7 @@ impl Add for &Coverage {
 
 impl<'a> RangeCoverage<'a> {
     pub fn is_covered(&self, ip: InstructionPointer) -> bool {
-        *self.coverage.get(*ip).unwrap()
+        *self.coverage.get(*ip - *self.offset).unwrap()
     }
 
     pub fn improvement_on(&self, other: &RangeCoverage) -> usize {

--- a/compiler/fuzzer/src/coverage.rs
+++ b/compiler/fuzzer/src/coverage.rs
@@ -13,11 +13,7 @@ pub struct RangeCoverage<'a> {
 
 impl Coverage {
     pub fn none(size: usize) -> Self {
-        let mut coverage = bitvec![];
-        for _ in 0..size {
-            coverage.push(false);
-        }
-        Self(coverage)
+        Self(BitVec::repeat(false, size))
     }
 
     pub fn add(&mut self, ip: InstructionPointer) {

--- a/compiler/fuzzer/src/coverage.rs
+++ b/compiler/fuzzer/src/coverage.rs
@@ -60,14 +60,13 @@ impl Add for &Coverage {
 
 impl Coverage {
     pub fn format_range(&self, range: Range<InstructionPointer>) -> String {
-        let mut s = vec![];
+        let mut s = "[".to_owned();
 
-        s.push('[');
         for ip in *range.start..*range.end {
             s.push(if self.is_covered(ip.into()) { '*' } else { ' ' });
         }
         s.push(']');
-        s.into_iter().join("")
+        s
     }
 }
 impl fmt::Debug for Coverage {
@@ -75,7 +74,7 @@ impl fmt::Debug for Coverage {
         write!(
             f,
             "{}",
-            self.format_range(0.into()..self.covered.len().into())
+            self.format_range(0.into()..self.covered.len().into()),
         )
     }
 }

--- a/compiler/fuzzer/src/coverage.rs
+++ b/compiler/fuzzer/src/coverage.rs
@@ -41,7 +41,7 @@ impl Coverage {
 
     pub fn relative_coverage(&self) -> f64 {
         assert!(!self.0.is_empty());
-        let num_covered = self.0.iter().filter(|bit| **bit).count();
+        let num_covered = self.0.count_ones();
         let num_total = self.0.len();
         (num_covered as f64) / (num_total as f64)
     }

--- a/compiler/fuzzer/src/fuzzer.rs
+++ b/compiler/fuzzer/src/fuzzer.rs
@@ -53,6 +53,7 @@ impl Fuzzer {
         let pool = InputPool::new(function.argument_count(), &collect_symbols_in_heap(&heap));
         let runner = Runner::new(lir.clone(), function, pool.generate_new_input());
 
+        let num_instructions = lir.instructions.len();
         Self {
             lir,
             function_heap: heap,
@@ -60,7 +61,7 @@ impl Fuzzer {
             function_id,
             status: Some(Status::StillFuzzing {
                 pool,
-                total_coverage: Coverage::none(),
+                total_coverage: Coverage::none(num_instructions),
                 runner,
             }),
         }
@@ -127,22 +128,17 @@ impl Fuzzer {
             RunResult::Timeout => self.create_new_fuzzing_case(pool, total_coverage),
             RunResult::Done { .. } | RunResult::NeedsUnfulfilled { .. } => {
                 let function_range = self.lir.range_of_function(&self.function_id);
-                if total_coverage
-                    .in_range(function_range.clone())
-                    .relative_coverage()
-                    == 1.0
-                {
+                let function_coverage = total_coverage.in_range(&function_range);
+
+                if function_coverage.relative_coverage() == 1.0 {
                     Status::TotalCoverageButNoPanic
                 } else {
                     // We favor small inputs with good code coverage.
                     let score = {
                         let complexity = complexity_of_input(&runner.input) as Score;
+                        let new_function_coverage = runner.coverage.in_range(&function_range);
                         let score: Score = 0.1
-                            * runner
-                                .coverage
-                                .in_range(function_range)
-                                .improvement_on(&total_coverage)
-                                as f64
+                            * new_function_coverage.improvement_on(&function_coverage) as f64
                             - 0.4 * complexity;
                         score.clamp(0.1, Score::MAX)
                     };

--- a/compiler/fuzzer/src/fuzzer.rs
+++ b/compiler/fuzzer/src/fuzzer.rs
@@ -1,4 +1,5 @@
 use crate::{
+    coverage::Coverage,
     input::Input,
     input_pool::{InputPool, Score},
     runner::{RunResult, Runner},
@@ -29,6 +30,7 @@ pub struct Fuzzer {
 pub enum Status {
     StillFuzzing {
         pool: InputPool,
+        total_coverage: Coverage,
         runner: Runner<Arc<Lir>>,
     },
     // TODO: In the future, also add a state for trying to simplify the input.
@@ -37,6 +39,7 @@ pub enum Status {
         panic: Panic,
         tracer: StackTracer,
     },
+    TotalCoverageButNoPanic,
 }
 
 impl Fuzzer {
@@ -55,7 +58,11 @@ impl Fuzzer {
             function_heap: heap,
             function,
             function_id,
-            status: Some(Status::StillFuzzing { pool, runner }),
+            status: Some(Status::StillFuzzing {
+                pool,
+                total_coverage: Coverage::none(),
+                runner,
+            }),
         }
     }
 
@@ -68,13 +75,15 @@ impl Fuzzer {
 
     pub fn run(&mut self, execution_controller: &mut impl ExecutionController) {
         let mut status = self.status.take().unwrap();
-        while !matches!(status, Status::FoundPanic { .. })
+        while matches!(status, Status::StillFuzzing { .. })
             && execution_controller.should_continue_running()
         {
             status = match status {
-                Status::StillFuzzing { pool, runner } => {
-                    self.continue_fuzzing(execution_controller, pool, runner)
-                }
+                Status::StillFuzzing {
+                    pool,
+                    total_coverage,
+                    runner,
+                } => self.continue_fuzzing(execution_controller, pool, total_coverage, runner),
                 // We already found some arguments that caused the function to panic,
                 // so there's nothing more to do.
                 Status::FoundPanic {
@@ -86,6 +95,7 @@ impl Fuzzer {
                     panic,
                     tracer,
                 },
+                Status::TotalCoverageButNoPanic => Status::TotalCoverageButNoPanic,
             };
         }
         self.status = Some(status);
@@ -95,11 +105,12 @@ impl Fuzzer {
         &self,
         execution_controller: &mut impl ExecutionController,
         mut pool: InputPool,
+        total_coverage: Coverage,
         mut runner: Runner<Arc<Lir>>,
     ) -> Status {
         runner.run(execution_controller);
         let Some(result) = runner.result else {
-            return Status::StillFuzzing { pool, runner };
+            return Status::StillFuzzing { pool, total_coverage, runner };
         };
 
         let call_string = format!(
@@ -113,23 +124,25 @@ impl Fuzzer {
         );
         trace!("{}", result.to_string(&call_string));
         match result {
-            RunResult::Timeout => self.create_new_fuzzing_case(pool),
+            RunResult::Timeout => self.create_new_fuzzing_case(pool, total_coverage),
             RunResult::Done { .. } | RunResult::NeedsUnfulfilled { .. } => {
-                // TODO: For now, our "coverage" is just the number of executed
-                // instructions. In the future, we should instead actually look
-                // at what parts of the code ran. This way, we can boost inputs
-                // that achieve big coverage with few instructions.
-                let coverage = runner.num_instructions;
-
-                // We favor small inputs with good code coverage.
-                let score = {
-                    let coverage = coverage as Score;
-                    let complexity = complexity_of_input(&runner.input) as Score;
-                    let score: Score = 0.1 * coverage - 0.4 * complexity;
-                    score.clamp(0.1, Score::MAX)
-                };
-                pool.add(runner.input, score);
-                self.create_new_fuzzing_case(pool)
+                if total_coverage
+                    .relative_coverage_of_range(self.lir.range_of_function(&self.function_id))
+                    == 1f64
+                {
+                    Status::TotalCoverageButNoPanic
+                } else {
+                    // We favor small inputs with good code coverage.
+                    let score = {
+                        let complexity = complexity_of_input(&runner.input) as Score;
+                        let score: Score = 0.1
+                            * runner.coverage.improvement_on(&total_coverage) as f64
+                            - 0.4 * complexity;
+                        score.clamp(0.1, Score::MAX)
+                    };
+                    pool.add(runner.input, score);
+                    self.create_new_fuzzing_case(pool, &total_coverage + &runner.coverage)
+                }
             }
             RunResult::Panicked(panic) => Status::FoundPanic {
                 input: runner.input,
@@ -138,8 +151,12 @@ impl Fuzzer {
             },
         }
     }
-    fn create_new_fuzzing_case(&self, pool: InputPool) -> Status {
+    fn create_new_fuzzing_case(&self, pool: InputPool, total_coverage: Coverage) -> Status {
         let runner = Runner::new(self.lir.clone(), self.function, pool.generate_new_input());
-        Status::StillFuzzing { pool, runner }
+        Status::StillFuzzing {
+            pool,
+            total_coverage,
+            runner,
+        }
     }
 }

--- a/compiler/fuzzer/src/fuzzer.rs
+++ b/compiler/fuzzer/src/fuzzer.rs
@@ -128,7 +128,7 @@ impl Fuzzer {
             RunResult::Done { .. } | RunResult::NeedsUnfulfilled { .. } => {
                 if total_coverage
                     .relative_coverage_of_range(self.lir.range_of_function(&self.function_id))
-                    == 1f64
+                    == 1.0
                 {
                     Status::TotalCoverageButNoPanic
                 } else {

--- a/compiler/fuzzer/src/lib.rs
+++ b/compiler/fuzzer/src/lib.rs
@@ -62,7 +62,7 @@ where
         match fuzzer.into_status() {
             Status::StillFuzzing { total_coverage, .. } => {
                 let coverage = total_coverage
-                    .in_range(lir.range_of_function(&id))
+                    .in_range(&lir.range_of_function(&id))
                     .relative_coverage();
                 debug!("Achieved a coverage of {:.1} %.", coverage * 100.0);
             }

--- a/compiler/fuzzer/src/lib.rs
+++ b/compiler/fuzzer/src/lib.rs
@@ -62,7 +62,7 @@ where
         match fuzzer.into_status() {
             Status::StillFuzzing { total_coverage, .. } => {
                 let coverage =
-                    total_coverage.relative_coverage_of_range(lir.range_of_function(&id));
+                    total_coverage.in_range(lir.range_of_function(&id)).relative_coverage();
                 debug!("Achieved a coverage of {:.1} %.", coverage * 100.0);
             }
             Status::FoundPanic {

--- a/compiler/fuzzer/src/lib.rs
+++ b/compiler/fuzzer/src/lib.rs
@@ -77,7 +77,7 @@ where
                     panic,
                     tracer,
                 };
-                // case.dump(db);
+                case.dump(db);
                 failing_cases.push(case);
             }
             Status::TotalCoverageButNoPanic => {}
@@ -91,10 +91,12 @@ pub struct FailingFuzzCase {
     function: Id,
     input: Input,
     panic: Panic,
+    #[allow(dead_code)]
     tracer: StackTracer,
 }
 
 impl FailingFuzzCase {
+    #[allow(unused_variables)]
     pub fn dump<DB>(&self, db: &DB)
     where
         DB: AstToHir + PositionConversionDb,
@@ -104,9 +106,10 @@ impl FailingFuzzCase {
             self.function, self.input, self.panic.reason,
         );
         error!("{} is responsible.", self.panic.responsible);
-        error!(
-            "This is the stack trace:\n{}",
-            self.tracer.format_panic_stack_trace_to_root_fiber(db),
-        );
+        // Segfaults: https://github.com/candy-lang/candy/issues/458
+        // error!(
+        //     "This is the stack trace:\n{}",
+        //     self.tracer.format_panic_stack_trace_to_root_fiber(db),
+        // );
     }
 }

--- a/compiler/fuzzer/src/lib.rs
+++ b/compiler/fuzzer/src/lib.rs
@@ -61,8 +61,9 @@ where
 
         match fuzzer.into_status() {
             Status::StillFuzzing { total_coverage, .. } => {
-                let coverage =
-                    total_coverage.in_range(lir.range_of_function(&id)).relative_coverage();
+                let coverage = total_coverage
+                    .in_range(lir.range_of_function(&id))
+                    .relative_coverage();
                 debug!("Achieved a coverage of {:.1} %.", coverage * 100.0);
             }
             Status::FoundPanic {

--- a/compiler/fuzzer/src/lib.rs
+++ b/compiler/fuzzer/src/lib.rs
@@ -1,5 +1,6 @@
 #![feature(let_chains, round_char_boundary)]
 
+mod coverage;
 mod fuzzer;
 mod input;
 mod input_pool;

--- a/compiler/fuzzer/src/lib.rs
+++ b/compiler/fuzzer/src/lib.rs
@@ -63,7 +63,7 @@ where
             Status::StillFuzzing { total_coverage, .. } => {
                 let coverage =
                     total_coverage.relative_coverage_of_range(lir.range_of_function(&id));
-                debug!("Achieved a coverage of {:.1}%.", coverage * 100.0);
+                debug!("Achieved a coverage of {:.1} %.", coverage * 100.0);
             }
             Status::FoundPanic {
                 input,

--- a/compiler/fuzzer/src/runner.rs
+++ b/compiler/fuzzer/src/runner.rs
@@ -58,6 +58,7 @@ impl RunResult {
 impl<L: Borrow<Lir>> Runner<L> {
     pub fn new(lir: L, function: Function, input: Input) -> Self {
         let (mut heap, constant_mapping) = lir.borrow().constant_heap.clone();
+        let num_instructions = lir.borrow().instructions.len();
 
         let mut mapping = FxHashMap::default();
         let function = function
@@ -85,7 +86,7 @@ impl<L: Borrow<Lir>> Runner<L> {
             input,
             tracer,
             num_instructions: 0,
-            coverage: Coverage::none(),
+            coverage: Coverage::none(num_instructions),
             result: None,
         }
     }

--- a/compiler/language_server/src/features_candy/hints/fuzzer.rs
+++ b/compiler/language_server/src/features_candy/hints/fuzzer.rs
@@ -56,6 +56,7 @@ impl FuzzerManager {
         match &fuzzer.status() {
             Status::StillFuzzing { .. } => None,
             Status::FoundPanic { .. } => Some(fuzzer.function_id.module.clone()),
+            Status::TotalCoverageButNoPanic => None,
         }
     }
 

--- a/compiler/vm/src/context.rs
+++ b/compiler/vm/src/context.rs
@@ -1,6 +1,8 @@
+use crate::fiber::InstructionPointer;
+
 pub trait ExecutionController {
     fn should_continue_running(&self) -> bool;
-    fn instruction_executed(&mut self);
+    fn instruction_executed(&mut self, ip: InstructionPointer);
 }
 
 pub struct RunForever;
@@ -9,7 +11,7 @@ impl ExecutionController for RunForever {
         true
     }
 
-    fn instruction_executed(&mut self) {}
+    fn instruction_executed(&mut self, _: InstructionPointer) {}
 }
 
 pub struct RunLimitedNumberOfInstructions {
@@ -27,7 +29,7 @@ impl ExecutionController for RunLimitedNumberOfInstructions {
         self.instructions_left > 0
     }
 
-    fn instruction_executed(&mut self) {
+    fn instruction_executed(&mut self, _: InstructionPointer) {
         if self.instructions_left == 0 {
             panic!();
         }
@@ -44,7 +46,7 @@ impl ExecutionController for CountingExecutionController {
         true
     }
 
-    fn instruction_executed(&mut self) {
+    fn instruction_executed(&mut self, _: InstructionPointer) {
         self.num_instructions += 1;
     }
 }
@@ -67,8 +69,8 @@ impl<'a, 'b, A: ExecutionController, B: ExecutionController> ExecutionController
         self.a.should_continue_running() && self.b.should_continue_running()
     }
 
-    fn instruction_executed(&mut self) {
-        self.a.instruction_executed();
-        self.b.instruction_executed();
+    fn instruction_executed(&mut self, ip: InstructionPointer) {
+        self.a.instruction_executed(ip);
+        self.b.instruction_executed(ip);
     }
 }

--- a/compiler/vm/src/fiber.rs
+++ b/compiler/vm/src/fiber.rs
@@ -71,7 +71,7 @@ pub enum Status {
     Panicked(Panic),
 }
 
-#[derive(Clone, Copy, Deref, Eq, From, Hash, PartialEq)]
+#[derive(Clone, Copy, Deref, Eq, From, Hash, Ord, PartialEq, PartialOrd)]
 pub struct InstructionPointer(usize);
 impl InstructionPointer {
     pub fn null_pointer() -> Self {
@@ -79,11 +79,6 @@ impl InstructionPointer {
     }
     fn next(&self) -> Self {
         Self(self.0 + 1)
-    }
-}
-impl PartialOrd for InstructionPointer {
-    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        (**self).partial_cmp(&**other)
     }
 }
 impl Step for InstructionPointer {
@@ -311,7 +306,7 @@ impl<T: FiberTracer> Fiber<T> {
         while matches!(self.status, Status::Running)
             && execution_controller.should_continue_running()
         {
-            let Some(next_instruction) = self.next_instruction else {
+            let Some(current_instruction) = self.next_instruction else {
                 self.status = Status::Done;
                 self.tracer.call_ended(
                     &mut self.heap,
@@ -322,20 +317,20 @@ impl<T: FiberTracer> Fiber<T> {
 
             let instruction = lir
                 .instructions
-                .get(*next_instruction)
+                .get(*current_instruction)
                 .expect("invalid instruction pointer")
                 .clone(); // PERF: Can we avoid this clone?
-            self.next_instruction = Some(next_instruction.next());
+            self.next_instruction = Some(current_instruction.next());
 
             self.run_instruction(instruction);
-            execution_controller.instruction_executed(next_instruction);
+            execution_controller.instruction_executed(current_instruction);
         }
     }
     pub fn run_instruction(&mut self, instruction: Instruction) {
         if TRACE {
             trace!("Running instruction: {instruction:?}");
-            let next_instruction = self.next_instruction.unwrap();
-            trace!("Instruction pointer: {:?}", next_instruction);
+            let current_instruction = self.next_instruction.unwrap();
+            trace!("Instruction pointer: {:?}", current_instruction);
             trace!(
                 "Data stack: {}",
                 if self.data_stack.is_empty() {

--- a/compiler/vm/src/fiber.rs
+++ b/compiler/vm/src/fiber.rs
@@ -18,7 +18,10 @@ use candy_frontend::{
 use derive_more::{Deref, From};
 use itertools::Itertools;
 use rustc_hash::FxHashMap;
-use std::fmt::{self, Debug};
+use std::{
+    fmt::{self, Debug},
+    iter::Step,
+};
 use tracing::trace;
 
 const TRACE: bool = false;
@@ -76,6 +79,28 @@ impl InstructionPointer {
     }
     fn next(&self) -> Self {
         Self(self.0 + 1)
+    }
+}
+impl PartialOrd for InstructionPointer {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        (**self).partial_cmp(&**other)
+    }
+}
+impl Step for InstructionPointer {
+    fn steps_between(start: &Self, end: &Self) -> Option<usize> {
+        Some(**end - **start)
+    }
+
+    fn forward_checked(start: Self, count: usize) -> Option<Self> {
+        Some((*start + count).into())
+    }
+
+    fn backward_checked(start: Self, count: usize) -> Option<Self> {
+        if count > *start {
+            None
+        } else {
+            Some((*start - count).into())
+        }
     }
 }
 impl Debug for InstructionPointer {

--- a/compiler/vm/src/fiber.rs
+++ b/compiler/vm/src/fiber.rs
@@ -92,15 +92,11 @@ impl Step for InstructionPointer {
     }
 
     fn forward_checked(start: Self, count: usize) -> Option<Self> {
-        Some((*start + count).into())
+        (*start).checked_add(count).map(Self)
     }
 
     fn backward_checked(start: Self, count: usize) -> Option<Self> {
-        if count > *start {
-            None
-        } else {
-            Some((*start - count).into())
-        }
+        (*start).checked_sub(count).map(Self)
     }
 }
 impl Debug for InstructionPointer {

--- a/compiler/vm/src/fiber.rs
+++ b/compiler/vm/src/fiber.rs
@@ -307,7 +307,7 @@ impl<T: FiberTracer> Fiber<T> {
             self.next_instruction = Some(next_instruction.next());
 
             self.run_instruction(instruction);
-            execution_controller.instruction_executed();
+            execution_controller.instruction_executed(next_instruction);
         }
     }
     pub fn run_instruction(&mut self, instruction: Instruction) {

--- a/compiler/vm/src/lib.rs
+++ b/compiler/vm/src/lib.rs
@@ -3,6 +3,7 @@
     anonymous_lifetime_in_impl_trait,
     let_chains,
     slice_ptr_get,
+    step_trait,
     strict_provenance
 )]
 

--- a/compiler/vm/src/lir.rs
+++ b/compiler/vm/src/lir.rs
@@ -14,6 +14,7 @@ use itertools::Itertools;
 use pad::{Alignment, PadStr};
 use rustc_hash::FxHashSet;
 use std::fmt::{self, Display, Formatter};
+use std::ops::Range;
 use strum::{EnumDiscriminants, IntoStaticStr};
 
 pub struct Lir {
@@ -193,6 +194,24 @@ impl StackExt for Vec<Id> {
         for _ in 0..n {
             self.pop();
         }
+    }
+}
+
+impl Lir {
+    pub fn range_of_function(&self, function: &hir::Id) -> Range<InstructionPointer> {
+        let start = self
+            .origins
+            .iter()
+            .position(|origins| origins.contains(function))
+            .unwrap();
+        let end = start
+            + self
+                .origins
+                .iter()
+                .skip(start)
+                .take_while(|origins| origins.contains(function))
+                .count();
+        start.into()..end.into()
     }
 }
 


### PR DESCRIPTION
Fuzzing now tracks the coverage and improvements of the coverage, not the number of executed instructions. Essentially, inputs that increase coverage are favored. This is analogous to how AFL works.

### Checklist
<!-- Please check if your PR fulfills the following requirements: -->

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
