### PR TITLE
Move builtins to separate package

### DIFF
--- a/.github/labels.yaml
+++ b/.github/labels.yaml
@@ -1,3 +1,5 @@
+'P: Builtins':
+  - packages/Builtins/**/*
 'P: Compiler: CLI':
   - compiler/cli/**/*
 'P: Compiler: Formatter':

--- a/compiler/frontend/src/ast_to_hir.rs
+++ b/compiler/frontend/src/ast_to_hir.rs
@@ -9,7 +9,7 @@ use crate::{
     error::{CompilerError, CompilerErrorPayload},
     hir::{self, Body, Expression, Function, HirError, IdKey, Pattern, PatternIdentifierId},
     id::IdGenerator,
-    module::Module,
+    module::{Module, Package},
     position::Offset,
     string_to_rcst::ModuleError,
     utils::AdjustCasingOfFirstLetter,
@@ -84,12 +84,14 @@ fn compile_top_level(
         db,
         public_identifiers: FxHashMap::default(),
         body: Body::default(),
-        id_prefix: hir::Id::new(module, vec![]),
+        id_prefix: hir::Id::new(module.clone(), vec![]),
         identifiers: im::HashMap::new(),
         is_top_level: true,
     };
 
-    context.generate_sparkles();
+    if module.package == Package::Managed("Builtins".into()) {
+        context.generate_sparkles();
+    }
     context.generate_use();
     context.compile(ast);
     context.generate_exports_struct();

--- a/compiler/frontend/src/ast_to_hir.rs
+++ b/compiler/frontend/src/ast_to_hir.rs
@@ -90,7 +90,7 @@ fn compile_top_level(
         use_id: None,
     };
 
-    if module.package == Package::Managed("Builtins".into()) {
+    if module.package == Package::builtins() {
         context.generate_sparkles();
     }
     context.generate_use();

--- a/compiler/frontend/src/mir_optimize/mod.rs
+++ b/compiler/frontend/src/mir_optimize/mod.rs
@@ -202,7 +202,7 @@ impl Expression {
             let hashcode_before = self.do_hash();
 
             reference_following::follow_references(self, visible);
-            constant_folding::fold_constants(self, visible, id_generator);
+            constant_folding::fold_constants(self, visible);
             inlining::inline_tiny_functions(self, visible, id_generator);
             inlining::inline_functions_containing_use(self, visible, id_generator);
             constant_lifting::lift_constants(self, id_generator);

--- a/compiler/frontend/src/module/package.rs
+++ b/compiler/frontend/src/module/package.rs
@@ -104,6 +104,13 @@ pub enum Package {
 }
 
 impl Package {
+    pub fn builtins() -> Package {
+        Package::Managed(PathBuf::from("Builtins"))
+    }
+    pub fn core() -> Package {
+        Package::Managed(PathBuf::from("Core"))
+    }
+
     pub fn to_path(&self, packages_path: &PackagesPath) -> Option<PathBuf> {
         match self {
             Package::User(path) => Some(path.clone()),

--- a/compiler/language_server/src/features_candy/hints/mod.rs
+++ b/compiler/language_server/src/features_candy/hints/mod.rs
@@ -28,6 +28,7 @@ pub mod hint;
 mod hints_finder;
 mod utils;
 
+#[derive(Debug)]
 pub enum Event {
     UpdateModule(Module, Vec<u8>),
     CloseModule(Module),

--- a/compiler/language_server/src/features_candy/mod.rs
+++ b/compiler/language_server/src/features_candy/mod.rs
@@ -60,7 +60,7 @@ impl CandyFeatures {
     async fn send_to_hints_server(&self, event: hints::Event) {
         match self.hints_events_sender.send(event).await {
             Ok(_) => {}
-            Err(_) => panic!("Couldn't send message to hints server."),
+            Err(error) => panic!("Couldn't send message to hints server: {error:?}."),
         }
     }
 }

--- a/compiler/vm/benches/utils.rs
+++ b/compiler/vm/benches/utils.rs
@@ -96,7 +96,7 @@ pub fn setup() -> Database {
 fn load_core(module_provider: &mut InMemoryModuleProvider) {
     let packages_path = PackagesPath::try_from("../../packages").unwrap();
     let core_path = packages_path.join("Core");
-    let package = Package::Managed("Core".into());
+    let package = Package::core();
 
     for file in WalkDir::new(&core_path)
         .into_iter()

--- a/compiler/vm/benches/utils.rs
+++ b/compiler/vm/benches/utils.rs
@@ -95,9 +95,10 @@ pub fn setup() -> Database {
     db
 }
 fn load_package(package_name: impl Into<String>, module_provider: &mut InMemoryModuleProvider) {
+    let package_name = package_name.into();
     let packages_path = PackagesPath::try_from("../../packages").unwrap();
-    let package_path = packages_path.join(package_name.into());
-    let package = Package::core();
+    let package_path = packages_path.join(package_name.clone());
+    let package = Package::Managed(package_name.into());
 
     for file in WalkDir::new(&package_path)
         .into_iter()

--- a/compiler/vm/benches/utils.rs
+++ b/compiler/vm/benches/utils.rs
@@ -79,7 +79,8 @@ pub fn setup_and_compile(source_code: &str) -> Lir {
 
 pub fn setup() -> Database {
     let mut db = Database::default();
-    load_core(&mut db.module_provider);
+    load_package("Builtins", &mut db.module_provider);
+    load_package("Core", &mut db.module_provider);
     db.module_provider.add_str(&MODULE, r#"_ = use "Core""#);
 
     // Load `Core` into the cache.
@@ -93,12 +94,12 @@ pub fn setup() -> Database {
 
     db
 }
-fn load_core(module_provider: &mut InMemoryModuleProvider) {
+fn load_package(package_name: impl Into<String>, module_provider: &mut InMemoryModuleProvider) {
     let packages_path = PackagesPath::try_from("../../packages").unwrap();
-    let core_path = packages_path.join("Core");
+    let package_path = packages_path.join(package_name.into());
     let package = Package::core();
 
-    for file in WalkDir::new(&core_path)
+    for file in WalkDir::new(&package_path)
         .into_iter()
         .map(|it| it.unwrap())
         .filter(|it| it.file_type().is_file())

--- a/compiler/vm/src/builtin_functions.rs
+++ b/compiler/vm/src/builtin_functions.rs
@@ -129,14 +129,12 @@ macro_rules! unpack {
             let ( $( $arg, )+ ) = if let [$( $arg, )+] = $args {
                 ( $( *$arg, )+ )
             } else {
-                return Err(
-                    "A builtin function was called with the wrong number of arguments.".to_string(),
-                );
+                panic!("A builtin function was called with the wrong number of arguments.");
             };
             let ( $( $arg, )+ ): ( $( UnpackedData<$type>, )+ ) = ( $(
                 UnpackedData {
                     object: $arg,
-                    data: $arg.try_into()?,
+                    data: $arg.try_into().unwrap(),
                 },
             )+ );
 
@@ -150,14 +148,12 @@ macro_rules! unpack_and_later_drop {
             let ( $( $arg, )+ ) = if let [$( $arg, )+] = $args {
                 ( $( *$arg, )+ )
             } else {
-                return Err(
-                    "A builtin function was called with the wrong number of arguments.".to_string(),
-                );
+                panic!("A builtin function was called with the wrong number of arguments.");
             };
             let ( $( $arg, )+ ): ( $( UnpackedData<$type>, )+ ) = ( $(
                 UnpackedData {
                     object: $arg,
-                    data: $arg.try_into()?,
+                    data: $arg.try_into().unwrap(),
                 },
             )+ );
 

--- a/packages/Builtins/_.candy
+++ b/packages/Builtins/_.candy
@@ -1,11 +1,10 @@
 typeIs value type =
   needs (type | ✨.typeOf | ✨.equals Tag)
   value | ✨.typeOf | ✨.equals type
-not bool =
-  bool %
-    True -> False
-    False -> True
-    _ -> needs False
+not bool = bool %
+  True -> False
+  False -> True
+  _ -> needs False
 isNonNegative int =
   needs (int | typeIs Int)
   int | ✨.intCompareTo 0 %
@@ -20,7 +19,7 @@ isLessThanOrEqualTo a b =
 
 channelCreate capacity :=
   # Creates a new channel with the specified `capacity`.
-  # 
+  #
   # This function returns a struct `[sendPort, receivePort]`.
   needs
     capacity | typeIs Int
@@ -29,15 +28,14 @@ channelCreate capacity :=
   ✨.channelCreate capacity
 channelSend sendPort packet :=
   # Sends the `packet` to the channel specified by the `sendPort`.
-  # 
+  #
   # If the channel is full, this function blocks until there is space available.
   needs (sendPort | typeIs SendPort)
   ✨.channelSend sendPort packet
 channelReceive receivePort :=
   # Receives a packet from the specified `receivePort`.
   #
-  # If the channel is empty, this function blocks until there is a packet
-  # available.
+  # If the channel is empty, this function blocks until there is a packet available.
   needs (receivePort | typeIs ReceivePort)
   ✨.channelReceive receivePort
 
@@ -51,7 +49,7 @@ getArgumentCount function :=
   ✨.getArgumentCount function
 functionRun function :=
   # Executes `function` and returns its result.
-  # 
+  #
   # `function` may not accept any arguments.
   needs (function | typeIs Function)
   needs (function | getArgumentCount | equals 0)
@@ -86,8 +84,7 @@ intAdd a b :=
   needs (b | typeIs Int)
   ✨.intAdd a b
 intBitLength value :=
-  # Determines the fewest bits necessary to express this integer, not including
-  # the sign.
+  # Determines the fewest bits necessary to express this integer, not including the sign.
   needs (value | typeIs Int)
   ✨.intBitLength value
 intBitwiseAnd a b :=
@@ -103,16 +100,15 @@ intBitwiseXor a b :=
   needs (b | typeIs Int)
   ✨.intBitwiseXor a b
 intCompareTo a b :=
-  # Returns `Less`, `Equal`, or `Greater` depending on whether `a` is less than,
-  # equal to, or greater than `b`.
+  # Returns `Less`, `Equal`, or `Greater` depending on whether `a` is less than, equal to, or
+  # greater than `b`.
   needs (a | typeIs Int)
   needs (b | typeIs Int)
   ✨.intCompareTo a b
 intDivideTruncating dividend divisor :=
   # Returns `dividend` ÷ `divisor`.
-  # 
-  # This operation rounds towards zero, truncating any fractional part of the
-  # exact result.
+  #
+  # This operation rounds towards zero, truncating any fractional part of the exact result.
   needs (dividend | typeIs Int)
   needs (divisor | typeIs Int)
   needs (divisor | equals 0 | not) "You can't divide by zero."
@@ -130,11 +126,10 @@ intMultiply factorA factorB :=
 intParse text :=
   # Parses `text` as an integer.
   #
-  # `text` must be a string of decimal digits, optionally preceded by a minus
-  # sign.
+  # `text` must be a string of decimal digits, optionally preceded by a minus sign.
   #
-  # This function returns `Ok integer` if `text` represents an integer and
-  # `Error errorMessage` otherwise.
+  # This function returns `Ok integer` if `text` represents an integer and `Error errorMessage`
+  # otherwise.
   needs (text | typeIs Text)
   ✨.intParse text
 intRemainder dividend divisor :=
@@ -199,17 +194,13 @@ listReplace list index newItem :=
   ✨.listReplace list index newItem
 
 parallel body :=
-  # Executes `body`, which accepts a nursery to spawn fibers that can run in
-  # parallel.
+  # Executes `body`, which accepts a nursery to spawn fibers that can run in parallel.
   #
-  # This call exits with `body`'s return value once all fibers spawned within
-  # body have exited.
-  ## TODO: Propagate the responsibility here. `body` may contain a `needs` that
-  ## always fails. That shouldn't be our fault, but our caller's.
+  # This call exits with `body`'s return value once all fibers spawned within body have exited.
+  ## TODO: Propagate the responsibility here. `body` may contain a `needs` that always fails. That
+  ## shouldn't be our fault, but our caller's.
   needs (body | typeIs Function)
-  needs
-    body | getArgumentCount | equals 1
-    "The `body` should be a function taking a nursery."
+  needs (body | getArgumentCount | equals 1) "The `body` should be a function taking a nursery."
   ✨.parallel body
 
 print message :=
@@ -233,7 +224,7 @@ structHasKey struct key :=
 
 tagGetValue tag :=
   needs (tag | typeIs Tag)
-  neesd (tag | ✨.tagHasValue)
+  needs (tag | ✨.tagHasValue)
   ✨.tagGetValue tag
 tagHasValue tag :=
   needs (tag | typeIs Tag)
@@ -297,16 +288,13 @@ textTrimStart text :=
   # text
   ✨.textTrimStart text
 
-toDebugText any :=
-  ✨.toDebugText any
+toDebugText any := ✨.toDebugText any
 
 try function :=
-  # Returns `Ok result` if `function` returns normally and `Error panicReason`
-  # if the `function` panics.
+  # Returns `Ok result` if `function` returns normally and `Error panicReason` if the `function`
+  # panics.
   needs (function | typeIs Function)
   needs (function | getArgumentCount | equals 0)
   ✨.try function
 
-typeOf any :=
-  # typeTag
-  ✨.typeOf any
+typeOf any := ✨.typeOf any

--- a/packages/Builtins/_.candy
+++ b/packages/Builtins/_.candy
@@ -1,0 +1,312 @@
+typeIs value type =
+  needs (type | ✨.typeOf | ✨.equals Tag)
+  value | ✨.typeOf | ✨.equals type
+not bool =
+  bool %
+    True -> False
+    False -> True
+    _ -> needs False
+isNonNegative int =
+  needs (int | typeIs Int)
+  int | ✨.intCompareTo 0 %
+    Greater | Equal -> True
+    Less -> False
+isLessThanOrEqualTo a b =
+  needs (a | typeIs Int)
+  needs (b | typeIs Int)
+  a | ✨.intCompareTo b %
+    Less | Equal -> True
+    Greater -> False
+
+channelCreate capacity :=
+  # Creates a new channel with the specified `capacity`.
+  # 
+  # This function returns a struct `[sendPort, receivePort]`.
+  needs
+    capacity | typeIs Int
+    "`capacity` is not an integer. Channels need a capacity because otherwise, there would be no backpressure among fibers, and memory leaks would go unnoticed."
+  needs (capacity | isNonNegative)
+  ✨.channelCreate capacity
+channelSend sendPort packet :=
+  # Sends the `packet` to the channel specified by the `sendPort`.
+  # 
+  # If the channel is full, this function blocks until there is space available.
+  needs (sendPort | typeIs SendPort)
+  ✨.channelSend sendPort packet
+channelReceive receivePort :=
+  # Receives a packet from the specified `receivePort`.
+  #
+  # If the channel is empty, this function blocks until there is a packet
+  # available.
+  needs (receivePort | typeIs ReceivePort)
+  ✨.channelReceive receivePort
+
+equals a b :=
+  # Returns `True` or `False` depending on whether `a` and `b` are equal.
+  ✨.equals a b
+
+getArgumentCount function :=
+  # Returns the number of arguments that `function` expects.
+  needs (function | typeIs Function)
+  ✨.getArgumentCount function
+functionRun function :=
+  # Executes `function` and returns its result.
+  # 
+  # `function` may not accept any arguments.
+  needs (function | typeIs Function)
+  needs (function | getArgumentCount | equals 0)
+  ✨.functionRun function
+
+ifElse condition then else :=
+  conditionIsBool = condition %
+    True | False -> True
+    _ -> False
+  needs conditionIsBool
+  needs (then | typeIs Function)
+  needs (then | getArgumentCount | equals 0)
+  needs (else | typeIs Function)
+  needs (else | getArgumentCount | equals 0)
+  ✨.ifElse condition then else
+
+fitsInRustU32 value =
+  needs (value | typeIs Int)
+  needs (value | isNonNegative)
+  rustU32Max = 4294967295
+  # https://doc.rust-lang.org/std/primitive.u32.html#associatedconstant.MAX
+  value | isLessThanOrEqualTo rustU32Max
+fitsInRustU128 value =
+  needs (value | typeIs Int)
+  needs (value | isNonNegative)
+  rustU128Max = 340282366920938463463374607431768211455
+  # https://doc.rust-lang.org/std/primitive.u128.html#associatedconstant.MAX
+  value | isLessThanOrEqualTo rustU128Max
+
+intAdd a b :=
+  needs (a | typeIs Int)
+  needs (b | typeIs Int)
+  ✨.intAdd a b
+intBitLength value :=
+  # Determines the fewest bits necessary to express this integer, not including
+  # the sign.
+  needs (value | typeIs Int)
+  ✨.intBitLength value
+intBitwiseAnd a b :=
+  needs (a | typeIs Int)
+  needs (b | typeIs Int)
+  ✨.intBitwiseAnd a b
+intBitwiseOr a b :=
+  needs (a | typeIs Int)
+  needs (b | typeIs Int)
+  ✨.intBitwiseOr a b
+intBitwiseXor a b :=
+  needs (a | typeIs Int)
+  needs (b | typeIs Int)
+  ✨.intBitwiseXor a b
+intCompareTo a b :=
+  # Returns `Less`, `Equal`, or `Greater` depending on whether `a` is less than,
+  # equal to, or greater than `b`.
+  needs (a | typeIs Int)
+  needs (b | typeIs Int)
+  ✨.intCompareTo a b
+intDivideTruncating dividend divisor :=
+  # Returns `dividend` ÷ `divisor`.
+  # 
+  # This operation rounds towards zero, truncating any fractional part of the
+  # exact result.
+  needs (dividend | typeIs Int)
+  needs (divisor | typeIs Int)
+  needs (divisor | equals 0 | not) "You can't divide by zero."
+  ✨.intDivideTruncating dividend divisor
+intModulo dividend divisor :=
+  needs (dividend | typeIs Int)
+  needs (divisor | typeIs Int)
+  needs (divisor | equals 0 | not) "You can't divide by zero."
+  ✨.intModulo dividend divisor
+intMultiply factorA factorB :=
+  # Returns `factorA` × `factorB`.
+  needs (factorA | typeIs Int)
+  needs (factorB | typeIs Int)
+  ✨.intMultiply factorA factorB
+intParse text :=
+  # Parses `text` as an integer.
+  #
+  # `text` must be a string of decimal digits, optionally preceded by a minus
+  # sign.
+  #
+  # This function returns `Ok integer` if `text` represents an integer and
+  # `Error errorMessage` otherwise.
+  needs (text | typeIs Text)
+  ✨.intParse text
+intRemainder dividend divisor :=
+  needs (dividend | typeIs Int)
+  needs (divisor | typeIs Int)
+  needs (divisor | equals 0 | not) "You can't divide by zero."
+  ✨.intRemainder dividend divisor
+intShiftLeft value amount :=
+  needs (value | typeIs Int)
+  needs (amount | typeIs Int)
+  needs
+    amount | isNonNegative
+    "The shift `amount` is negative: {amount | ✨.toDebugText}. You might want to call `shiftRight` instead."
+  needs (amount | fitsInRustU128) "Shifts by that much are not yet supported."
+  ✨.intShiftLeft value amount
+intShiftRight value amount :=
+  needs (value | typeIs Int)
+  needs (amount | typeIs Int)
+  needs
+    amount | isNonNegative
+    "The shift `amount` is negative: {amount | ✨.toDebugText}. You might want to call `shiftLeft` instead."
+  needs (amount | fitsInRustU128) "Shifts by that much are not yet supported."
+  ✨.intShiftRight value amount
+intSubtract minuend subtrahend :=
+  # Returns `minuend` - `subtrahend`.
+  needs (minuend | typeIs Int)
+  needs (subtrahend | typeIs Int)
+  ✨.intSubtract minuend subtrahend
+
+listFilled length item :=
+  # Returns a list of `length` elements, each of which is `item`.
+  needs (length | typeIs Int)
+  needs (length | isNonNegative)
+  ✨.listFilled length item
+listGet list index :=
+  needs (list | typeIs List)
+  needs (index | typeIs Int)
+  needs (index | isNonNegative)
+  needs (index | intCompareTo (list | ✨.listLength) | equals Less)
+  ✨.listGet list index
+listInsert list index item :=
+  needs (list | typeIs List)
+  needs (index | typeIs Int)
+  needs (index | isNonNegative)
+  needs (index | isLessThanOrEqualTo (list | ✨.listLength))
+  ✨.listInsert list index item
+listLength list :=
+  needs (list | typeIs List)
+  ✨.listLength list
+listRemoveAt list index :=
+  # Returns `(listWithoutItemAtIndex, itemAtIndex)`.
+  needs (list | typeIs List)
+  needs (index | typeIs Int)
+  needs (index | isNonNegative)
+  needs (index | intCompareTo (list | listLength) | equals Less)
+  ✨.listRemoveAt list index
+listReplace list index newItem :=
+  needs (list | typeIs List)
+  needs (index | typeIs Int)
+  needs (index | isNonNegative)
+  needs (index | intCompareTo (list | listLength) | equals Less)
+  ✨.listReplace list index newItem
+
+parallel body :=
+  # Executes `body`, which accepts a nursery to spawn fibers that can run in
+  # parallel.
+  #
+  # This call exits with `body`'s return value once all fibers spawned within
+  # body have exited.
+  ## TODO: Propagate the responsibility here. `body` may contain a `needs` that
+  ## always fails. That shouldn't be our fault, but our caller's.
+  needs (body | typeIs Function)
+  needs
+    body | getArgumentCount | equals 1
+    "The `body` should be a function taking a nursery."
+  ✨.parallel body
+
+print message :=
+  needs (message | typeIs Text)
+  ✨.print message
+
+structGet struct key :=
+  needs (struct | typeIs Struct)
+  needs (struct | ✨.structHasKey key)
+  ✨.structGet struct key
+structGetKeys struct :=
+  # Returns a list of all keys inside `struct`.
+  #
+  # The order of the keys is unspecified.
+  needs (struct | typeIs Struct)
+  ✨.structGetKeys struct
+structHasKey struct key :=
+  # Returns whether `struct` contains the key `key`.
+  needs (struct | typeIs Struct)
+  ✨.structHasKey struct key
+
+tagGetValue tag :=
+  needs (tag | typeIs Tag)
+  neesd (tag | ✨.tagHasValue)
+  ✨.tagGetValue tag
+tagHasValue tag :=
+  needs (tag | typeIs Tag)
+  ✨.tagHasValue tag
+tagWithoutValue tag :=
+  needs (tag | typeIs Tag)
+  ✨.tagWithoutValue tag
+
+textCharacters text :=
+  # Returns a list of characters (Unicode grapheme clusters) in this text.
+  needs (text | typeIs Text)
+  ✨.textCharacters text
+textConcatenate a b :=
+  needs (a | typeIs Text)
+  needs (b | typeIs Text)
+  ✨.textConcatenate a b
+textContains text pattern :=
+  needs (text | typeIs Text)
+  needs (pattern | typeIs Text)
+  ✨.textContains text pattern
+textEndsWith text pattern :=
+  needs (text | typeIs Text)
+  needs (pattern | typeIs Text)
+  ✨.textEndsWith text pattern
+textFromUtf8 bytes :=
+  needs (bytes | typeIs List)
+  ## TODO: Add this when it runs faster.
+  ## needs (bytes | iterable.fromList | iterable.all { byte ->
+  ##   bool.lazyAnd (int.is byte) {
+  ##     bool.and (byte | int.isNonNegative) (byte | int.isLessThan 256)
+  ##   }
+  ## })
+  ✨.textFromUtf8 bytes
+textGetRange text startInclusive endExclusive :=
+  needs (text | typeIs Text)
+  needs (startInclusive | typeIs Int)
+  needs (startInclusive | isNonNegative)
+  needs (startInclusive | intCompareTo (text | ✨.textLength) | equals Less)
+  needs (endExclusive | typeIs Int)
+  needs (endExclusive | isNonNegative)
+  needs (endExclusive | isLessThanOrEqualTo (text | ✨.textLength))
+  needs (startInclusive | isLessThanOrEqualTo endExclusive)
+  ✨.textGetRange text startInclusive endExclusive
+textIsEmpty text :=
+  needs (text | typeIs Text)
+  ✨.textIsEmpty text
+textLength text :=
+  # Returns the number of characters (Unicode grapheme clusters) in this text.
+  needs (text | typeIs Text)
+  ✨.textLength text
+textStartsWith text pattern :=
+  needs (text | typeIs Text)
+  needs (pattern | typeIs Text)
+  ✨.textStartsWith text pattern
+textTrimEnd text :=
+  needs (text | typeIs Text)
+  # text
+  ✨.textTrimEnd text
+textTrimStart text :=
+  needs (text | typeIs Text)
+  # text
+  ✨.textTrimStart text
+
+toDebugText any :=
+  ✨.toDebugText any
+
+try function :=
+  # Returns `Ok result` if `function` returns normally and `Error panicReason`
+  # if the `function` panics.
+  needs (function | typeIs Function)
+  needs (function | getArgumentCount | equals 0)
+  ✨.try function
+
+typeOf any :=
+  # typeTag
+  ✨.typeOf any

--- a/packages/Builtins/_.candy
+++ b/packages/Builtins/_.candy
@@ -142,7 +142,7 @@ intShiftLeft value amount :=
   needs (amount | typeIs Int)
   needs
     amount | isNonNegative
-    "The shift `amount` is negative: {amount | ✨.toDebugText}. You might want to call `shiftRight` instead."
+    "The shift `amount` is negative: {amount}. You might want to call `shiftRight` instead."
   needs (amount | fitsInRustU128) "Shifts by that much are not yet supported."
   ✨.intShiftLeft value amount
 intShiftRight value amount :=
@@ -150,7 +150,7 @@ intShiftRight value amount :=
   needs (amount | typeIs Int)
   needs
     amount | isNonNegative
-    "The shift `amount` is negative: {amount | ✨.toDebugText}. You might want to call `shiftLeft` instead."
+    "The shift `amount` is negative: {amount}. You might want to call `shiftLeft` instead."
   needs (amount | fitsInRustU128) "Shifts by that much are not yet supported."
   ✨.intShiftRight value amount
 intSubtract minuend subtrahend :=

--- a/packages/Core/bool.candy
+++ b/packages/Core/bool.candy
@@ -2,23 +2,25 @@
 function = use "..function"
 type = use "..type"
 
-is value := ✨.ifElse (equals value True) { True } { equals value False }
+is value := value %
+  True | False -> True
+  _ -> False
 
-not a :=
-  needs (is a)
-  ✨.ifElse a { False } { True }
+not value :=
+  needs (is value)
+  value %
+    True -> False
+    False -> True
 
 lazyAnd a b :=
   needs (is a)
   needs (function.is0 b)
-  ✨.ifElse
-    a
-    {
-      result = b | ✨.functionRun
+  a %
+    True ->
+      result = b | function.run
       needs (is result) "`b` didn't return a bool."
       result
-    }
-    { False }
+    False -> False
 and a b :=
   needs (is a)
   needs (is b)
@@ -27,11 +29,12 @@ and a b :=
 lazyOr a b :=
   needs (is a)
   needs (function.is0 b)
-  ✨.ifElse a { True } {
-    result = b | ✨.functionRun
-    needs (is result) "`b` didn't return a bool."
-    result
-  }
+  a %
+    True -> True
+    False ->
+      result = b | function.run
+      needs (is result) "`b` didn't return a bool."
+      result
 or a b :=
   needs (is a)
   needs (is b)
@@ -40,9 +43,9 @@ or a b :=
 xor a b :=
   needs (is a)
   needs (is b)
-  equals a (not b)
+  a | equals (b | not)
 
 implies a b :=
   needs (is a)
   needs (is b)
-  ✨.ifElse a { b } { True }
+  a | not | or b

--- a/packages/Core/channel.candy
+++ b/packages/Core/channel.candy
@@ -1,3 +1,4 @@
+builtins = use "Builtins"
 bool = use "..bool"
 [equals] = use "..equality"
 [if] = use "..controlFlow"
@@ -7,27 +8,7 @@ type = use "..type"
 isSendPort value := type.is value SendPort
 isReceivePort value := type.is value ReceivePort
 
-create capacity :=
-  needs
-    int.is capacity
-    "`capacity` is not an integer. Channels need a capacity because otherwise, there would be no backpressure among fibers, and memory leaks would go unnoticed."
-  needs (int.isNonNegative capacity)
-  needs (int.fitsInRustU32 capacity)
-  # Technically, it needs to fit in a usize, the natural word length on systems.
-  # Typically, this is 64-bits, so we are conservative here, although there
-  # also exist exotic/old systems with smaller word sizes of 16 bits.
-  ✨.channelCreate capacity
+create := builtins.channelCreate
 
-send port packet :=
-  needs
-    bool.not (isReceivePort port)
-    "`port` should be a send port, not a receive port."
-  needs (isSendPort port)
-  port | ✨.channelSend packet
-
-receive port :=
-  needs
-    bool.not (isSendPort port)
-    "`port` should be a receive port, not a send port."
-  needs (isReceivePort port)
-  port | ✨.channelReceive
+send := builtins.channelSend
+receive := builtins.channelReceive

--- a/packages/Core/concurrency.candy
+++ b/packages/Core/concurrency.candy
@@ -1,12 +1,9 @@
+builtins = use "Builtins"
 channel = use "..channel"
 function = use "..function"
 [if] = use "..controlFlow"
 
-parallel body :=
-  needs (function.is1 body) "The `body` should be a function taking a nursery."
-  ## TODO: Propagate the responsibility here. `body` may contain a `needs` that
-  ## always fails. That shouldn't be our fault, but our caller's.
-  ✨.parallel body
+parallel := builtins.parallel
 
 async nursery body :=
   needs (channel.isSendPort nursery)

--- a/packages/Core/controlFlow.candy
+++ b/packages/Core/controlFlow.candy
@@ -1,14 +1,10 @@
+builtins = use "Builtins"
 bool = use "..bool"
 [equals] = use "..equality"
 function = use "..function"
 [typeOf] = use "..type"
 
-ifElse condition then else :=
-  needs (bool.is condition)
-  needs (function.is0 then)
-  needs (function.is0 else)
-  ✨.ifElse condition then else
-
+ifElse := builtins.ifElse
 if condition then :=
   needs (bool.is condition)
   needs (function.is0 then)
@@ -39,11 +35,11 @@ loop body :=
 
 repeat times body :=
   needs (typeOf times | equals Int)
-  needs (times | ✨.intCompareTo 0 | equals Less | bool.not)
+  needs (times | builtins.intCompareTo 0 | equals Less | bool.not)
   needs (function.is0 body)
   recursive times { recurse times ->
-    if (times | ✨.intCompareTo 0 | equals Greater) {
+    if (times | builtins.intCompareTo 0 | equals Greater) {
       function.run body
-      recurse (✨.intSubtract times 1)
+      recurse (times | builtins.intSubtract 1)
     }
   }

--- a/packages/Core/equality.candy
+++ b/packages/Core/equality.candy
@@ -1,1 +1,3 @@
-equals a b := ✨.equals a b
+builtins = use "Builtins"
+
+equals := builtins.equals

--- a/packages/Core/function.candy
+++ b/packages/Core/function.candy
@@ -1,18 +1,17 @@
+builtins = use "Builtins"
 [equals] = use "..equality"
 type = use "..type"
 
 is value := type.is value Function
 
-getArgumentCount function :=
-  needs (is function)
-  ✨.getArgumentCount function
+getArgumentCount := builtins.getArgumentCount
 
-is0 value := ✨.ifElse (is value) { equals (getArgumentCount value) 0 } { False }
-is1 value := ✨.ifElse (is value) { equals (getArgumentCount value) 1 } { False }
-is2 value := ✨.ifElse (is value) { equals (getArgumentCount value) 2 } { False }
-is3 value := ✨.ifElse (is value) { equals (getArgumentCount value) 3 } { False }
-is4 value := ✨.ifElse (is value) { equals (getArgumentCount value) 4 } { False }
-is5 value := ✨.ifElse (is value) { equals (getArgumentCount value) 5 } { False }
+is0 value := builtins.ifElse (is value) { equals (getArgumentCount value) 0 } { False }
+is1 value := builtins.ifElse (is value) { equals (getArgumentCount value) 1 } { False }
+is2 value := builtins.ifElse (is value) { equals (getArgumentCount value) 2 } { False }
+is3 value := builtins.ifElse (is value) { equals (getArgumentCount value) 3 } { False }
+is4 value := builtins.ifElse (is value) { equals (getArgumentCount value) 4 } { False }
+is5 value := builtins.ifElse (is value) { equals (getArgumentCount value) 5 } { False }
 
 run body :=
   # A function that runs the given `body` with no arguments and returns its result.
@@ -23,7 +22,7 @@ run body :=
   # }
   # ```
   needs (is0 body)
-  ✨.functionRun body
+  builtins.functionRun body
 
 doNotRun body :=
   # A function that doesn't run the given `body`.

--- a/packages/Core/int.candy
+++ b/packages/Core/int.candy
@@ -1,3 +1,4 @@
+builtins = use "Builtins"
 bool = use "..bool"
 [check] = use "..check"
 [ifElse] = use "..controlFlow"
@@ -6,52 +7,30 @@ type = use "..type"
 
 is value := type.is value Int
 
-add summandA summandB :=
-  needs (is summandA)
-  needs (is summandB)
-  summandA | ✨.intAdd summandB
-subtract minuend subtrahend :=
-  needs (is minuend)
-  needs (is subtrahend)
-  minuend | ✨.intSubtract subtrahend
+add := builtins.intAdd
+subtract := builtins.intSubtract
 negate value :=
   needs (is value)
   subtract 0 value
-multiply factorA factorB :=
-  needs (is factorA)
-  needs (is factorB)
-  factorA | ✨.intMultiply factorB
-divideTruncating dividend divisor :=
-  needs (is dividend)
-  needs (is divisor)
-  needs (divisor | equals 0 | bool.not) "You can't divide by zero."
-  dividend | ✨.intDivideTruncating divisor
-remainder dividend divisor :=
-  needs (is dividend)
-  needs (is divisor)
-  needs (divisor | equals 0 | bool.not) "You can't divide by zero."
-  dividend | ✨.intRemainder divisor
-modulo dividend divisor :=
-  needs (is dividend)
-  needs (is divisor)
-  needs (divisor | equals 0 | bool.not) "You can't divide by zero."
-  dividend | ✨.intModulo divisor
+multiply := builtins.intMultiply
+divideTruncating := builtins.intDivideTruncating
+remainder := builtins.intRemainder
+modulo := builtins.intModulo
 
 compareTo valueA valueB :=
   needs (is valueA)
   needs (is valueB)
-  result = valueA | ✨.intCompareTo valueB
-  check (equals result Equal | bool.implies (equals valueA valueB))
-  # check ((equals result Equal) | bool.implies (equals valueA valueB))
+  result = valueA | builtins.intCompareTo valueB
+  check (result | equals Equal | bool.implies (equals valueA valueB))
   result
 isLessThan valueA valueB :=
   needs (is valueA)
   needs (is valueB)
-  equals (compareTo valueA valueB) Less
+  valueA | compareTo valueB | equals Less
 isGreaterThan valueA valueB :=
   needs (is valueA)
   needs (is valueB)
-  equals (compareTo valueA valueB) Greater
+  valueA | compareTo valueB | equals Greater
 isLessThanOrEqualTo valueA valueB :=
   needs (is valueA)
   needs (is valueB)
@@ -92,50 +71,21 @@ fitsInRustU128 value :=
   # https://doc.rust-lang.org/std/primitive.u128.html#associatedconstant.MAX
   value | isLessThan rustU128Max
 
-shiftLeft value amount :=
-  needs (is value)
-  needs (is amount)
-  needs
-    isNonNegative amount
-    "The shift `amount` is negative. You might want to call `shiftRight` instead."
-  # TODO: Add the negated value in the error message as soon as we support string interpolation.
-  needs (fitsInRustU128 amount) "Shifts by that much are not yet supported."
-  value | ✨.intShiftLeft amount
-shiftRight value amount :=
-  needs (is value)
-  needs (is amount)
-  needs
-    isNonNegative amount
-    "The shift `amount` is negative. You might want to call `shiftLeft` instead."
-  # TODO: Add the negated value in the error message as soon as we support string interpolation.
-  needs (fitsInRustU128 amount) "Shifts by that much are not yet supported."
-  value | ✨.intShiftRight amount
+shiftLeft := builtins.intShiftLeft
+shiftRight := builtins.intShiftRight
 
-bitLength value :=
-  # Determines the fewest bits necessary to express this integer, not including
-  # the sign.
-  needs (is value)
-  value | ✨.intBitLength
+bitLength := builtins.intBitLength
 
-bitwiseAnd valueA valueB :=
-  needs (is valueA)
-  needs (is valueB)
-  valueA | ✨.intBitwiseAnd valueB
-bitwiseOr valueA valueB :=
-  needs (is valueA)
-  needs (is valueB)
-  valueA | ✨.intBitwiseOr valueB
-bitwiseXor valueA valueB :=
-  needs (is valueA)
-  needs (is valueB)
-  valueA | ✨.intBitwiseXor valueB
+bitwiseAnd := builtins.intBitwiseAnd
+bitwiseOr := builtins.intBitwiseOr
+bitwiseXor := builtins.intBitwiseXor
 
 isEven value :=
   needs (is value)
-  equals (bitwiseAnd value 1) 0
+  value | bitwiseAnd 1 | equals 0
 isOdd value :=
   needs (is value)
-  isOdd = equals (bitwiseAnd value 1) 1
+  isOdd = value | bitwiseAnd 1 | equals 1
   check (value | isEven | equals (isOdd | bool.not))
   isOdd
 
@@ -162,6 +112,4 @@ coerceIn value minimum maximum :=
   needs (minimum | isLessThanOrEqualTo maximum)
   value | coerceAtLeast minimum | coerceAtMost maximum
 
-parse text :=
-  needs (type.is text Text)
-  text | ✨.intParse
+parse := builtins.intParse

--- a/packages/Core/iterable.candy
+++ b/packages/Core/iterable.candy
@@ -238,9 +238,7 @@ windowed iterable size step allowPartialWindows :=
   generateWithState iterable { iterable ->
     items = iterable | take size | toList
     length = items | list.length
-    isLongEnough = ifElse allowPartialWindows { length | int.isPositive } {
-      length | int.equals size
-    }
+    isLongEnough = ifElse allowPartialWindows { length | int.isPositive } { length | equals size }
     ifElse isLongEnough { Ok [Item: items, State: iterable | skip step] } { Error Empty }
   }
 chunked iterable size :=

--- a/packages/Core/iterable.candy
+++ b/packages/Core/iterable.candy
@@ -164,14 +164,14 @@ where iterable tester :=
   needs (function.is1 tester)
   whereHelper whereHelper iterable tester
 
-takeWhile iterable tester = generateWithState iterable { iterable ->
+takeWhile iterable tester := generateWithState iterable { iterable ->
   iterable | next | result.flatMap { itemAndRest ->
     [item, rest] = itemAndRest
     ifElse (tester item) { Ok [item, State: rest] } { Error Empty }
   }
 }
 
-takeUntil iterable tester = iterable | takeWhile { item -> tester item | bool.not }
+takeUntil iterable tester := iterable | takeWhile { item -> tester item | bool.not }
 
 take iterable n :=
   needs (is iterable)

--- a/packages/Core/list.candy
+++ b/packages/Core/list.candy
@@ -1,3 +1,4 @@
+builtins = use "Builtins"
 bool = use "..bool"
 [ifElse, recursive] = use "..controlFlow"
 [equals] = use "..equality"
@@ -8,9 +9,7 @@ type = use "..type"
 
 is value := type.is value List
 
-length list :=
-  needs (is list)
-  list | ✨.listLength
+length := builtins.listLength
 isEmpty list :=
   needs (is list)
   equals (length list) 0
@@ -31,11 +30,7 @@ isValidInsertIndex list index :=
   ifElse (list | isEmpty) { False } { index | int.isNonNegative }
   | bool.lazyAnd { index | int.isLessThanOrEqualTo (list | length) }
 
-get list index :=
-  needs (is list)
-  needs (int.is index)
-  needs (list | isValidIndex index)
-  list | ✨.listGet index
+get := builtins.listGet
 
 # TODO: add `single list` when we have pattern matching
 last list :=
@@ -43,13 +38,7 @@ last list :=
   list | lastIndex | result.mapError { _ -> "Can't get the last item of an empty list." }
   | result.map { index -> list | get index }
 
-insert list index item :=
-  needs (is list)
-
-  needs (int.is index)
-  needs (list | isValidInsertIndex index)
-
-  list | ✨.listInsert index item
+insert := builtins.listInsert
 
 prepend list item :=
   needs (is list)
@@ -58,11 +47,7 @@ append list item :=
   needs (is list)
   list | insert (length list) item
 
-replace list index newValue :=
-  needs (is list)
-  needs (int.is index)
-  needs (list | isValidIndex index)
-  list | ✨.listReplace index newValue
+replace := builtins.listReplace
 update list index updater :=
   needs (is list)
   needs (int.is index)
@@ -72,18 +57,9 @@ update list index updater :=
   newValue = updater oldValue
   list | replace index newValue
 
-removeAt list index :=
-  needs (is list)
-  needs (int.is index)
-  needs (list | isValidIndex index)
-  list | ✨.listRemoveAt index
+removeAt := builtins.listRemoveAt
 
-filled length item :=
-  # Creates a new list of the given `length`, where each slot is filled with the same item.
-  needs (int.is length)
-  needs (int.isNonNegative length)
-  needs (int.fitsInRustU32 length)
-  ✨.listFilled length item
+filled := builtins.listFilled
 generate length valueGetter :=
   # Creates a new list of the given `length`, where each slot is filled by calling `valueGetter`
   # with the index.

--- a/packages/Core/struct.candy
+++ b/packages/Core/struct.candy
@@ -1,3 +1,4 @@
+builtins = use "Builtins"
 [ifElse] = use "..controlFlow"
 type = use "..type"
 
@@ -5,14 +6,14 @@ is value := type.is value Struct
 
 hasKey struct key :=
   needs (is struct)
-  struct | ✨.structHasKey key
+  struct | builtins.structHasKey key
 
 get struct key :=
   needs (is struct)
-  ifElse (struct | hasKey key) { Ok (struct | ✨.structGet key) } {
+  ifElse (struct | hasKey key) { Ok (struct | builtins.structGet key) } {
     Error "Key {key} not found in struct"
   }
 
 getKeys struct :=
   needs (is struct)
-  struct | ✨.structGetKeys
+  struct | builtins.structGetKeys

--- a/packages/Core/symbol.candy
+++ b/packages/Core/symbol.candy
@@ -1,3 +1,0 @@
-type = use "..type"
-
-is value := type.is value Symbol

--- a/packages/Core/tag.candy
+++ b/packages/Core/tag.candy
@@ -1,24 +1,20 @@
+builtins = use "Builtins"
+bool = use "..bool"
 [ifElse] = use "..controlFlow"
 type = use "..type"
 
 is value := type.is value Tag
 
-hasValue tag :=
-  needs (is tag)
-  tag | ✨.tagHasValue
+hasValue := builtins.tagHasValue
 
-withoutValue tag :=
-  needs (is tag)
-  tag | ✨.tagWithoutValue
+withoutValue := builtins.tagWithoutValue
 
-getValue tag :=
-  needs (is tag)
-  needs (hasValue tag)
-  tag | ✨.tagGetValue
+getValue := builtins.tagGetValue
 
 withSymbol tag symbolTag :=
   needs (is tag)
   needs (is symbolTag)
+  needs (symbolTag | hasValue | bool.not)
   ifElse (tag | hasValue) { symbolTag (tag | getValue) } { symbolTag | withoutValue }
 
 withValue tag value :=

--- a/packages/Core/text.candy
+++ b/packages/Core/text.candy
@@ -1,3 +1,4 @@
+builtins = use "Builtins"
 bool = use "..bool"
 [ifElse] = use "..controlFlow"
 [equals] = use "..equality"
@@ -9,28 +10,12 @@ type = use "..type"
 
 is value := type.is value Text
 
-fromUtf8 bytes :=
-  needs (list.is bytes)
-  # TODO: Add this when it runs faster.
-  # needs (bytes | iterable.fromList | iterable.all { byte ->
-  #   bool.lazyAnd (int.is byte) {
-  #     bool.and (byte | int.isNonNegative) (byte | int.isLessThan 256)
-  #   }
-  # })
+fromUtf8 := builtins.textFromUtf8
 
-  bytes | ✨.textFromUtf8
+isEmpty := builtins.textIsEmpty
+length := builtins.textLength
 
-isEmpty text :=
-  needs (is text)
-  text | ✨.textIsEmpty
-length text :=
-  # Returns the number of Unicode grapheme clusters in this text.
-  needs (is text)
-  text | ✨.textLength
-
-characters text :=
-  needs (is text)
-  text | ✨.textCharacters
+characters := builtins.textCharacters
 characterAt text index :=
   needs (is text)
   needs (int.is index)
@@ -38,38 +23,14 @@ characterAt text index :=
   needs (int.isLessThan index (length text))
   text | characters | list.get index
 
-getRange text startInclusive endExclusive :=
-  needs (is text)
+# TODO: Support ranges when we have them.
+getRange := builtins.textGetRange
 
-  needs (int.is startInclusive)
-  needs (int.isNonNegative startInclusive)
+concatenate := builtins.textConcatenate
 
-  needs (int.is endExclusive)
-  needs (int.isNonNegative endExclusive)
-
-  needs (int.isLessThanOrEqualTo startInclusive endExclusive)
-  needs (int.isLessThanOrEqualTo endExclusive (length text))
-
-  # TODO: Support ranges when we have them.
-  text | ✨.textGetRange startInclusive endExclusive
-
-concatenate textA textB :=
-  needs (is textA)
-  needs (is textB)
-  textA | ✨.textConcatenate textB
-
-startsWith text pattern :=
-  needs (is text)
-  needs (is pattern)
-  text | ✨.textStartsWith pattern
-endsWith text pattern :=
-  needs (is text)
-  needs (is pattern)
-  text | ✨.textEndsWith pattern
-contains text pattern :=
-  needs (is text)
-  needs (is pattern)
-  text | ✨.textContains pattern
+startsWith := builtins.textStartsWith
+endsWith := builtins.textEndsWith
+contains := builtins.textContains
 
 removePrefix text prefix :=
   needs (is text)
@@ -84,12 +45,8 @@ removeSuffix text suffix :=
     { text | getRange (textLength | int.subtract (suffix | length)) textLength }
     { text }
 
-trimStart text :=
-  needs (is text)
-  text | ✨.textTrimStart
-trimEnd text :=
-  needs (is text)
-  text | ✨.textTrimEnd
+trimStart := builtins.textTrimStart
+trimEnd := builtins.textTrimEnd
 trim text :=
   needs (is text)
   text | trimStart | trimEnd

--- a/packages/Core/toDebugText.candy
+++ b/packages/Core/toDebugText.candy
@@ -1,1 +1,3 @@
-toDebugText value := ✨.toDebugText value
+builtins = use "Builtins"
+
+toDebugText value := builtins.toDebugText value

--- a/packages/Core/todo.candy
+++ b/packages/Core/todo.candy
@@ -1,7 +1,8 @@
+panic = use "..panic"
 text = use "..text"
 
 todo message :=
   # Always panics with a todo message.
   needs (text.is message)
   ## There is no way to call `todo` correctly.
-  needs False "TODO: {message}"
+  panic "TODO: {message}"

--- a/packages/Core/todo.candy
+++ b/packages/Core/todo.candy
@@ -1,4 +1,3 @@
-panic = use "..panic"
 text = use "..text"
 
 todo message :=

--- a/packages/Core/todo.candy
+++ b/packages/Core/todo.candy
@@ -5,4 +5,4 @@ todo message :=
   # Always panics with a todo message.
   needs (text.is message)
   ## There is no way to call `todo` correctly.
-  panic "TODO: {message}"
+  needs False "TODO: {message}"

--- a/packages/Core/type.candy
+++ b/packages/Core/type.candy
@@ -1,6 +1,7 @@
+builtins = use "Builtins"
 [equals] = use "..equality"
 
-typeOf value := ✨.typeOf value
+typeOf := builtins.typeOf
 
 is value type :=
   needs (typeOf type | equals Tag)

--- a/packages/examples/_.candy
+++ b/packages/examples/_.candy
@@ -2,6 +2,7 @@
 # `cargo build --release -- run`
 # `cargo build --release && time target/release/candy run`
 
+builtins = use "Builtins"
 # [channel, text] = use "Core"
 # 
 # echo = use ".echo"
@@ -12,6 +13,6 @@ main := { environment ->
   #   needs (text.is message)
   #   environment.stdout | channel.send message
 
-  result = 1 | ✨.intAdd 2
-  result | ✨.toDebugText | ✨.print
+  result = 1 | builtins.intAdd 2
+  result | builtins.toDebugText | builtins.print
 }

--- a/packages/examples/fibonacci.candy
+++ b/packages/examples/fibonacci.candy
@@ -1,3 +1,4 @@
+builtins = use "Builtins"
 # [ifElse, int, recursive] = use "Core"
 
 recursive initialArg body :=
@@ -13,20 +14,20 @@ recursive initialArg body :=
 compareTo valueA valueB :=
   # needs (is valueA)
   # needs (is valueB)
-  result = valueA | ✨.intCompareTo valueB
+  result = valueA | builtins.intCompareTo valueB
   # check (equals result Equal | bool.implies (equals valueA valueB))
   # check ((equals result Equal) | bool.implies (equals valueA valueB))
   result
 isLessThan valueA valueB :=
   # needs (is valueA)
   # needs (is valueB)
-  ✨.equals (compareTo valueA valueB) Less
+  builtins.equals (compareTo valueA valueB) Less
 
 fibonacci n =
   # needs (int.is n)
   recursive n { recurse n ->
-    ✨.ifElse (n | isLessThan 2) { n } {
-      recurse (n | ✨.intSubtract 1) | ✨.intAdd (recurse (n | ✨.intSubtract 2))
+    builtins.ifElse (n | isLessThan 2) { n } {
+      recurse (n | builtins.intSubtract 1) | builtins.intAdd (recurse (n | builtins.intSubtract 2))
     }
   }
 

--- a/packages/examples/helloWorld.candy
+++ b/packages/examples/helloWorld.candy
@@ -1,5 +1,5 @@
 # A self-contained hello world example that doesn't even use the Core library.
 
-main := { environment ->
-  environment.stdout | ✨.channelSend "Hello, world!"
-}
+builtins = use "Builtins"
+
+main := { environment -> environment.stdout | builtins.channelSend "Hello, world!" }

--- a/packages/examples/iterable.candy
+++ b/packages/examples/iterable.candy
@@ -1,33 +1,29 @@
-core = use "Core"
-bool = core.bool
-ifElse = core.ifElse
-iterable = core.iterable
-list = core.list
-result = core.result
+builtins = use "Builtins"
+[bool, channel, equals, ifElse, iterable, list, result, text] = use "Core"
 
 splitWhereFirst iter checker =
   # Splits the iterable into a list and an iterable of the remaining items. The
   # matching item itself is still the first item of the remaining iterable.
-  ✨.print "Getting leading items"
+  builtins.print "Getting leading items"
   firstPart = iter | iterable.takeUntil { item -> checker item } | iterable.toList
-  ✨.print "Turned into list"
+  builtins.print "Turned into list"
   (firstPart, iter | iterable.skip (firstPart | list.length))
 
-split iter delimeter = iterable.newWithState iter { state ->
-  state | iterable.takeUntil { item -> core.equals item delimeter }
+split iter delimeter = iterable.generateWithState iter { state ->
+  state | iterable.takeUntil { item -> equals item delimeter }
   state | iterable.next | result.map { }
 }
 
 main := { env ->
-  print = { message -> core.channel.send env.stdout message }
+  print = { message -> channel.send env.stdout message }
 
   foo =
-    "Hello, world! This is some long text. Bla bla blub." | core.text.characters | iterable.fromList
+    "Hello, world! This is some long text. Bla bla blub." | text.characters | iterable.fromList
   #| splitWhereFirst { c ->
-  #  ✨.print c
-  #  core.equals c ","
+  #  builtins.print c
+  #  equals c ","
   #}
-  #✨.print "Hi"
-  #✨.print foo
+  #builtins.print "Hi"
+  #builtins.print foo
   | iterable.forEach { item -> print item }
 }

--- a/packages/examples/sqrt.candy
+++ b/packages/examples/sqrt.candy
@@ -1,3 +1,4 @@
+builtins = use "Builtins"
 [equals, fixedDecimal, ifElse, recursive] = use "Core"
 
 sqrt x :=
@@ -15,4 +16,4 @@ sqrt x :=
 main _ :=
   input = 2
   result = input | fixedDecimal.fromInt | sqrt
-  ✨.print "The root of {input} is {result | fixedDecimal.toText}"
+  builtins.print "The root of {input} is {result | fixedDecimal.toText}"

--- a/vscode_extension/declarative/language-configuration.json
+++ b/vscode_extension/declarative/language-configuration.json
@@ -26,13 +26,13 @@
       "action": { "indent": "none", "appendText": "##" }
     },
     {
-      // Octothorpe with space when there's not already an existing space after.
+      // Octothorpes with space when there's not already an existing space after.
       "beforeText": "^\\s*## ",
       "afterText": "[^ ]*$",
       "action": { "indent": "none", "appendText": "## " }
     },
     {
-      // Octothorpe without space.
+      // Octothorpes without space.
       "beforeText": "^\\s*##",
       "action": { "indent": "none", "appendText": "##" }
     },

--- a/vscode_extension/declarative/language-configuration.json
+++ b/vscode_extension/declarative/language-configuration.json
@@ -15,7 +15,7 @@
   },
   "indentationRules": {
     "increaseIndentPattern": "^[^#]*(\\([^)#]*|\\[[^\\]#]*|\\{[^}#]*|=\\s*(#.*)?|\"[^\"]*)$",
-    "decreaseIndentPattern": "^[\\)\\]\\}\"].*$"
+    "decreaseIndentPattern": "^[\\)\\]\\}].*$"
   },
   "surroundingPairs": [
     ["(", ")"],

--- a/vscode_extension/declarative/language-configuration.json
+++ b/vscode_extension/declarative/language-configuration.json
@@ -19,6 +19,24 @@
   },
   "onEnterRules": [
     {
+      // Octothorpes without space when there's already an existing space after
+      // so we don't need to insert one.
+      "beforeText": "^\\s*##",
+      "afterText": "^ ",
+      "action": { "indent": "none", "appendText": "##" }
+    },
+    {
+      // Octothorpe with space when there's not already an existing space after.
+      "beforeText": "^\\s*## ",
+      "afterText": "[^ ]*$",
+      "action": { "indent": "none", "appendText": "## " }
+    },
+    {
+      // Octothorpe without space.
+      "beforeText": "^\\s*##",
+      "action": { "indent": "none", "appendText": "##" }
+    },
+    {
       // Octothorpe without space when there's already an existing space after
       // so we don't need to insert one.
       "beforeText": "^\\s*#",

--- a/vscode_extension/declarative/language-configuration.json
+++ b/vscode_extension/declarative/language-configuration.json
@@ -19,8 +19,8 @@
   },
   "onEnterRules": [
     {
-      // Octothorpe with space when there's already an existing space after so
-      // we don't need to insert one.
+      // Octothorpe without space when there's already an existing space after
+      // so we don't need to insert one.
       "beforeText": "^\\s*#",
       "afterText": "^ ",
       "action": { "indent": "none", "appendText": "#" }

--- a/vscode_extension/declarative/language-configuration.json
+++ b/vscode_extension/declarative/language-configuration.json
@@ -17,6 +17,26 @@
     "increaseIndentPattern": "^[^#]*(\\([^)#]*|\\[[^\\]#]*|\\{[^}#]*|=\\s*(#.*)?|\"[^\"]*)$",
     "decreaseIndentPattern": "^[\\)\\]\\}].*$"
   },
+  "onEnterRules": [
+    {
+      // Octothorpe with space when there's already an existing space after so
+      // we don't need to insert one.
+      "beforeText": "^\\s*#",
+      "afterText": "^ ",
+      "action": { "indent": "none", "appendText": "#" }
+    },
+    {
+      // Octothorpe with space when there's not already an existing space after.
+      "beforeText": "^\\s*# ",
+      "afterText": "[^ ]*$",
+      "action": { "indent": "none", "appendText": "# " }
+    },
+    {
+      // Octothorpe without space.
+      "beforeText": "^\\s*#",
+      "action": { "indent": "none", "appendText": "#" }
+    }
+  ],
   "surroundingPairs": [
     ["(", ")"],
     ["[", "]"],


### PR DESCRIPTION
<!-- Please enter the corresponding issue ID: -->

<!-- Please summarize your changes: -->
- Builtins now live in the separate `Builtins` package and `✨` can only be accessed in there.
  - Outside that package, struct accesses use `(use "Builtins").structGet` to reuse the validation logic.
- When writing a comment in Candy and pressing enter, the new line receives a leading `# ` as well.


### Checklist
<!-- Please check if your PR fulfills the following requirements: -->

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
