### PR TITLE
Fix golden IR checkout on main

### DIFF
--- a/.github/workflows/compiler.yaml
+++ b/.github/workflows/compiler.yaml
@@ -59,7 +59,7 @@ jobs:
         with:
           token: ${{ secrets.GOLDEN_IR_PUSH_TOKEN }}
           repository: candy-lang/golden-irs
-          ref: ${{ github.event.pull_request.base.sha }}_
+          ref: ${{ github.event_name == 'pull_request' && format('{0}_', github.event.pull_request.base.sha) || 'main' }}_
           fetch-depth: 1
           path: golden-irs/
 

--- a/.github/workflows/compiler.yaml
+++ b/.github/workflows/compiler.yaml
@@ -59,7 +59,7 @@ jobs:
         with:
           token: ${{ secrets.GOLDEN_IR_PUSH_TOKEN }}
           repository: candy-lang/golden-irs
-          ref: ${{ github.event_name == 'pull_request' && format('{0}_', github.event.pull_request.base.sha) || 'main' }}_
+          ref: ${{ github.event_name == 'pull_request' && format('{0}_', github.event.pull_request.base.sha) || 'main' }}
           fetch-depth: 1
           path: golden-irs/
 


### PR DESCRIPTION
<!-- Please enter the corresponding issue ID: -->
Failed workflow: https://github.com/candy-lang/candy/actions/runs/5825850612/job/15798424410

<!-- Please summarize your changes: -->
When running on the main branch, the golden IR job tried checking out golden IR branch `_`, which doesn't exist. Now, it checks out `main`. The behavior when running for PRs is unchanged


### Checklist
<!-- Please check if your PR fulfills the following requirements: -->

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
