### PR TITLE
Make the VM fast again

### DIFF
--- a/compiler/language_server/src/debug_adapter/paused/stack_trace.rs
+++ b/compiler/language_server/src/debug_adapter/paused/stack_trace.rs
@@ -29,7 +29,7 @@ impl PausedState {
         args: StackTraceArguments,
     ) -> Result<StackTraceResponse, &'static str> {
         let vm = &self.vm.as_ref().unwrap();
-        let tracer = &vm.tracer;
+        let tracer = vm.tracer();
 
         let start_frame = args.start_frame.unwrap_or_default();
         let levels = args
@@ -51,7 +51,7 @@ impl PausedState {
                     start_at_1_config,
                     id,
                     frame,
-                    &self.vm.as_ref().unwrap().lir,
+                    self.vm.as_ref().unwrap().lir(),
                 )
             },
         ));
@@ -154,13 +154,13 @@ impl StackFrameKey {
             return None;
         }
 
-        Some(&vm.tracer.call_stack[self.index - 1])
+        Some(&vm.tracer().call_stack[self.index - 1])
     }
     pub fn get_locals<'a, L: Borrow<Lir>>(
         &self,
         vm: &'a Vm<L, DebugTracer>,
     ) -> &'a Vec<(Id, InlineObject)> {
-        let tracer = &vm.tracer;
+        let tracer = vm.tracer();
         if self.index == 0 {
             &tracer.root_locals
         } else {

--- a/compiler/language_server/src/debug_adapter/paused/variable.rs
+++ b/compiler/language_server/src/debug_adapter/paused/variable.rs
@@ -53,7 +53,7 @@ impl PausedState {
                                 .vm
                                 .as_ref()
                                 .unwrap()
-                                .lir
+                                .lir()
                                 .functions_behind(function.body());
                             assert_eq!(functions.len(), 1);
                             let function = functions.iter().next().unwrap();
@@ -102,7 +102,7 @@ impl PausedState {
                         "Unexpected callee: {}",
                         DisplayWithSymbolTable::to_string(
                             &it,
-                            &self.vm.as_ref().unwrap().lir.symbol_table,
+                            &self.vm.as_ref().unwrap().lir().symbol_table,
                         ),
                     ),
                 };
@@ -162,7 +162,7 @@ impl PausedState {
                 Data::Tag(Tag::Heap(tag)) => {
                     if should_include_named {
                         if start == 0 && count > 0 {
-                            let symbol_table = &self.vm.as_ref().unwrap().lir.symbol_table;
+                            let symbol_table = &self.vm.as_ref().unwrap().lir().symbol_table;
                             variables.push(Variable {
                                 name: "Symbol".to_string(),
                                 value: symbol_table.get(tag.symbol_id()).to_string(),
@@ -235,11 +235,11 @@ impl PausedState {
                             .copied()
                             .zip_eq(struct_.values().iter().copied())
                             .collect_vec();
-                        let symbol_table = &self.vm.as_ref().unwrap().lir.symbol_table;
+                        let symbol_table = &self.vm.as_ref().unwrap().lir().symbol_table;
                         fields.sort_by(|a, b| OrdWithSymbolTable::cmp(a, symbol_table, b));
                         variables.extend(fields.into_iter().skip(start).take(count).map(
                             |(key, value)| {
-                                let symbol_table = &self.vm.as_ref().unwrap().lir.symbol_table;
+                                let symbol_table = &self.vm.as_ref().unwrap().lir().symbol_table;
                                 self.create_variable(
                                     DisplayWithSymbolTable::to_string(&key, symbol_table),
                                     value,
@@ -253,7 +253,7 @@ impl PausedState {
                     "Tried to get inner variables of {}.",
                     DisplayWithSymbolTable::to_string(
                         &it,
-                        &self.vm.as_ref().unwrap().lir.symbol_table
+                        &self.vm.as_ref().unwrap().lir().symbol_table
                     ),
                 ),
             },
@@ -303,7 +303,7 @@ impl PausedState {
             name,
             value: DisplayWithSymbolTable::to_string(
                 &object,
-                &self.vm.as_ref().unwrap().lir.symbol_table,
+                &self.vm.as_ref().unwrap().lir().symbol_table,
             ),
             type_field: Self::type_field_for(data.into(), supports_variable_type),
             presentation_hint: Some(Self::presentation_hint_for(data.into())),

--- a/compiler/language_server/src/debug_adapter/session.rs
+++ b/compiler/language_server/src/debug_adapter/session.rs
@@ -350,7 +350,7 @@ impl DebugSession {
                 break None; // The VM finished executing anyways.
             };
             let is_trace_instruction = matches!(
-                vm.lir.instructions[*instruction_pointer],
+                vm.lir().instructions[*instruction_pointer],
                 Instruction::TraceCallEnds | Instruction::TraceExpressionEvaluated,
             );
 


### PR DESCRIPTION
Makes the VM faster by not memcopying stack memory all the time.

### Checklist
<!-- Please check if your PR fulfills the following requirements: -->

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
