### PR TITLE
Handle exports struct if multiple main functions exist

### DIFF
--- a/compiler/backend_inkwell/src/lib.rs
+++ b/compiler/backend_inkwell/src/lib.rs
@@ -7,7 +7,7 @@ use inkwell::{
     module::{Linkage, Module},
     support::LLVMString,
     types::{BasicType, StructType},
-    values::{BasicValue, BasicValueEnum, FunctionValue, GlobalValue, PointerValue},
+    values::{BasicValue, BasicValueEnum, FunctionValue, GlobalValue},
     AddressSpace,
 };
 
@@ -36,7 +36,6 @@ pub struct CodeGen<'ctx> {
     locals: HashMap<Id, BasicValueEnum<'ctx>>,
     functions: HashMap<Id, FunctionInfo<'ctx>>,
     unrepresented_ids: HashSet<Id>,
-    main_return: Option<PointerValue<'ctx>>,
 }
 
 impl<'ctx> CodeGen<'ctx> {
@@ -53,7 +52,6 @@ impl<'ctx> CodeGen<'ctx> {
             locals: HashMap::new(),
             functions: HashMap::new(),
             unrepresented_ids: HashSet::new(),
-            main_return: None,
         }
     }
 
@@ -158,53 +156,53 @@ impl<'ctx> CodeGen<'ctx> {
         };
 
         self.builder.position_at_end(block);
-        self.compile_mir(&self.mir.body.clone(), &main_info);
+        let main_return = self
+            .compile_mir(&self.mir.body.clone(), &main_info)
+            .expect("Main Function should return a struct");
         self.builder.position_at_end(block);
 
         let environment = self
             .module
             .add_global(candy_value_ptr, None, "candy_environment");
 
-        if let Some(main_return) = self.main_return {
-            const MAIN_FN_NAME: &str = "Main";
-            let main_text = self.make_str_literal(MAIN_FN_NAME);
+        const MAIN_FN_NAME: &str = "Main";
+        let main_text = self.make_str_literal(MAIN_FN_NAME);
 
-            let main_tag = self
-                .builder
-                .build_call(make_candy_tag, &[main_text.into()], "");
+        let main_tag = self
+            .builder
+            .build_call(make_candy_tag, &[main_text.into()], "");
 
-            let main_fn = self
-                .builder
-                .build_call(
-                    candy_builtin_struct_get,
-                    &[
-                        main_return.into(),
-                        main_tag.try_as_basic_value().unwrap_left().into(),
-                    ],
-                    "",
-                )
-                .try_as_basic_value()
-                .unwrap_left();
+        let main_fn = self
+            .builder
+            .build_call(
+                candy_builtin_struct_get,
+                &[
+                    main_return.as_basic_value_enum().into(),
+                    main_tag.try_as_basic_value().unwrap_left().into(),
+                ],
+                "",
+            )
+            .try_as_basic_value()
+            .unwrap_left();
 
-            let main_res_ptr = self.builder.build_call(
-                run_candy_main,
-                &[main_fn.into(), environment.as_basic_value_enum().into()],
+        let main_res_ptr = self.builder.build_call(
+            run_candy_main,
+            &[main_fn.into(), environment.as_basic_value_enum().into()],
+            "",
+        );
+
+        if print_main_output {
+            self.builder.build_call(
+                print_fn,
+                &[main_res_ptr.try_as_basic_value().unwrap_left().into()],
                 "",
             );
-
-            if print_main_output {
-                self.builder.build_call(
-                    print_fn,
-                    &[main_res_ptr.try_as_basic_value().unwrap_left().into()],
-                    "",
-                );
-                for value in self.module.get_globals() {
-                    if value != environment {
-                        let val =
-                            self.builder
-                                .build_load(candy_value_ptr, value.as_pointer_value(), "");
-                        self.builder.build_call(free_fn, &[val.into()], "");
-                    }
+            for value in self.module.get_globals() {
+                if value != environment {
+                    let val =
+                        self.builder
+                            .build_load(candy_value_ptr, value.as_pointer_value(), "");
+                    self.builder.build_call(free_fn, &[val.into()], "");
                 }
             }
         }
@@ -263,15 +261,21 @@ impl<'ctx> CodeGen<'ctx> {
         Ok(())
     }
 
-    fn compile_mir(&mut self, mir: &Body, function_ctx: &FunctionInfo<'ctx>) {
+    fn compile_mir(
+        &mut self,
+        mir: &Body,
+        function_ctx: &FunctionInfo<'ctx>,
+    ) -> Option<impl BasicValue<'ctx>> {
         let candy_value_ptr = self
             .module
             .get_struct_type("candy_value")
             .unwrap()
             .ptr_type(AddressSpace::default());
 
-        for (idx, (id, expr)) in mir.expressions.iter().enumerate() {
-            match expr {
+        let mut return_value = None;
+
+        for (id, expr) in mir.expressions.iter() {
+            let expr_value = match expr {
                 Expression::Int(value) => {
                     let i64_type = self.context.i64_type();
                     let v = i64_type.const_int(value.try_into().unwrap(), false);
@@ -285,10 +289,7 @@ impl<'ctx> CodeGen<'ctx> {
                         call.try_as_basic_value().unwrap_left(),
                     );
 
-                    if idx == mir.expressions.len() - 1 {
-                        self.builder
-                            .build_return(Some(&global.as_basic_value_enum()));
-                    }
+                    Some(global.as_basic_value_enum())
                 }
                 candy_frontend::mir::Expression::Text(text) => {
                     let string = self.make_str_literal(text);
@@ -300,10 +301,7 @@ impl<'ctx> CodeGen<'ctx> {
                     let global =
                         self.create_global(text, id, call.try_as_basic_value().unwrap_left());
 
-                    if idx == mir.expressions.len() - 1 {
-                        self.builder
-                            .build_return(Some(&global.as_basic_value_enum()));
-                    }
+                    Some(global.as_basic_value_enum())
                 }
                 candy_frontend::mir::Expression::Tag { symbol, value } => {
                     self.tags.insert(symbol.clone(), *value);
@@ -317,10 +315,7 @@ impl<'ctx> CodeGen<'ctx> {
                     let global =
                         self.create_global(symbol, id, call.try_as_basic_value().unwrap_left());
 
-                    if idx == mir.expressions.len() - 1 {
-                        self.builder
-                            .build_return(Some(&global.as_basic_value_enum()));
-                    }
+                    Some(global.as_basic_value_enum())
                 }
                 candy_frontend::mir::Expression::Builtin(builtin) => {
                     let builtin_name = format!("candy_builtin_{}", builtin.as_ref());
@@ -356,10 +351,7 @@ impl<'ctx> CodeGen<'ctx> {
                         call.try_as_basic_value().unwrap_left(),
                     );
 
-                    if idx == mir.expressions.len() - 1 {
-                        self.builder
-                            .build_return(Some(&global.as_basic_value_enum()));
-                    }
+                    Some(global.as_basic_value_enum())
                 }
                 candy_frontend::mir::Expression::List(list) => {
                     let i64_type = self.context.i64_type();
@@ -404,10 +396,7 @@ impl<'ctx> CodeGen<'ctx> {
                     let global =
                         self.create_global("", id, candy_list.try_as_basic_value().unwrap_left());
 
-                    if idx == mir.expressions.len() - 1 {
-                        self.builder
-                            .build_return(Some(&global.as_basic_value_enum()));
-                    }
+                    Some(global.as_basic_value_enum())
                 }
                 candy_frontend::mir::Expression::Struct(s) => {
                     let i64_type = self.context.i64_type();
@@ -487,24 +476,13 @@ impl<'ctx> CodeGen<'ctx> {
 
                     self.locals.insert(*id, struct_value);
 
-                    let function_ctx_name =
-                        function_ctx.function_value.get_name().to_str().unwrap();
-                    if idx == mir.expressions.len() - 1 {
-                        if function_ctx_name != "main" {
-                            self.builder
-                                .build_return(Some(&struct_value.into_pointer_value()));
-                        } else {
-                            self.main_return.replace(struct_value.into_pointer_value());
-                        }
-                    }
+                    Some(struct_value.into_pointer_value().as_basic_value_enum())
                 }
                 candy_frontend::mir::Expression::Reference(ref_id) => {
                     let value = self.get_value_with_id(function_ctx, ref_id).unwrap();
 
                     self.locals.insert(*id, value);
-                    if idx == mir.expressions.len() - 1 {
-                        self.builder.build_return(Some(&value));
-                    }
+                    Some(value)
                 }
                 candy_frontend::mir::Expression::HirId(hir_id) => {
                     let text = format!("{hir_id}");
@@ -515,7 +493,10 @@ impl<'ctx> CodeGen<'ctx> {
                         .builder
                         .build_call(make_candy_text, &[string.into()], "");
 
-                    self.create_global(&text, id, call.try_as_basic_value().unwrap_left());
+                    let global =
+                        self.create_global(&text, id, call.try_as_basic_value().unwrap_left());
+
+                    Some(global.as_basic_value_enum())
                 }
                 candy_frontend::mir::Expression::Function {
                     original_hirs,
@@ -608,9 +589,7 @@ impl<'ctx> CodeGen<'ctx> {
                     self.compile_mir(body, &function_info);
                     self.builder.position_at_end(current_block);
 
-                    if idx == mir.expressions.len() - 1 {
-                        self.builder.build_return(Some(&global));
-                    }
+                    Some(global.as_basic_value_enum())
                 }
                 candy_frontend::mir::Expression::Parameter => unreachable!(),
                 candy_frontend::mir::Expression::Call {
@@ -652,10 +631,7 @@ impl<'ctx> CodeGen<'ctx> {
                         let call_value = call.try_as_basic_value().unwrap_left();
                         self.locals.insert(*id, call_value);
 
-                        if idx == mir.expressions.len() - 1 {
-                            self.builder
-                                .build_return(Some(&call_value.into_pointer_value()));
-                        }
+                        Some(call_value.as_basic_value_enum())
                     } else {
                         let function_value = self
                             .get_value_with_id(function_ctx, function)
@@ -693,10 +669,7 @@ impl<'ctx> CodeGen<'ctx> {
                         let call_value = call.try_as_basic_value().unwrap_left();
                         self.locals.insert(*id, call_value);
 
-                        if idx == mir.expressions.len() - 1 {
-                            self.builder
-                                .build_return(Some(&call_value.into_pointer_value()));
-                        }
+                        Some(call_value.as_basic_value_enum())
                     }
                 }
                 candy_frontend::mir::Expression::UseModule { .. } => unreachable!(),
@@ -708,6 +681,8 @@ impl<'ctx> CodeGen<'ctx> {
                     self.builder.build_call(panic_fn, &[reason.into()], "");
 
                     self.builder.build_unreachable();
+
+                    None
                 }
                 candy_frontend::mir::Expression::TraceCallStarts { .. } => unimplemented!(),
                 candy_frontend::mir::Expression::TraceCallEnds { .. } => unimplemented!(),
@@ -717,8 +692,20 @@ impl<'ctx> CodeGen<'ctx> {
                 candy_frontend::mir::Expression::TraceFoundFuzzableFunction { .. } => {
                     unimplemented!()
                 }
+            };
+
+            if let Some(expr_value) = expr_value {
+                return_value.replace(expr_value);
             }
         }
+        let fn_name = function_ctx.function_value.get_name().to_string_lossy();
+        // This "main" refers to the entrypoint of the compiled program, not to the Candy main function
+        // which may be named differently.
+        if fn_name != "main" {
+            self.builder
+                .build_return(return_value.as_ref().map(|v| v as &dyn BasicValue<'ctx>));
+        }
+        return_value
     }
 
     fn create_global(
@@ -790,6 +777,9 @@ impl<'ctx> CodeGen<'ctx> {
         }
         if v.is_none() && let Some(value) = self.locals.get(id) {
             v.replace(*value);
+        }
+        if self.unrepresented_ids.contains(id) {
+            v.replace(candy_value_ptr.const_null().as_basic_value_enum());
         }
         v.unwrap_or_else(|| panic!("{id} should be a real ID"))
             .into()

--- a/compiler/backend_inkwell/src/lib.rs
+++ b/compiler/backend_inkwell/src/lib.rs
@@ -158,7 +158,7 @@ impl<'ctx> CodeGen<'ctx> {
         self.builder.position_at_end(block);
         let main_return = self
             .compile_mir(&self.mir.body.clone(), &main_info)
-            .expect("Main Function should return a struct");
+            .unwrap();
         self.builder.position_at_end(block);
 
         let environment = self
@@ -298,8 +298,11 @@ impl<'ctx> CodeGen<'ctx> {
                         .builder
                         .build_call(make_candy_text, &[string.into()], "");
 
-                    let global =
-                        self.create_global(text, id, call.try_as_basic_value().unwrap_left());
+                    let global = self.create_global(
+                        &format!("text_{text}"),
+                        id,
+                        call.try_as_basic_value().unwrap_left(),
+                    );
 
                     Some(global.as_basic_value_enum())
                 }
@@ -312,8 +315,11 @@ impl<'ctx> CodeGen<'ctx> {
                         .builder
                         .build_call(make_candy_tag, &[string.into()], "");
 
-                    let global =
-                        self.create_global(symbol, id, call.try_as_basic_value().unwrap_left());
+                    let global = self.create_global(
+                        &format!("tag_{symbol}"),
+                        id,
+                        call.try_as_basic_value().unwrap_left(),
+                    );
 
                     Some(global.as_basic_value_enum())
                 }
@@ -682,7 +688,8 @@ impl<'ctx> CodeGen<'ctx> {
 
                     self.builder.build_unreachable();
 
-                    None
+                    // Early return to avoid building a return instruction.
+                    return None;
                 }
                 candy_frontend::mir::Expression::TraceCallStarts { .. } => unimplemented!(),
                 candy_frontend::mir::Expression::TraceCallEnds { .. } => unimplemented!(),


### PR DESCRIPTION
<!-- Please enter the corresponding issue ID: -->
Closes: #637 

<!-- Please summarize your changes: -->

Previously, having multiple main functions defined could lead to the return value of the wrong one being used for the exports struct. This PR changes the inkwell backend to address this issue.

### Checklist
<!-- Please check if your PR fulfills the following requirements: -->

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
