### PR TITLE
Disable reference counting for constants

### DIFF
--- a/compiler/cli/src/run.rs
+++ b/compiler/cli/src/run.rs
@@ -72,9 +72,9 @@ pub(crate) fn run(options: Options) -> ProgramResult {
         ("Stdout", SendPort::create(&mut ended.heap, stdout.channel)),
         ("Stdin", SendPort::create(&mut ended.heap, stdin.channel)),
     ];
-    let environment = Struct::create_with_symbol_keys(&mut ended.heap, fields).into();
+    let environment = Struct::create_with_symbol_keys(&mut ended.heap, true, fields).into();
     let mut tracer = StackTracer::default();
-    let platform = HirId::create(&mut ended.heap, hir::Id::platform());
+    let platform = HirId::create(&mut ended.heap, true, hir::Id::platform());
     vm.initialize_for_function(
         ended.heap,
         ended.constant_mapping,

--- a/compiler/cli/src/run.rs
+++ b/compiler/cli/src/run.rs
@@ -75,14 +75,7 @@ pub(crate) fn run(options: Options) -> ProgramResult {
     let environment = Struct::create_with_symbol_keys(&mut ended.heap, true, fields).into();
     let mut tracer = StackTracer::default();
     let platform = HirId::create(&mut ended.heap, true, hir::Id::platform());
-    vm.initialize_for_function(
-        ended.heap,
-        ended.constant_mapping,
-        main,
-        &[environment],
-        platform,
-        &mut tracer,
-    );
+    vm.initialize_for_function(ended.heap, main, &[environment], platform, &mut tracer);
     loop {
         match vm.status() {
             Status::CanRun => {

--- a/compiler/cli/src/services/stdin.rs
+++ b/compiler/cli/src/services/stdin.rs
@@ -40,7 +40,7 @@ impl StdinService {
             };
             let packet = {
                 let mut heap = Heap::default();
-                let object = Text::create(&mut heap, &input).into();
+                let object = Text::create(&mut heap, true, &input).into();
                 Packet { heap, object }
             };
             vm.send(request.channel_id(), packet);

--- a/compiler/fuzzer/src/input_pool.rs
+++ b/compiler/fuzzer/src/input_pool.rs
@@ -23,8 +23,8 @@ impl InputPool {
             .iter()
             .map(|symbol| symbol.clone_to_heap(&mut heap).try_into().unwrap())
             .collect_vec();
-        symbols.push(Text::create(&mut heap, "True"));
-        symbols.push(Text::create(&mut heap, "False"));
+        symbols.push(Text::create(&mut heap, true, "True"));
+        symbols.push(Text::create(&mut heap, true, "False"));
 
         Self {
             heap: Rc::new(RefCell::new(heap)),

--- a/compiler/fuzzer/src/runner.rs
+++ b/compiler/fuzzer/src/runner.rs
@@ -72,7 +72,7 @@ impl<L: Borrow<Lir>> Runner<L> {
         let arguments = input
             .arguments
             .clone_to_heap_with_mapping(&mut heap, &mut mapping);
-        let responsible = HirId::create(&mut heap, Id::fuzzer());
+        let responsible = HirId::create(&mut heap, true, Id::fuzzer());
 
         let mut tracer = StackTracer::default();
         let vm = Vm::for_function(

--- a/compiler/language_server/src/debug_adapter/session.rs
+++ b/compiler/language_server/src/debug_adapter/session.rs
@@ -209,8 +209,8 @@ impl DebugSession {
                     .await;
 
                 // Run the `main` function.
-                let environment = Struct::create(&mut heap, &FxHashMap::default()).into();
-                let platform = HirId::create(&mut heap, Id::platform());
+                let environment = Struct::create(&mut heap, true, &FxHashMap::default()).into();
+                let platform = HirId::create(&mut heap, true, Id::platform());
                 let mut tracer = DebugTracer;
                 vm.initialize_for_function(
                     heap,

--- a/compiler/language_server/src/debug_adapter/session.rs
+++ b/compiler/language_server/src/debug_adapter/session.rs
@@ -192,17 +192,16 @@ impl DebugSession {
                     evaluated_expressions: TracingMode::All,
                 };
                 let lir = compile_lir(&self.db, module.clone(), tracing.clone()).0;
-                let (mut heap, main, constant_mapping) =
-                    match Vm::for_module(&lir, &mut DummyTracer)
-                        .run_until_completion(&mut DummyTracer)
-                        .into_main_function()
-                    {
-                        Ok(result) => result,
-                        Err(error) => {
-                            error!("Failed to find main function: {error}");
-                            return Err("program-invalid");
-                        }
-                    };
+                let (mut heap, main) = match Vm::for_module(&lir, &mut DummyTracer)
+                    .run_until_completion(&mut DummyTracer)
+                    .into_main_function()
+                {
+                    Ok(result) => result,
+                    Err(error) => {
+                        error!("Failed to find main function: {error}");
+                        return Err("program-invalid");
+                    }
+                };
 
                 let mut vm = Vm::uninitialized(Rc::new(lir));
                 self.send_response_ok(request.seq, ResponseBody::Launch)
@@ -212,14 +211,7 @@ impl DebugSession {
                 let environment = Struct::create(&mut heap, true, &FxHashMap::default()).into();
                 let platform = HirId::create(&mut heap, true, Id::platform());
                 let mut tracer = DebugTracer;
-                vm.initialize_for_function(
-                    heap,
-                    constant_mapping,
-                    main,
-                    &[environment],
-                    platform,
-                    &mut tracer,
-                );
+                vm.initialize_for_function(heap, main, &[environment], platform, &mut tracer);
 
                 let mut execution_controller = RunLimitedNumberOfInstructions::new(10000);
                 // TODO: remove when we support pause and continue

--- a/compiler/vm/benches/utils.rs
+++ b/compiler/vm/benches/utils.rs
@@ -127,7 +127,7 @@ pub fn compile(db: &mut Database, source_code: &str) -> Lir {
 
 pub fn run(lir: impl Borrow<Lir>) -> Packet {
     let mut tracer = DummyTracer;
-    let (mut heap, main, constant_mapping) = Vm::for_module(lir.borrow(), &mut tracer)
+    let (mut heap, main) = Vm::for_module(lir.borrow(), &mut tracer)
         .run_until_completion(&mut tracer)
         .into_main_function()
         .unwrap();
@@ -138,7 +138,6 @@ pub fn run(lir: impl Borrow<Lir>) -> Packet {
     let ended = Vm::for_function(
         lir,
         heap,
-        constant_mapping,
         main,
         &[environment.into()],
         responsible,

--- a/compiler/vm/benches/utils.rs
+++ b/compiler/vm/benches/utils.rs
@@ -133,8 +133,8 @@ pub fn run(lir: impl Borrow<Lir>) -> Packet {
         .unwrap();
 
     // Run the `main` function.
-    let environment = Struct::create(&mut heap, &FxHashMap::default());
-    let responsible = HirId::create(&mut heap, hir::Id::user());
+    let environment = Struct::create(&mut heap, true, &FxHashMap::default());
+    let responsible = HirId::create(&mut heap, true, hir::Id::user());
     let ended = Vm::for_function(
         lir,
         heap,

--- a/compiler/vm/fuzz/fuzz_targets/fuzz_vm.rs
+++ b/compiler/vm/fuzz/fuzz_targets/fuzz_vm.rs
@@ -77,8 +77,8 @@ fuzz_target!(|data: &[u8]| {
     };
 
     // Run the `main` function.
-    let environment = Struct::create(&mut heap, &Default::default());
-    let responsible = HirId::create(&mut heap, hir::Id::user());
+    let environment = Struct::create(&mut heap, true, &Default::default());
+    let responsible = HirId::create(&mut heap, true, hir::Id::user());
     match Vm::for_function(
         &lir,
         heap,

--- a/compiler/vm/fuzz/fuzz_targets/fuzz_vm.rs
+++ b/compiler/vm/fuzz/fuzz_targets/fuzz_vm.rs
@@ -71,7 +71,7 @@ fuzz_target!(|data: &[u8]| {
 
     let result = Vm::for_module(&lir, &mut DummyTracer).run_until_completion(&mut DummyTracer);
 
-    let Ok((mut heap, main, constant_mapping)) = result.into_main_function() else {
+    let Ok((mut heap, main)) = result.into_main_function() else {
         println!("The module doesn't export a main function.");
         return;
     };
@@ -82,7 +82,6 @@ fuzz_target!(|data: &[u8]| {
     match Vm::for_function(
         &lir,
         heap,
-        constant_mapping,
         main,
         &[environment.into()],
         responsible,

--- a/compiler/vm/src/builtin_functions.rs
+++ b/compiler/vm/src/builtin_functions.rs
@@ -196,7 +196,7 @@ impl Heap {
 
     fn equals(&mut self, args: &[InlineObject]) -> BuiltinResult {
         unpack_and_later_drop!(self, args, |a: Any, b: Any| {
-            Return(Tag::create_bool(self, **a == **b).into())
+            Return(Tag::create_bool(self, true, **a == **b).into())
         })
     }
 
@@ -210,7 +210,7 @@ impl Heap {
     }
     fn get_argument_count(&mut self, args: &[InlineObject]) -> BuiltinResult {
         unpack_and_later_drop!(self, args, |function: Function| {
-            Return(Int::create(self, function.argument_count()).into())
+            Return(Int::create(self, true, function.argument_count()).into())
         })
     }
 
@@ -280,10 +280,10 @@ impl Heap {
     fn int_parse(&mut self, args: &[InlineObject]) -> BuiltinResult {
         unpack_and_later_drop!(self, args, |text: Text| {
             let result = match BigInt::from_str(text.get()) {
-                Ok(int) => Ok(Int::create_from_bigint(self, int).into()),
-                Err(err) => Err(Text::create(self, &err.to_string()).into()),
+                Ok(int) => Ok(Int::create_from_bigint(self, true, int).into()),
+                Err(err) => Err(Text::create(self, true, &err.to_string()).into()),
             };
-            Return(Tag::create_result(self, result).into())
+            Return(Tag::create_result(self, true, result).into())
         })
     }
     fn int_remainder(&mut self, args: &[InlineObject]) -> BuiltinResult {
@@ -319,7 +319,7 @@ impl Heap {
                 item.object.dup_by(self, length_usize - 1);
             }
 
-            Return(List::create(self, &vec![item_object; length_usize]).into())
+            Return(List::create(self, true, &vec![item_object; length_usize]).into())
         })
     }
     fn list_get(&mut self, args: &[InlineObject]) -> BuiltinResult {
@@ -342,7 +342,7 @@ impl Heap {
     }
     fn list_length(&mut self, args: &[InlineObject]) -> BuiltinResult {
         unpack_and_later_drop!(self, args, |list: List| {
-            Return(Int::create(self, list.len()).into())
+            Return(Int::create(self, true, list.len()).into())
         })
     }
     fn list_remove_at(&mut self, args: &[InlineObject]) -> BuiltinResult {
@@ -374,7 +374,7 @@ impl Heap {
     fn print(&mut self, args: &[InlineObject]) -> BuiltinResult {
         unpack_and_later_drop!(self, args, |message: Any| {
             info!("{}", message.object);
-            Return(Tag::create_nothing(self).into())
+            Return(Tag::create_nothing(self, true).into())
         })
     }
 
@@ -387,12 +387,12 @@ impl Heap {
     }
     fn struct_get_keys(&mut self, args: &[InlineObject]) -> BuiltinResult {
         unpack_and_later_drop!(self, args, |struct_: Struct| {
-            Return(List::create(self, struct_.keys()).into())
+            Return(List::create(self, true, struct_.keys()).into())
         })
     }
     fn struct_has_key(&mut self, args: &[InlineObject]) -> BuiltinResult {
         unpack_and_later_drop!(self, args, |struct_: Struct, key: Any| {
-            Return(Tag::create_bool(self, struct_.contains(key.object)).into())
+            Return(Tag::create_bool(self, true, struct_.contains(key.object)).into())
         })
     }
 
@@ -405,7 +405,7 @@ impl Heap {
     }
     fn tag_has_value(&mut self, args: &[InlineObject]) -> BuiltinResult {
         unpack_and_later_drop!(self, args, |tag: Tag| {
-            Return(Tag::create_bool(self, tag.value().is_some()).into())
+            Return(Tag::create_bool(self, true, tag.value().is_some()).into())
         })
     }
     fn tag_without_value(&mut self, args: &[InlineObject]) -> BuiltinResult {
@@ -448,7 +448,7 @@ impl Heap {
                         .ok_or_else(|| format!("Value is not a byte: {it}."))
                 })
                 .try_collect()?;
-            Return(Text::create_from_utf8(self, &bytes).into())
+            Return(Text::create_from_utf8(self, true, &bytes).into())
         })
     }
     fn text_get_range(&mut self, args: &[InlineObject]) -> BuiltinResult {
@@ -492,7 +492,7 @@ impl Heap {
     #[allow(clippy::wrong_self_convention)]
     fn to_debug_text(&mut self, args: &[InlineObject]) -> BuiltinResult {
         unpack_and_later_drop!(self, args, |value: Any| {
-            Return(Text::create(self, &format!("{:?}", **value)).into())
+            Return(Text::create(self, true, &format!("{:?}", **value)).into())
         })
     }
 
@@ -516,7 +516,7 @@ impl Heap {
                 Data::SendPort(_) => "SendPort",
                 Data::ReceivePort(_) => "ReceivePort",
             };
-            Return(Tag::create_from_str(self, type_name, None).into())
+            Return(Tag::create_from_str(self, true, type_name, None).into())
         })
     }
 }

--- a/compiler/vm/src/fiber.rs
+++ b/compiler/vm/src/fiber.rs
@@ -349,7 +349,7 @@ impl<T: FiberTracer> Fiber<T> {
             Instruction::CreateTag { symbol } => {
                 let value = self.pop_from_data_stack();
                 symbol.dup();
-                let tag = Tag::create(&mut self.heap, true, *symbol, *value);
+                let tag = Tag::create(&mut self.heap, true, *symbol, value);
                 self.push_to_data_stack(tag);
             }
             Instruction::CreateList { num_items } => {
@@ -388,7 +388,7 @@ impl<T: FiberTracer> Fiber<T> {
                 self.push_to_data_stack(function);
             }
             Instruction::PushConstant(constant) => {
-                self.push_to_data_stack(constant);
+                self.push_to_data_stack(*constant);
             }
             Instruction::PushFromStack(offset) => {
                 let address = self.get_from_data_stack(*offset);

--- a/compiler/vm/src/heap/mod.rs
+++ b/compiler/vm/src/heap/mod.rs
@@ -33,7 +33,24 @@ pub struct Heap {
 }
 
 impl Heap {
-    pub fn allocate(&mut self, header_word: u64, content_size: usize) -> HeapObject {
+    pub fn allocate(
+        &mut self,
+        kind_bits: u64,
+        is_reference_counted: bool,
+        remaining_header_word: u64,
+        content_size: usize,
+    ) -> HeapObject {
+        debug_assert_eq!(kind_bits & !HeapObject::KIND_MASK, 0);
+        debug_assert_eq!(
+            remaining_header_word & (HeapObject::KIND_MASK | HeapObject::IS_REFERENCE_COUNTED_MASK),
+            0,
+        );
+        let header_word = kind_bits
+            | ((is_reference_counted as u64) << HeapObject::IS_REFERENCE_COUNTED_SHIFT)
+            | remaining_header_word;
+        self.allocate_raw(header_word, content_size)
+    }
+    pub fn allocate_raw(&mut self, header_word: u64, content_size: usize) -> HeapObject {
         let layout = Layout::from_size_align(
             2 * HeapObject::WORD_SIZE + content_size,
             HeapObject::WORD_SIZE,
@@ -47,7 +64,9 @@ impl Heap {
             .cast();
         unsafe { *pointer.as_ptr() = header_word };
         let object = HeapObject::new(pointer);
-        object.set_reference_count(1);
+        if object.is_reference_counted() {
+            object.set_reference_count(1);
+        }
         self.objects.insert(ObjectInHeap(object));
         object
     }
@@ -121,21 +140,24 @@ impl Heap {
             *value = 0;
         }
 
-        let to_deallocate = self
-            .objects
-            .iter()
-            .filter(|it| it.reference_count() == 0)
-            .map(|&it| *it)
-            .collect_vec();
-        for object in to_deallocate {
-            self.deallocate(object.into());
+        for object in &self.objects {
+            if object.is_reference_counted() {
+                object.set_reference_count(0);
+            }
         }
     }
     pub(super) fn drop_all_unreferenced(&mut self) {
         self.channel_refcounts
             .retain(|_, &mut refcount| refcount > 0);
-        for object in &self.objects {
-            object.set_reference_count(0);
+
+        let to_deallocate = self
+            .objects
+            .iter()
+            .filter(|it| it.reference_count() == Some(0))
+            .map(|&it| *it)
+            .collect_vec();
+        for object in to_deallocate {
+            self.deallocate(object.into());
         }
     }
 
@@ -152,11 +174,17 @@ impl Debug for Heap {
         writeln!(f, "{{\n  channel_refcounts: {:?}", self.channel_refcounts)?;
 
         for &object in &self.objects {
-            let reference_count = object.reference_count();
             writeln!(
                 f,
-                "  {object:p} ({reference_count} {}): {object:?}",
-                if reference_count == 1 { "ref" } else { "refs" },
+                "  {object:p}{}: {object:?}",
+                if let Some(reference_count) = object.reference_count() {
+                    format!(
+                        " ({reference_count} {})",
+                        if reference_count == 1 { "ref" } else { "refs" },
+                    )
+                } else {
+                    String::new()
+                },
             )?;
         }
         write!(f, "}}")

--- a/compiler/vm/src/heap/object.rs
+++ b/compiler/vm/src/heap/object.rs
@@ -106,7 +106,7 @@ pub enum Int {
 }
 
 impl Int {
-    pub fn create<T>(heap: &mut Heap, value: T) -> Self
+    pub fn create<T>(heap: &mut Heap, is_reference_counted: bool, value: T) -> Self
     where
         T: Copy + TryInto<i64> + Into<BigInt>,
     {
@@ -115,14 +115,14 @@ impl Int {
             .map_err(|_| ())
             .and_then(InlineInt::try_from)
             .map(|it| it.into())
-            .unwrap_or_else(|_| HeapInt::create(heap, value.into()).into())
+            .unwrap_or_else(|_| HeapInt::create(heap, is_reference_counted, value.into()).into())
     }
-    pub fn create_from_bigint(heap: &mut Heap, value: BigInt) -> Self {
+    pub fn create_from_bigint(heap: &mut Heap, is_reference_counted: bool, value: BigInt) -> Self {
         i64::try_from(&value)
             .map_err(|_| ())
             .and_then(InlineInt::try_from)
             .map(|it| it.into())
-            .unwrap_or_else(|_| HeapInt::create(heap, value).into())
+            .unwrap_or_else(|_| HeapInt::create(heap, is_reference_counted, value).into())
     }
 
     pub fn get(&self) -> Cow<BigInt> {
@@ -214,6 +214,7 @@ macro_rules! shift_fn {
                 // TODO: Support shifting by larger numbers
                 (Int::Inline(lhs), rhs) => Int::create_from_bigint(
                     heap,
+                    true,
                     BigInt::from(lhs.get()).$function(rhs.try_get::<i128>().unwrap()),
                 ),
                 (Int::Heap(lhs), rhs) => lhs.$name(heap, rhs.try_get::<i128>().unwrap()),
@@ -250,37 +251,52 @@ impl_try_from_heap_object!(Int, "Expected an int.");
 pub struct Tag(HeapTag);
 
 impl Tag {
-    pub fn create(heap: &mut Heap, symbol: Text, value: impl Into<Option<InlineObject>>) -> Self {
-        HeapTag::create(heap, symbol, value).into()
+    pub fn create(
+        heap: &mut Heap,
+        is_reference_counted: bool,
+        symbol: Text,
+        value: impl Into<Option<InlineObject>>,
+    ) -> Self {
+        HeapTag::create(heap, is_reference_counted, symbol, value).into()
     }
     pub fn create_from_str(
         heap: &mut Heap,
+        is_reference_counted: bool,
         symbol: &str,
         value: impl Into<Option<InlineObject>>,
     ) -> Self {
-        let symbol = Text::create(heap, symbol);
-        Self::create(heap, symbol, value)
+        let symbol = Text::create(heap, is_reference_counted, symbol);
+        Self::create(heap, is_reference_counted, symbol, value)
     }
-    pub fn create_nothing(heap: &mut Heap) -> Self {
-        Self::create_from_str(heap, "Nothing", None)
+    pub fn create_nothing(heap: &mut Heap, is_reference_counted: bool) -> Self {
+        Self::create_from_str(heap, is_reference_counted, "Nothing", None)
     }
-    pub fn create_bool(heap: &mut Heap, value: bool) -> Self {
-        Self::create_from_str(heap, if value { "True" } else { "False" }, None)
+    pub fn create_bool(heap: &mut Heap, is_reference_counted: bool, value: bool) -> Self {
+        Self::create_from_str(
+            heap,
+            is_reference_counted,
+            if value { "True" } else { "False" },
+            None,
+        )
     }
-    pub fn create_ordering(heap: &mut Heap, value: Ordering) -> Self {
+    pub fn create_ordering(heap: &mut Heap, is_reference_counted: bool, value: Ordering) -> Self {
         let value = match value {
             Ordering::Less => "Less",
             Ordering::Equal => "Equal",
             Ordering::Greater => "Greater",
         };
-        Self::create_from_str(heap, value, None)
+        Self::create_from_str(heap, is_reference_counted, value, None)
     }
-    pub fn create_result(heap: &mut Heap, value: Result<InlineObject, InlineObject>) -> Self {
+    pub fn create_result(
+        heap: &mut Heap,
+        is_reference_counted: bool,
+        value: Result<InlineObject, InlineObject>,
+    ) -> Self {
         let (symbol, value) = match value {
             Ok(it) => ("Ok", it),
             Err(it) => ("Error", it),
         };
-        Self::create_from_str(heap, symbol, value)
+        Self::create_from_str(heap, is_reference_counted, symbol, value)
     }
 }
 
@@ -318,14 +334,14 @@ impl TryFrom<Data> for bool {
 pub struct Text(HeapText);
 
 impl Text {
-    pub fn create(heap: &mut Heap, value: &str) -> Self {
-        HeapText::create(heap, value).into()
+    pub fn create(heap: &mut Heap, is_reference_counted: bool, value: &str) -> Self {
+        HeapText::create(heap, is_reference_counted, value).into()
     }
-    pub fn create_from_utf8(heap: &mut Heap, bytes: &[u8]) -> Tag {
+    pub fn create_from_utf8(heap: &mut Heap, is_reference_counted: bool, bytes: &[u8]) -> Tag {
         let result = str::from_utf8(bytes)
-            .map(|it| Text::create(heap, it).into())
-            .map_err(|_| Text::create(heap, "Invalid UTF-8.").into());
-        Tag::create_result(heap, result)
+            .map(|it| Text::create(heap, is_reference_counted, it).into())
+            .map_err(|_| Text::create(heap, is_reference_counted, "Invalid UTF-8.").into());
+        Tag::create_result(heap, is_reference_counted, result)
     }
 }
 
@@ -339,8 +355,8 @@ impl_try_from_heap_object!(Text, "Expected a text.");
 pub struct List(HeapList);
 
 impl List {
-    pub fn create(heap: &mut Heap, items: &[InlineObject]) -> Self {
-        HeapList::create(heap, items).into()
+    pub fn create(heap: &mut Heap, is_reference_counted: bool, items: &[InlineObject]) -> Self {
+        HeapList::create(heap, is_reference_counted, items).into()
     }
 }
 
@@ -354,18 +370,28 @@ impl_try_from_heap_object!(List, "Expected a list.");
 pub struct Struct(HeapStruct);
 
 impl Struct {
-    pub fn create(heap: &mut Heap, fields: &FxHashMap<InlineObject, InlineObject>) -> Self {
-        HeapStruct::create(heap, fields).into()
+    pub fn create(
+        heap: &mut Heap,
+        is_reference_counted: bool,
+        fields: &FxHashMap<InlineObject, InlineObject>,
+    ) -> Self {
+        HeapStruct::create(heap, is_reference_counted, fields).into()
     }
     pub fn create_with_symbol_keys(
         heap: &mut Heap,
+        is_reference_counted: bool,
         fields: impl IntoIterator<Item = (&str, InlineObject)>,
     ) -> Self {
         let fields = fields
             .into_iter()
-            .map(|(key, value)| ((Tag::create_from_str(heap, key, None)).into(), value))
+            .map(|(key, value)| {
+                (
+                    (Tag::create_from_str(heap, is_reference_counted, key, None)).into(),
+                    value,
+                )
+            })
             .collect();
-        Self::create(heap, &fields)
+        Self::create(heap, is_reference_counted, &fields)
     }
 }
 
@@ -381,11 +407,12 @@ pub struct Function(HeapFunction);
 impl Function {
     pub fn create(
         heap: &mut Heap,
+        is_reference_counted: bool,
         captured: &[InlineObject],
         argument_count: usize,
         body: InstructionPointer,
     ) -> Self {
-        HeapFunction::create(heap, captured, argument_count, body).into()
+        HeapFunction::create(heap, is_reference_counted, captured, argument_count, body).into()
     }
 }
 
@@ -400,8 +427,8 @@ impl_try_from_heap_object!(Function, "Expected a function.");
 pub struct HirId(HeapHirId);
 
 impl HirId {
-    pub fn create(heap: &mut Heap, id: Id) -> HirId {
-        HeapHirId::create(heap, id).into()
+    pub fn create(heap: &mut Heap, is_reference_counted: bool, id: Id) -> HirId {
+        HeapHirId::create(heap, is_reference_counted, id).into()
     }
 }
 

--- a/compiler/vm/src/heap/object_heap/function.rs
+++ b/compiler/vm/src/heap/object_heap/function.rs
@@ -20,13 +20,14 @@ pub struct HeapFunction(HeapObject);
 
 impl HeapFunction {
     const CAPTURED_LEN_SHIFT: usize = 32;
-    const ARGUMENT_COUNT_SHIFT: usize = 3;
+    const ARGUMENT_COUNT_SHIFT: usize = 4;
 
     pub fn new_unchecked(object: HeapObject) -> Self {
         Self(object)
     }
     pub fn create(
         heap: &mut Heap,
+        is_reference_counted: bool,
         captured: &[InlineObject],
         argument_count: usize,
         body: InstructionPointer,
@@ -48,8 +49,9 @@ impl HeapFunction {
         );
 
         let function = Self(heap.allocate(
-            HeapObject::KIND_FUNCTION
-                | ((captured_len as u64) << Self::CAPTURED_LEN_SHIFT)
+            HeapObject::KIND_FUNCTION,
+            is_reference_counted,
+            ((captured_len as u64) << Self::CAPTURED_LEN_SHIFT)
                 | ((argument_count as u64) << Self::ARGUMENT_COUNT_SHIFT),
             (1 + captured_len) * HeapObject::WORD_SIZE,
         ));

--- a/compiler/vm/src/heap/object_heap/hir_id.rs
+++ b/compiler/vm/src/heap/object_heap/hir_id.rs
@@ -19,8 +19,13 @@ impl HeapHirId {
     pub fn new_unchecked(object: HeapObject) -> Self {
         Self(object)
     }
-    pub fn create(heap: &mut Heap, value: Id) -> Self {
-        let id = HeapHirId(heap.allocate(HeapObject::KIND_HIR_ID, mem::size_of::<Id>()));
+    pub fn create(heap: &mut Heap, is_reference_counted: bool, value: Id) -> Self {
+        let id = HeapHirId(heap.allocate(
+            HeapObject::KIND_HIR_ID,
+            is_reference_counted,
+            0,
+            mem::size_of::<Id>(),
+        ));
         unsafe { ptr::write(id.id_pointer().as_ptr(), value) };
         id
     }

--- a/compiler/vm/src/heap/object_heap/int.rs
+++ b/compiler/vm/src/heap/object_heap/int.rs
@@ -21,12 +21,17 @@ impl HeapInt {
     pub fn new_unchecked(object: HeapObject) -> Self {
         Self(object)
     }
-    pub fn create(heap: &mut Heap, value: BigInt) -> Self {
+    pub fn create(heap: &mut Heap, is_reference_counted: bool, value: BigInt) -> Self {
         if let Ok(value) = i64::try_from(&value) {
             debug_assert!(!InlineInt::fits(value));
         }
 
-        let int = Self(heap.allocate(HeapObject::KIND_INT, mem::size_of::<BigInt>()));
+        let int = Self(heap.allocate(
+            HeapObject::KIND_INT,
+            is_reference_counted,
+            0,
+            mem::size_of::<BigInt>(),
+        ));
         unsafe { ptr::write(int.int_pointer().as_ptr(), value) };
         int
     }
@@ -44,19 +49,19 @@ impl HeapInt {
     operator_fn!(int_divide_truncating, Div, div);
     operator_fn!(remainder, Rem, rem);
     pub fn modulo(self, heap: &mut Heap, rhs: &BigInt) -> Int {
-        Int::create_from_bigint(heap, self.get().mod_floor(rhs))
+        Int::create_from_bigint(heap, true, self.get().mod_floor(rhs))
     }
 
     pub fn compare_to(self, heap: &mut Heap, rhs: &BigInt) -> Tag {
         // PERF: Add manual check if the `rhs` is an [InlineInt]?
-        Tag::create_ordering(heap, self.get().cmp(rhs))
+        Tag::create_ordering(heap, true, self.get().cmp(rhs))
     }
 
     operator_fn!(shift_left, Shl, shl);
     operator_fn!(shift_right, Shr, shr);
 
     pub fn bit_length(self, heap: &mut Heap) -> Int {
-        Int::create(heap, self.get().bits())
+        Int::create(heap, true, self.get().bits())
     }
 
     operator_fn!(bitwise_and, BitAnd, bitand);
@@ -71,7 +76,7 @@ macro_rules! operator_fn {
             for<'a> &'a BigInt: $trait<T, Output = BigInt>,
         {
             let result = $trait::$function(self.get(), rhs);
-            Int::create_from_bigint(heap, result)
+            Int::create_from_bigint(heap, true, result)
         }
     };
 }

--- a/compiler/vm/src/heap/object_heap/mod.rs
+++ b/compiler/vm/src/heap/object_heap/mod.rs
@@ -58,7 +58,7 @@ impl HeapObject {
     const KIND_FUNCTION: u64 = 0b011;
     const KIND_HIR_ID: u64 = 0b111;
 
-    pub const IS_REFERENCE_COUNTED_SHIFT: usize = 4;
+    pub const IS_REFERENCE_COUNTED_SHIFT: usize = 3;
     pub const IS_REFERENCE_COUNTED_MASK: u64 = 0b1 << Self::IS_REFERENCE_COUNTED_SHIFT;
 
     pub fn new(address: NonNull<u64>) -> Self {
@@ -276,7 +276,10 @@ impl From<HeapObject> for HeapData {
         let header_word = object.header_word();
         match header_word & HeapObject::KIND_MASK {
             HeapObject::KIND_INT => {
-                assert_eq!(header_word, HeapObject::KIND_INT);
+                assert_eq!(
+                    header_word & !HeapObject::IS_REFERENCE_COUNTED_MASK,
+                    HeapObject::KIND_INT,
+                );
                 HeapData::Int(HeapInt::new_unchecked(object))
             }
             HeapObject::KIND_LIST => HeapData::List(HeapList::new_unchecked(object)),
@@ -285,7 +288,10 @@ impl From<HeapObject> for HeapData {
             HeapObject::KIND_TEXT => HeapData::Text(HeapText::new_unchecked(object)),
             HeapObject::KIND_FUNCTION => HeapData::Function(HeapFunction::new_unchecked(object)),
             HeapObject::KIND_HIR_ID => {
-                assert_eq!(header_word, HeapObject::KIND_HIR_ID);
+                assert_eq!(
+                    header_word & !HeapObject::IS_REFERENCE_COUNTED_MASK,
+                    HeapObject::KIND_HIR_ID,
+                );
                 HeapData::HirId(HeapHirId::new_unchecked(object))
             }
             tag => panic!("Invalid tag: {tag:b}"),

--- a/compiler/vm/src/heap/object_heap/struct_.rs
+++ b/compiler/vm/src/heap/object_heap/struct_.rs
@@ -18,12 +18,16 @@ use std::{
 pub struct HeapStruct(HeapObject);
 
 impl HeapStruct {
-    const LEN_SHIFT: usize = 3;
+    const LEN_SHIFT: usize = 4;
 
     pub fn new_unchecked(object: HeapObject) -> Self {
         Self(object)
     }
-    pub fn create(heap: &mut Heap, value: &FxHashMap<InlineObject, InlineObject>) -> Self {
+    pub fn create(
+        heap: &mut Heap,
+        is_reference_counted: bool,
+        value: &FxHashMap<InlineObject, InlineObject>,
+    ) -> Self {
         let len = value.len();
         assert_eq!(
             (len << Self::LEN_SHIFT) >> Self::LEN_SHIFT,
@@ -35,7 +39,7 @@ impl HeapStruct {
             // PERF: Reuse hashes from the map.
             .map(|(&key, &value)| (key.do_hash(), key, value))
             .sorted_by_key(|(hash, _, _)| *hash);
-        let struct_ = Self::create_uninitialized(heap, len);
+        let struct_ = Self::create_uninitialized(heap, is_reference_counted, len);
         unsafe {
             for (index, (hash, key, value)) in entries.enumerate() {
                 *struct_.content_word_pointer(index).as_ptr() = hash;
@@ -48,14 +52,16 @@ impl HeapStruct {
         };
         struct_
     }
-    fn create_uninitialized(heap: &mut Heap, len: usize) -> Self {
+    fn create_uninitialized(heap: &mut Heap, is_reference_counted: bool, len: usize) -> Self {
         assert_eq!(
             (len << Self::LEN_SHIFT) >> Self::LEN_SHIFT,
             len,
             "Struct is too long.",
         );
         Self(heap.allocate(
-            HeapObject::KIND_STRUCT | ((len as u64) << Self::LEN_SHIFT),
+            HeapObject::KIND_STRUCT,
+            is_reference_counted,
+            (len as u64) << Self::LEN_SHIFT,
             3 * len * HeapObject::WORD_SIZE,
         ))
     }
@@ -103,7 +109,7 @@ impl HeapStruct {
         let hash = key.do_hash();
         match self.index_of_key(key, hash) {
             Ok(index) => {
-                let struct_ = Self::create_uninitialized(heap, self.len());
+                let struct_ = Self::create_uninitialized(heap, true, self.len());
                 unsafe {
                     ptr::copy_nonoverlapping(
                         self.content_word_pointer(0).as_ptr(),
@@ -121,7 +127,7 @@ impl HeapStruct {
                 struct_
             }
             Err(index) => {
-                let struct_ = Self::create_uninitialized(heap, self.len() + 1);
+                let struct_ = Self::create_uninitialized(heap, true, self.len() + 1);
                 // PERF: Merge consecutive copies.
                 self.insert_into_items(struct_, 0, index, hash);
                 self.insert_into_items(struct_, 1, index, key);

--- a/compiler/vm/src/heap/object_heap/tag.rs
+++ b/compiler/vm/src/heap/object_heap/tag.rs
@@ -21,9 +21,19 @@ impl HeapTag {
     pub fn new_unchecked(object: HeapObject) -> Self {
         Self(object)
     }
-    pub fn create(heap: &mut Heap, symbol: Text, value: impl Into<Option<InlineObject>>) -> Self {
+    pub fn create(
+        heap: &mut Heap,
+        is_reference_counted: bool,
+        symbol: Text,
+        value: impl Into<Option<InlineObject>>,
+    ) -> Self {
         let value = value.into();
-        let tag = Self(heap.allocate(HeapObject::KIND_TAG, 2 * HeapObject::WORD_SIZE));
+        let tag = Self(heap.allocate(
+            HeapObject::KIND_TAG,
+            is_reference_counted,
+            0,
+            2 * HeapObject::WORD_SIZE,
+        ));
         unsafe {
             *tag.symbol_pointer().as_mut() = symbol.into();
             *tag.value_pointer().as_mut() = value.map_or(0, |value| value.raw_word().get());
@@ -51,7 +61,7 @@ impl HeapTag {
     }
 
     pub fn without_value(self, heap: &mut Heap) -> Tag {
-        Tag::create(heap, self.symbol(), None)
+        Tag::create(heap, true, self.symbol(), None)
     }
 }
 

--- a/compiler/vm/src/heap/object_heap/text.rs
+++ b/compiler/vm/src/heap/object_heap/text.rs
@@ -18,12 +18,12 @@ use unicode_segmentation::UnicodeSegmentation;
 pub struct HeapText(HeapObject);
 
 impl HeapText {
-    const BYTE_LEN_SHIFT: usize = 3;
+    const BYTE_LEN_SHIFT: usize = 4;
 
     pub fn new_unchecked(object: HeapObject) -> Self {
         Self(object)
     }
-    pub fn create(heap: &mut Heap, value: &str) -> Self {
+    pub fn create(heap: &mut Heap, is_reference_counted: bool, value: &str) -> Self {
         let byte_len = value.len();
         assert_eq!(
             (byte_len << Self::BYTE_LEN_SHIFT) >> Self::BYTE_LEN_SHIFT,
@@ -31,7 +31,9 @@ impl HeapText {
             "Text is too long.",
         );
         let text = Self(heap.allocate(
-            HeapObject::KIND_TEXT | ((byte_len as u64) << Self::BYTE_LEN_SHIFT),
+            HeapObject::KIND_TEXT,
+            is_reference_counted,
+            (byte_len as u64) << Self::BYTE_LEN_SHIFT,
             byte_len,
         ));
         unsafe { ptr::copy_nonoverlapping(value.as_ptr(), text.text_pointer().as_ptr(), byte_len) };
@@ -50,27 +52,27 @@ impl HeapText {
     }
 
     pub fn is_empty(self, heap: &mut Heap) -> Tag {
-        Tag::create_bool(heap, self.get().is_empty())
+        Tag::create_bool(heap, true, self.get().is_empty())
     }
     pub fn length(self, heap: &mut Heap) -> Int {
-        Int::create(heap, self.get().graphemes(true).count())
+        Int::create(heap, true, self.get().graphemes(true).count())
     }
     pub fn characters(self, heap: &mut Heap) -> List {
         let characters = self
             .get()
             .graphemes(true)
-            .map(|it| Text::create(heap, it).into())
+            .map(|it| Text::create(heap, true, it).into())
             .collect_vec();
-        List::create(heap, &characters)
+        List::create(heap, true, &characters)
     }
     pub fn contains(self, heap: &mut Heap, pattern: Text) -> Tag {
-        Tag::create_bool(heap, self.get().contains(pattern.get()))
+        Tag::create_bool(heap, true, self.get().contains(pattern.get()))
     }
     pub fn starts_with(self, heap: &mut Heap, prefix: Text) -> Tag {
-        Tag::create_bool(heap, self.get().starts_with(prefix.get()))
+        Tag::create_bool(heap, true, self.get().starts_with(prefix.get()))
     }
     pub fn ends_with(self, heap: &mut Heap, suffix: Text) -> Tag {
-        Tag::create_bool(heap, self.get().ends_with(suffix.get()))
+        Tag::create_bool(heap, true, self.get().ends_with(suffix.get()))
     }
     pub fn get_range(self, heap: &mut Heap, range: Range<Int>) -> Text {
         // TODO: Support indices larger than usize.
@@ -88,17 +90,17 @@ impl HeapText {
             .skip(start_inclusive)
             .take(end_exclusive - start_inclusive)
             .collect();
-        Text::create(heap, &text)
+        Text::create(heap, true, &text)
     }
 
     pub fn concatenate(self, heap: &mut Heap, other: Text) -> Text {
-        Text::create(heap, &format!("{}{}", self.get(), other.get()))
+        Text::create(heap, true, &format!("{}{}", self.get(), other.get()))
     }
     pub fn trim_start(self, heap: &mut Heap) -> Text {
-        Text::create(heap, self.get().trim_start())
+        Text::create(heap, true, self.get().trim_start())
     }
     pub fn trim_end(self, heap: &mut Heap) -> Text {
-        Text::create(heap, self.get().trim_end())
+        Text::create(heap, true, self.get().trim_end())
     }
 }
 

--- a/compiler/vm/src/heap/object_inline/int.rs
+++ b/compiler/vm/src/heap/object_inline/int.rs
@@ -55,9 +55,9 @@ impl InlineInt {
         let lhs = self.get();
         let rhs = rhs.get();
         lhs.checked_rem_euclid(rhs)
-            .map(|it| Int::create(heap, it))
+            .map(|it| Int::create(heap, true, it))
             .unwrap_or_else(|| {
-                Int::create_from_bigint(heap, BigInt::from(lhs).mod_floor(&rhs.into()))
+                Int::create_from_bigint(heap, true, BigInt::from(lhs).mod_floor(&rhs.into()))
             })
     }
 
@@ -72,7 +72,7 @@ impl InlineInt {
                 }
             }
         };
-        Tag::create_ordering(heap, ordering)
+        Tag::create_ordering(heap, true, ordering)
     }
 
     operator_fn!(shift_left, i64::checked_shl, Shl::shl);
@@ -94,9 +94,13 @@ macro_rules! operator_fn {
             let lhs = self.get();
             rhs.try_get()
                 .and_then(|rhs| $inline_operation(lhs, rhs))
-                .map(|it| Int::create(heap, it))
+                .map(|it| Int::create(heap, true, it))
                 .unwrap_or_else(|| {
-                    Int::create_from_bigint(heap, $bigint_operation(BigInt::from(lhs), rhs.get()))
+                    Int::create_from_bigint(
+                        heap,
+                        true,
+                        $bigint_operation(BigInt::from(lhs), rhs.get()),
+                    )
                 })
         }
     };

--- a/compiler/vm/src/heap/object_representation.md
+++ b/compiler/vm/src/heap/object_representation.md
@@ -41,7 +41,7 @@ For larger values, a pointer to a heap object containing an integer of (practica
 Each heap object has the following structure:
 
 - one header word
-- one word containing the reference count as an unsigned integer (`u64`) iff `r == 1`
+- iff `r == 1`: one word containing the reference count as an unsigned integer (`u64`)
 - zero to many words containing the actual data
   - for now, there are some objects whose content data length isn't a multiple of the word size since they use Rust's representation for simplicity
 

--- a/compiler/vm/src/heap/object_representation.md
+++ b/compiler/vm/src/heap/object_representation.md
@@ -41,7 +41,7 @@ For larger values, a pointer to a heap object containing an integer of (practica
 Each heap object has the following structure:
 
 - one header word
-- one word containing the reference count as an unsigned integer (`u64`)
+- one word containing the reference count as an unsigned integer (`u64`) iff `r == 1`
 - zero to many words containing the actual data
   - for now, there are some objects whose content data length isn't a multiple of the word size since they use Rust's representation for simplicity
 
@@ -49,13 +49,16 @@ The header word is a tagged union of different types of values:
 
 |                                                                     Value | Meaning  |
 | ------------------------------------------------------------------------: | :------- |
-| `00000000 00000000 00000000 00000000 00000000 00000000 00000000 00000000` | Int      |
-| `aaaaaaaa aaaaaaaa aaaaaaaa aaaaaaaa aaaaaaaa aaaaaaaa aaaaaaaa aaaaa001` | List     |
-| `aaaaaaaa aaaaaaaa aaaaaaaa aaaaaaaa aaaaaaaa aaaaaaaa aaaaaaaa aaaaa101` | Struct   |
-| `00000000 00000000 00000000 00000000 00000000 00000000 00000000 00000010` | Tag      |
-| `aaaaaaaa aaaaaaaa aaaaaaaa aaaaaaaa aaaaaaaa aaaaaaaa aaaaaaaa aaaaa110` | Text     |
-| `cccccccc cccccccc cccccccc cccccccc aaaaaaaa aaaaaaaa aaaaaaaa aaaaa011` | Function |
-| `00000000 00000000 00000000 00000000 00000000 00000000 00000000 00000111` | HirId    |
+| `00000000 00000000 00000000 00000000 00000000 00000000 00000000 0000r000` | Int      |
+| `aaaaaaaa aaaaaaaa aaaaaaaa aaaaaaaa aaaaaaaa aaaaaaaa aaaaaaaa aaaar001` | List     |
+| `aaaaaaaa aaaaaaaa aaaaaaaa aaaaaaaa aaaaaaaa aaaaaaaa aaaaaaaa aaaar101` | Struct   |
+| `00000000 00000000 00000000 00000000 00000000 00000000 00000000 0000r010` | Tag      |
+| `aaaaaaaa aaaaaaaa aaaaaaaa aaaaaaaa aaaaaaaa aaaaaaaa aaaaaaaa aaaar110` | Text     |
+| `cccccccc cccccccc cccccccc cccccccc aaaaaaaa aaaaaaaa aaaaaaaa aaaar011` | Function |
+| `00000000 00000000 00000000 00000000 00000000 00000000 00000000 0000r111` | HirId    |
+
+`r` is set to one iff the object is a reference-counted object.
+(Constants are not reference-counted so that they can be shared across fibers without locks.)
 
 > The remaining patterns are invalid.
 

--- a/compiler/vm/src/lib.rs
+++ b/compiler/vm/src/lib.rs
@@ -68,7 +68,7 @@ pub fn return_value_into_main_function(
     let exported_definitions: Struct = return_value.try_into().unwrap();
     debug!("The module exports these definitions: {exported_definitions}");
 
-    let main = Tag::create_from_str(heap, "Main", None);
+    let main = Tag::create_from_str(heap, true, "Main", None);
     exported_definitions
         .get(main)
         .ok_or("The module doesn't export a main function.")

--- a/compiler/vm/src/lib.rs
+++ b/compiler/vm/src/lib.rs
@@ -12,9 +12,8 @@
 use crate::heap::{Struct, Tag};
 use execution_controller::RunForever;
 use fiber::{EndedReason, VmEnded};
-use heap::{Function, Heap, HeapObject, InlineObject};
+use heap::{Function, Heap, InlineObject};
 use lir::Lir;
-use rustc_hash::FxHashMap;
 use std::borrow::Borrow;
 use tracer::Tracer;
 use tracing::{debug, error};
@@ -43,13 +42,11 @@ impl<L: Borrow<Lir>, T: Tracer> Vm<L, T> {
 }
 
 impl VmEnded {
-    pub fn into_main_function(
-        mut self,
-    ) -> Result<(Heap, Function, FxHashMap<HeapObject, HeapObject>), String> {
+    pub fn into_main_function(mut self) -> Result<(Heap, Function), String> {
         match self.reason {
             EndedReason::Finished(return_value) => {
                 match return_value_into_main_function(&mut self.heap, return_value) {
-                    Ok(main) => Ok((self.heap, main, self.constant_mapping)),
+                    Ok(main) => Ok((self.heap, main)),
                     Err(err) => Err(err.to_string()),
                 }
             }

--- a/compiler/vm/src/vm.rs
+++ b/compiler/vm/src/vm.rs
@@ -395,7 +395,7 @@ impl<L: Borrow<Lir>, T: Tracer> Vm<L, T> {
                         .try_into()
                         .unwrap();
                     let responsible =
-                        HirId::create(&mut fiber.heap, Id::complicated_responsibility());
+                        HirId::create(&mut fiber.heap, true, Id::complicated_responsibility());
                     let nursery_send_port = SendPort::create(&mut heap, nursery_id);
 
                     let child_tracer = fiber.tracer.child_fiber_created(id);
@@ -436,7 +436,7 @@ impl<L: Borrow<Lir>, T: Tracer> Vm<L, T> {
                         .try_into()
                         .unwrap();
                     let responsible =
-                        HirId::create(&mut fiber.heap, Id::complicated_responsibility());
+                        HirId::create(&mut fiber.heap, true, Id::complicated_responsibility());
 
                     let child_tracer = fiber.tracer.child_fiber_created(id);
                     self.fibers.insert(
@@ -650,7 +650,7 @@ impl<L: Borrow<Lir>, T: Tracer> Vm<L, T> {
                             .try_into()
                             .unwrap();
                         let responsible =
-                            HirId::create(&mut heap, Id::complicated_responsibility());
+                            HirId::create(&mut heap, true, Id::complicated_responsibility());
                         let child_id = self.fiber_id_generator.generate();
 
                         let parent = self
@@ -707,13 +707,13 @@ impl<L: Borrow<Lir>, T: Tracer> Vm<L, T> {
         let Packet { mut heap, object } = packet;
         let arguments: Struct = object.try_into().ok()?;
 
-        let function_tag = Tag::create_from_str(&mut heap, "Function", None);
+        let function_tag = Tag::create_from_str(&mut heap, true, "Function", None);
         let function: Function = arguments.get(**function_tag)?.try_into().ok()?;
         if function.argument_count() > 0 {
             return None;
         }
 
-        let return_channel_tag = Tag::create_from_str(&mut heap, "ReturnChannel", None);
+        let return_channel_tag = Tag::create_from_str(&mut heap, true, "ReturnChannel", None);
         let return_channel: SendPort = arguments.get(**return_channel_tag)?.try_into().ok()?;
 
         Some((heap, function, return_channel.channel_id()))

--- a/packages/examples/iterable.candy
+++ b/packages/examples/iterable.candy
@@ -18,7 +18,7 @@ main := { env ->
   print = { message -> channel.send env.stdout message }
 
   foo =
-    "Hello, world! This is some long text. Bla bla blub.Hello, world! This is some long text. Bla bla blub.Hello, world! This is some long text. Bla bla blub.Hello, world! This is some long text. Bla bla blub.Hello, world! This is some long text. Bla bla blub." | text.characters | iterable.fromList
+    "Hello, world! This is some long text. Bla bla blub." | text.characters | iterable.fromList
   #| splitWhereFirst { c ->
   #  builtins.print c
   #  equals c ","

--- a/packages/examples/iterable.candy
+++ b/packages/examples/iterable.candy
@@ -18,7 +18,7 @@ main := { env ->
   print = { message -> channel.send env.stdout message }
 
   foo =
-    "Hello, world! This is some long text. Bla bla blub." | text.characters | iterable.fromList
+    "Hello, world! This is some long text. Bla bla blub.Hello, world! This is some long text. Bla bla blub.Hello, world! This is some long text. Bla bla blub.Hello, world! This is some long text. Bla bla blub.Hello, world! This is some long text. Bla bla blub." | text.characters | iterable.fromList
   #| splitWhereFirst { c ->
   #  builtins.print c
   #  equals c ","


### PR DESCRIPTION
<!-- Please enter the corresponding issue ID: -->


<!-- Please summarize your changes: -->
For a relatively short program (`packages/examples/iterable.canddy`, but with a longer text), the execution got slower:

```
Before: cargo run --release -- run packages/examples/iterable.candy
  Time (mean ± σ):     789.7 ms ±  42.1 ms    [User: 725.0 ms, System: 63.0 ms]
  Range (min … max):   717.9 ms … 849.0 ms    10 runs

After: cargo run --release -- run packages/examples/iterable.candy
  Time (mean ± σ):      1.028 s ±  0.082 s    [User: 0.968 s, System: 0.062 s]
  Range (min … max):    0.919 s …  1.208 s    10 runs
```

I'm guessing this is mostly because we now have to check whether an object is reference counted or not quite commonly. This effect should be reduced once we add a new IR for tracking dups and drops.

Edit: Our CI benchmarks improved: https://github.com/candy-lang/candy/commit/3021dcc619da6c85944311f687dcaf37091736e1#commitcomment-122395527


### Checklist
<!-- Please check if your PR fulfills the following requirements: -->

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
