### PR TITLE
Improve reference resolution

### DIFF
--- a/compiler/cli/src/utils.rs
+++ b/compiler/cli/src/utils.rs
@@ -15,7 +15,7 @@ pub fn packages_path() -> PackagesPath {
         .find(|path| path.ends_with("target"))
         .unwrap();
     let candy_repo = target_dir.parent().unwrap();
-    PackagesPath::try_from(candy_repo.join("packages").join("Core").as_path()).unwrap()
+    PackagesPath::try_from(candy_repo.join("packages").as_path()).unwrap()
 }
 
 pub(crate) fn module_for_path(path: impl Into<Option<PathBuf>>) -> Result<Module, Exit> {

--- a/compiler/cli/src/utils.rs
+++ b/compiler/cli/src/utils.rs
@@ -15,7 +15,7 @@ pub fn packages_path() -> PackagesPath {
         .find(|path| path.ends_with("target"))
         .unwrap();
     let candy_repo = target_dir.parent().unwrap();
-    PackagesPath::try_from(candy_repo.join("packages").as_path()).unwrap()
+    PackagesPath::try_from(candy_repo.join("packages").join("Core").as_path()).unwrap()
 }
 
 pub(crate) fn module_for_path(path: impl Into<Option<PathBuf>>) -> Result<Module, Exit> {

--- a/compiler/language_server/src/features_candy/find_definition.rs
+++ b/compiler/language_server/src/features_candy/find_definition.rs
@@ -20,10 +20,13 @@ pub fn find_definition(db: &Database, module: Module, offset: Offset) -> Option<
     }
 
     let origin_hir_ids = db.cst_to_hir_id(module.clone(), origin_cst.data.id);
-    let [origin_hir_id] = origin_hir_ids.as_slice() else {
-        panic!("The CST-Id of an Identifier should map to exactly one HIR-Id")
-    };
-    let origin_expression = db.find_expression(origin_hir_id.clone())?;
+    assert_eq!(
+        origin_hir_ids.len(),
+        1,
+        "The CST ID of an identifier should map to exactly one HIR ID.",
+    );
+    let origin_hir_id = origin_hir_ids.into_iter().next().unwrap();
+    let origin_expression = db.find_expression(origin_hir_id)?;
     let target_hir_id = match origin_expression {
         Expression::Reference(id) => id,
         _ => return None,

--- a/compiler/language_server/src/features_candy/find_definition.rs
+++ b/compiler/language_server/src/features_candy/find_definition.rs
@@ -19,8 +19,11 @@ pub fn find_definition(db: &Database, module: Module, offset: Offset) -> Option<
         _ => return None,
     }
 
-    let origin_hir_id = db.cst_to_hir_id(module.clone(), origin_cst.data.id)?;
-    let origin_expression = db.find_expression(origin_hir_id)?;
+    let origin_hir_ids = db.cst_to_hir_id(module.clone(), origin_cst.data.id);
+    let [origin_hir_id] = origin_hir_ids.as_slice() else {
+        panic!("The CST-Id of an Identifier should map to exactly one HIR-Id")
+    };
+    let origin_expression = db.find_expression(origin_hir_id.clone())?;
     let target_hir_id = match origin_expression {
         Expression::Reference(id) => id,
         _ => return None,

--- a/compiler/language_server/src/features_candy/references.rs
+++ b/compiler/language_server/src/features_candy/references.rs
@@ -39,11 +39,13 @@ where
             Some(ReferenceQuery::Needs(module))
         }
         CstKind::Identifier { .. } => {
-            let hir_id = db.cst_to_hir_id(module, origin_cst.data.id);
-            let [hir_id] = hir_id.as_slice() else {
-                panic!("The CST-Id of an Identifier should map to exactly one HIR-Id")
-            };
-            let hir_id = hir_id.to_owned();
+            let hir_ids = db.cst_to_hir_id(module, origin_cst.data.id);
+            assert_eq!(
+                hir_ids.len(),
+                1,
+                "The CST ID of an identifier should map to exactly one HIR ID.",
+            );
+            let hir_id = hir_ids.into_iter().next().unwrap();
 
             let target_id: Option<hir::Id> =
                 if let Some(hir_expr) = db.find_expression(hir_id.clone()) {


### PR DESCRIPTION
<!-- Please enter the corresponding issue ID: -->
Closes: #491, Closes #494

An Id of a higher representation can get mapped to multiple Ids of a lower representation. Before this PR only one Id of the lower representation got returned in an inconsistent manner when the mapping was resolved. This PR changes the lookup to return all corresponding Ids. This allows the caller of the lookup to decide how to handle the Ids. 

These changes make definition lookups and renaming work consistently. Additionally reference resolution now also works in text templates.

### Checklist
<!-- Please check if your PR fulfills the following requirements: -->

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
