### PR TITLE
Debugger: Read memory

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -64,6 +64,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
+name = "base64"
+version = "0.21.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "604178f6c5c21f02dc555784810edfb88d34ac2c73b2eae109655649ee73ce3d"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -180,6 +186,7 @@ name = "candy_language_server"
 version = "0.1.0"
 dependencies = [
  "async-trait",
+ "base64",
  "candy_formatter",
  "candy_frontend",
  "candy_fuzzer",

--- a/compiler/language_server/Cargo.toml
+++ b/compiler/language_server/Cargo.toml
@@ -8,6 +8,7 @@ rust-version = "1.56"
 
 [dependencies]
 async-trait = "0.1.64"
+base64 = "0.21.2"
 candy_formatter = { path = "../formatter" }
 candy_frontend = { path = "../frontend" }
 candy_fuzzer = { path = "../fuzzer" }

--- a/compiler/language_server/src/debug_adapter/paused/memory.rs
+++ b/compiler/language_server/src/debug_adapter/paused/memory.rs
@@ -1,0 +1,144 @@
+use super::PausedState;
+use base64::Engine;
+use candy_frontend::id::CountableId;
+use candy_vm::{
+    fiber::FiberId,
+    heap::{Heap, HeapData, HeapObject, HeapObjectTrait, InlineObject, ObjectInHeap},
+};
+use dap::{requests::ReadMemoryArguments, responses::ReadMemoryResponse};
+use extension_trait::extension_trait;
+use std::{
+    num::NonZeroUsize,
+    ops::Range,
+    ptr::{slice_from_raw_parts, NonNull},
+    str::FromStr,
+};
+
+impl PausedState {
+    #[allow(unused_parens)]
+    pub fn read_memory(
+        &mut self,
+        args: ReadMemoryArguments,
+    ) -> Result<ReadMemoryResponse, &'static str> {
+        let reference = MemoryReference::from_dap(args.memory_reference)?;
+        let fiber = self
+            .vm_state
+            .vm
+            .fiber(reference.fiber_id)
+            .ok_or("fiber-not-found")?
+            .fiber_ref();
+
+        let start_address = reference
+            .address
+            .get()
+            .saturating_sub(args.offset.unwrap_or_default());
+        let end_address = start_address + args.count;
+        let range = fiber
+            .heap
+            .first_contiguous_range_in(start_address..end_address);
+        let Some(range) = range else {
+            return Ok(ReadMemoryResponse {
+                address: format_address(start_address),
+                unreadable_bytes: Some(args.count),
+                data: None,
+            });
+        };
+
+        let data = slice_from_raw_parts(
+            range.start.get() as *const u8,
+            range.end.get().min(end_address) - range.start.get(),
+        );
+        let data = unsafe { &*data };
+        let data = base64::engine::general_purpose::STANDARD.encode(data);
+
+        let next_address = fiber
+            .heap
+            .first_object_range_in(range.end.get()..end_address)
+            .map(|it| it.start);
+
+        Ok(ReadMemoryResponse {
+            address: format_address(range.start.get()),
+            unreadable_bytes: next_address.map(|it| it.get() - range.end.get()),
+            data: Some(data),
+        })
+    }
+}
+
+fn format_address(address: usize) -> String {
+    format!("{:#X}", address)
+}
+
+#[derive(Clone, Copy, Debug)]
+pub struct MemoryReference {
+    fiber_id: FiberId,
+    address: NonZeroUsize,
+}
+impl MemoryReference {
+    pub fn new(fiber_id: FiberId, object: HeapObject) -> Self {
+        Self {
+            fiber_id,
+            address: object.address().addr(),
+        }
+    }
+    pub fn maybe_new(fiber_id: FiberId, object: InlineObject) -> Option<Self> {
+        HeapObject::try_from(object)
+            .ok()
+            .map(|it| Self::new(fiber_id, it))
+    }
+
+    pub fn from_dap(value: String) -> Result<Self, &'static str> {
+        let mut parts = value.split('-');
+
+        let fiber_id = parts.next().ok_or("fiber-id-missing")?;
+        let fiber_id = usize::from_str(fiber_id).map_err(|_| "fiber-id-invalid")?;
+        let fiber_id = FiberId::from_usize(fiber_id);
+
+        let address = parts.next().ok_or("memory-address-missing")?;
+        let address = usize::from_str_radix(address, 16)
+            .ok()
+            .and_then(|it| it.try_into().ok())
+            .ok_or("memory-address-invalid")?;
+
+        Ok(Self { fiber_id, address })
+    }
+    pub fn to_dap(self) -> String {
+        format!("{}-{:X}", self.fiber_id.to_usize(), self.address)
+    }
+}
+
+#[extension_trait]
+impl HeapExtension for Heap {
+    fn first_contiguous_range_in(
+        &self,
+        address_range: Range<usize>,
+    ) -> Option<Range<NonZeroUsize>> {
+        let mut range = self.first_object_range_in(address_range)?;
+        loop {
+            if range.end.get() % HeapObject::WORD_SIZE != 0 {
+                break;
+            }
+
+            let next_object = HeapObject::new(NonNull::new(range.end.get() as *mut u64).unwrap());
+            if !self.objects().contains(&ObjectInHeap(next_object)) {
+                break;
+            }
+
+            range.end = HeapData::from(next_object).address_range().end;
+        }
+        Some(range)
+    }
+    fn first_object_range_in(&self, address_range: Range<usize>) -> Option<Range<NonZeroUsize>> {
+        self.objects()
+            .iter()
+            .map(|&it| HeapData::from(*it).address_range())
+            .filter(|it| (it.start.get()..it.end.get()).overlaps(&address_range))
+            .min_by_key(|it| it.start)
+    }
+}
+
+#[extension_trait]
+impl<T: Ord> RangeExtension<T> for Range<T> {
+    fn overlaps(&self, other: &Range<T>) -> bool {
+        self.start < other.end && other.start < self.end
+    }
+}

--- a/compiler/language_server/src/debug_adapter/paused/memory.rs
+++ b/compiler/language_server/src/debug_adapter/paused/memory.rs
@@ -70,6 +70,8 @@ fn format_address(address: usize) -> String {
 
 #[derive(Clone, Copy, Debug)]
 pub struct MemoryReference {
+    // TODO: Support inline values
+    // TODO: View memory across all fibers
     fiber_id: FiberId,
     address: NonZeroUsize,
 }

--- a/compiler/language_server/src/debug_adapter/paused/mod.rs
+++ b/compiler/language_server/src/debug_adapter/paused/mod.rs
@@ -1,6 +1,7 @@
 use self::{stack_trace::StackFrameKey, utils::IdMapping, variable::VariablesKey};
 use super::vm_state::VmState;
 
+mod memory;
 mod scope;
 mod stack_trace;
 mod utils;

--- a/compiler/language_server/src/debug_adapter/paused/scope.rs
+++ b/compiler/language_server/src/debug_adapter/paused/scope.rs
@@ -58,7 +58,7 @@ impl PausedState {
             variables_reference: self
                 .variables_ids
                 .key_to_id(VariablesKey::FiberHeap(stack_frame_key.fiber_id)),
-            named_variables: Some(fiber.heap.objects_len()),
+            named_variables: Some(fiber.heap.objects().len()),
             indexed_variables: Some(0),
             expensive: false,
             source: None,

--- a/compiler/language_server/src/debug_adapter/paused/variable.rs
+++ b/compiler/language_server/src/debug_adapter/paused/variable.rs
@@ -172,7 +172,7 @@ impl PausedState {
                                 named_variables: Some(0),
                                 indexed_variables: Some(0),
                                 memory_reference: Some(
-                                    MemoryReference::new(*fiber_id, **tag.symbol()).to_dap(),
+                                    MemoryReference::heap(*fiber_id, **tag.symbol()).to_dap(),
                                 ),
                             });
                         }
@@ -198,10 +198,9 @@ impl PausedState {
                                     variables_reference: 0,
                                     named_variables: Some(0),
                                     indexed_variables: Some(0),
-                                    memory_reference: tag.value().and_then(|it| {
-                                        MemoryReference::maybe_new(*fiber_id, it)
-                                            .map(|it| it.to_dap())
-                                    }),
+                                    memory_reference: tag
+                                        .value()
+                                        .map(|it| MemoryReference::new(*fiber_id, it).to_dap()),
                                 }
                             };
                             variables.push(value_variable);
@@ -318,7 +317,7 @@ impl PausedState {
             variables_reference,
             named_variables: Some(named_variables),
             indexed_variables: Some(indexed_variables),
-            memory_reference: MemoryReference::maybe_new(fiber_id, object).map(|it| it.to_dap()),
+            memory_reference: Some(MemoryReference::new(fiber_id, object).to_dap()),
         }
     }
     fn type_field_for(kind: DataDiscriminants, supports_variable_type: bool) -> Option<String> {

--- a/compiler/language_server/src/debug_adapter/session.rs
+++ b/compiler/language_server/src/debug_adapter/session.rs
@@ -153,7 +153,7 @@ impl DebugSession {
                     supports_set_expression: None,
                     supports_terminate_request: None,
                     supports_data_breakpoints: None,
-                    supports_read_memory_request: None,
+                    supports_read_memory_request: Some(true),
                     supports_write_memory_request: None,
                     supports_disassemble_request: None,
                     supports_cancel_request: None,
@@ -258,7 +258,13 @@ impl DebugSession {
                 .await
             }
             Command::Pause(_) => todo!(),
-            Command::ReadMemory(_) => todo!(),
+            Command::ReadMemory(args) => {
+                let state = self.state.require_paused_mut()?;
+                let response = state.read_memory(args)?;
+                self.send_response_ok(request.seq, ResponseBody::ReadMemory(Some(response)))
+                    .await;
+                Ok(())
+            }
             Command::Restart(_) => todo!(),
             Command::RestartFrame(_) => todo!(),
             Command::ReverseContinue(_) => todo!(),

--- a/compiler/language_server/src/lib.rs
+++ b/compiler/language_server/src/lib.rs
@@ -1,6 +1,4 @@
-#![feature(async_closure)]
-#![feature(box_patterns)]
-#![feature(let_chains)]
+#![feature(async_closure, box_patterns, let_chains, strict_provenance)]
 
 pub mod database;
 pub mod debug_adapter;

--- a/compiler/vm/src/heap/mod.rs
+++ b/compiler/vm/src/heap/mod.rs
@@ -89,8 +89,8 @@ impl Heap {
         }
     }
 
-    pub fn objects_len(&self) -> usize {
-        self.objects.len()
+    pub fn objects(&self) -> &FxHashSet<ObjectInHeap> {
+        &self.objects
     }
     pub fn iter(&self) -> impl Iterator<Item = HeapObject> + '_ {
         self.objects.iter().map(|it| **it)

--- a/compiler/vm/src/lib.rs
+++ b/compiler/vm/src/lib.rs
@@ -2,6 +2,7 @@
     allocator_api,
     anonymous_lifetime_in_impl_trait,
     let_chains,
+    nonzero_ops,
     slice_ptr_get,
     step_trait,
     strict_provenance


### PR DESCRIPTION
~**Depends on #506!**~

<!-- Please enter the corresponding issue ID: -->


<!-- Please summarize your changes: -->
You can now view the in-memory representation of heap objects while debugging:
![image](https://github.com/candy-lang/candy/assets/19330937/a00924b8-87cf-440d-a502-6d1630ca0526)



### Checklist
<!-- Please check if your PR fulfills the following requirements: -->

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
