### PR TITLE
Guard the calls with checks

### DIFF
--- a/compiler/backend_inkwell/candy_runtime/candy_builtin.c
+++ b/compiler/backend_inkwell/candy_runtime/candy_builtin.c
@@ -3,7 +3,7 @@
 #include <string.h>
 #include "candy_runtime.h"
 
-const candy_value_t *candy_builtin_equals(candy_value_t *left, candy_value_t *right)
+const candy_value_t *candy_builtin_equals(candy_value_t *left, candy_value_t *right, candy_value_t *responsible)
 {
     if (left
             ->type != right->type)
@@ -22,7 +22,7 @@ const candy_value_t *candy_builtin_equals(candy_value_t *left, candy_value_t *ri
     }
 }
 
-const candy_value_t *candy_builtin_if_else(candy_value_t *condition, candy_value_t *then, candy_value_t *otherwise)
+const candy_value_t *candy_builtin_if_else(candy_value_t *condition, candy_value_t *then, candy_value_t *otherwise, candy_value_t *responsible)
 {
     candy_value_t *body = candy_tag_to_bool(condition) ? then : otherwise;
     candy_function function = (body->value).function.function;
@@ -30,17 +30,17 @@ const candy_value_t *candy_builtin_if_else(candy_value_t *condition, candy_value
     return function(environment);
 }
 
-candy_value_t *candy_builtin_int_add(candy_value_t *left, candy_value_t *right)
+candy_value_t *candy_builtin_int_add(candy_value_t *left, candy_value_t *right, candy_value_t *responsible)
 {
     return make_candy_int(left->value.integer + right->value.integer);
 }
 
-candy_value_t *candy_builtin_int_subtract(candy_value_t *left, candy_value_t *right)
+candy_value_t *candy_builtin_int_subtract(candy_value_t *left, candy_value_t *right, candy_value_t *responsible)
 {
     return make_candy_int(left->value.integer - right->value.integer);
 }
 
-candy_value_t *candy_builtin_int_bit_length(candy_value_t *value)
+candy_value_t *candy_builtin_int_bit_length(candy_value_t *value, candy_value_t *responsible)
 {
     int64_t int_value = value->value.integer;
     int is_negative = int_value < 0;
@@ -57,22 +57,22 @@ candy_value_t *candy_builtin_int_bit_length(candy_value_t *value)
     return make_candy_int(shifts + is_negative);
 }
 
-candy_value_t *candy_builtin_int_bitwise_and(candy_value_t *left, candy_value_t *right)
+candy_value_t *candy_builtin_int_bitwise_and(candy_value_t *left, candy_value_t *right, candy_value_t *responsible)
 {
     return make_candy_int(left->value.integer & right->value.integer);
 }
 
-candy_value_t *candy_builtin_int_bitwise_or(candy_value_t *left, candy_value_t *right)
+candy_value_t *candy_builtin_int_bitwise_or(candy_value_t *left, candy_value_t *right, candy_value_t *responsible)
 {
     return make_candy_int(left->value.integer | right->value.integer);
 }
 
-candy_value_t *candy_builtin_int_bitwise_xor(candy_value_t *left, candy_value_t *right)
+candy_value_t *candy_builtin_int_bitwise_xor(candy_value_t *left, candy_value_t *right, candy_value_t *responsible)
 {
     return make_candy_int(left->value.integer ^ right->value.integer);
 }
 
-const candy_value_t *candy_builtin_int_compare_to(candy_value_t *left, candy_value_t *right)
+const candy_value_t *candy_builtin_int_compare_to(candy_value_t *left, candy_value_t *right, candy_value_t *responsible)
 {
     int64_t left_value = left->value.integer;
     int64_t right_value = right->value.integer;
@@ -90,7 +90,7 @@ const candy_value_t *candy_builtin_int_compare_to(candy_value_t *left, candy_val
     }
 }
 
-candy_value_t *candy_builtin_list_length(const candy_value_t *list)
+candy_value_t *candy_builtin_list_length(const candy_value_t *list, candy_value_t *responsible)
 {
     size_t index = 0;
     while (list->value.list[index] != NULL)
@@ -100,34 +100,34 @@ candy_value_t *candy_builtin_list_length(const candy_value_t *list)
     return make_candy_int(index);
 }
 
-const candy_value_t *candy_builtin_print(candy_value_t *value)
+const candy_value_t *candy_builtin_print(candy_value_t *value, candy_value_t *responsible)
 {
     print_candy_value(value);
     printf("\n");
     return &__internal_nothing;
 }
 
-candy_value_t *candy_builtin_struct_get(candy_value_t *structure, candy_value_t *key)
+candy_value_t *candy_builtin_struct_get(candy_value_t *structure, candy_value_t *key, candy_value_t *responsible)
 {
     size_t index = 0;
-    while (!candy_tag_to_bool(candy_builtin_equals(structure->value.structure.keys[index], key)))
+    while (!candy_tag_to_bool(candy_builtin_equals(structure->value.structure.keys[index], key, responsible)))
     {
         index++;
     }
     return structure->value.structure.values[index];
 }
 
-candy_value_t *candy_builtin_struct_get_keys(candy_value_t *structure)
+candy_value_t *candy_builtin_struct_get_keys(candy_value_t *structure, candy_value_t *responsible)
 {
     return make_candy_list(structure->value.structure.keys);
 }
 
-const candy_value_t *candy_builtin_struct_has_key(candy_value_t *structure, candy_value_t *key)
+const candy_value_t *candy_builtin_struct_has_key(candy_value_t *structure, candy_value_t *key, candy_value_t *responsible)
 {
     size_t index = 0;
     while (structure->value.structure.keys[index] != NULL)
     {
-        if (candy_tag_to_bool(candy_builtin_equals(structure->value.structure.keys[index], key)))
+        if (candy_tag_to_bool(candy_builtin_equals(structure->value.structure.keys[index], key, responsible)))
         {
             return &__internal_true;
         }
@@ -135,7 +135,7 @@ const candy_value_t *candy_builtin_struct_has_key(candy_value_t *structure, cand
     return &__internal_false;
 }
 
-const candy_value_t *candy_builtin_type_of(candy_value_t *value)
+const candy_value_t *candy_builtin_type_of(candy_value_t *value, candy_value_t *responsible)
 {
     switch (value->type)
     {

--- a/compiler/backend_inkwell/candy_runtime/candy_builtin.h
+++ b/compiler/backend_inkwell/candy_runtime/candy_builtin.h
@@ -1,17 +1,17 @@
 #include "candy_runtime.h"
 
-const candy_value_t *candy_builtin_equals(candy_value_t *left, candy_value_t *right);
-const candy_value_t *candy_builtin_if_else(candy_value_t *condition, candy_value_t *then, candy_value_t *otherwise);
-candy_value_t *candy_builtin_int_add(candy_value_t *left, candy_value_t *right);
-candy_value_t *candy_builtin_int_subtract(candy_value_t *left, candy_value_t *right);
-candy_value_t *candy_builtin_int_bit_length(candy_value_t *value);
-candy_value_t *candy_builtin_int_bitwise_and(candy_value_t *left, candy_value_t *right);
-candy_value_t *candy_builtin_int_bitwise_or(candy_value_t *left, candy_value_t *right);
-candy_value_t *candy_builtin_int_bitwise_xor(candy_value_t *left, candy_value_t *right);
-const candy_value_t *candy_builtin_int_compare_to(candy_value_t *left, candy_value_t *right);
-candy_value_t *candy_builtin_list_length(const candy_value_t *list);
-const candy_value_t *candy_builtin_print(candy_value_t *value);
-candy_value_t *candy_builtin_struct_get(candy_value_t *structure, candy_value_t *key);
-candy_value_t *candy_builtin_struct_get_keys(candy_value_t *structure);
-const candy_value_t *candy_builtin_struct_has_key(candy_value_t *structure, candy_value_t *key);
-const candy_value_t *candy_builtin_type_of(candy_value_t *value);
+const candy_value_t *candy_builtin_equals(candy_value_t *left, candy_value_t *right, candy_value_t *responsible);
+const candy_value_t *candy_builtin_if_else(candy_value_t *condition, candy_value_t *then, candy_value_t *otherwise, candy_value_t *responsible);
+candy_value_t *candy_builtin_int_add(candy_value_t *left, candy_value_t *right, candy_value_t *responsible);
+candy_value_t *candy_builtin_int_subtract(candy_value_t *left, candy_value_t *right, candy_value_t *responsible);
+candy_value_t *candy_builtin_int_bit_length(candy_value_t *value, candy_value_t *responsible);
+candy_value_t *candy_builtin_int_bitwise_and(candy_value_t *left, candy_value_t *right, candy_value_t *responsible);
+candy_value_t *candy_builtin_int_bitwise_or(candy_value_t *left, candy_value_t *right, candy_value_t *responsible);
+candy_value_t *candy_builtin_int_bitwise_xor(candy_value_t *left, candy_value_t *right, candy_value_t *responsible);
+const candy_value_t *candy_builtin_int_compare_to(candy_value_t *left, candy_value_t *right, candy_value_t *responsible);
+candy_value_t *candy_builtin_list_length(const candy_value_t *list, candy_value_t *responsible);
+const candy_value_t *candy_builtin_print(candy_value_t *value, candy_value_t *responsible);
+candy_value_t *candy_builtin_struct_get(candy_value_t *structure, candy_value_t *key, candy_value_t *responsible);
+candy_value_t *candy_builtin_struct_get_keys(candy_value_t *structure, candy_value_t *responsible);
+const candy_value_t *candy_builtin_struct_has_key(candy_value_t *structure, candy_value_t *key, candy_value_t *responsible);
+const candy_value_t *candy_builtin_type_of(candy_value_t *value, candy_value_t *responsible);

--- a/compiler/backend_inkwell/candy_runtime/candy_runtime.c
+++ b/compiler/backend_inkwell/candy_runtime/candy_runtime.c
@@ -59,7 +59,9 @@ void print_candy_value(const candy_value_t *value)
         break;
     case CANDY_TYPE_LIST:
         printf("(");
-        candy_value_t *length = candy_builtin_list_length(value);
+        // TODO: The responsible parameter is not by builtin_list_length
+        // anyways, so we just pass anything.
+        candy_value_t *length = candy_builtin_list_length(value, value);
         size_t list_length = length->value.integer;
         free_candy_value(length);
         size_t index = 0;
@@ -183,11 +185,14 @@ void *get_candy_function_environment(candy_value_t *function)
     return function->value.function.environment;
 }
 
-void candy_panic(const candy_value_t *reason)
+void candy_panic(const candy_value_t *reason, const candy_value_t* responsible)
 {
     printf("The program panicked for the following reason: \n");
     print_candy_value(reason);
     printf("\n");
+    printf("The code at ");
+    print_candy_value(responsible);
+    printf(" is responsible.");
     exit(-1);
 }
 

--- a/compiler/backend_inkwell/src/lib.rs
+++ b/compiler/backend_inkwell/src/lib.rs
@@ -696,12 +696,17 @@ impl<'ctx> CodeGen<'ctx> {
                     }
                 }
                 candy_frontend::mir::Expression::UseModule { .. } => unreachable!(),
-                candy_frontend::mir::Expression::Panic { reason, .. } => {
+                candy_frontend::mir::Expression::Panic {
+                    reason,
+                    responsible,
+                } => {
                     let panic_fn = self.module.get_function("candy_panic").unwrap();
 
                     let reason = self.get_value_with_id(function_ctx, reason).unwrap();
+                    let responsible = self.get_value_with_id(function_ctx, responsible).unwrap();
 
-                    self.builder.build_call(panic_fn, &[reason.into()], "");
+                    self.builder
+                        .build_call(panic_fn, &[reason.into(), responsible.into()], "");
 
                     self.builder.build_unreachable();
                 }

--- a/compiler/backend_inkwell/src/lib.rs
+++ b/compiler/backend_inkwell/src/lib.rs
@@ -521,9 +521,7 @@ impl<'ctx> CodeGen<'ctx> {
                     original_hirs,
                     parameters,
                     body,
-                    responsible_parameter,
                 } => {
-                    self.unrepresented_ids.insert(*responsible_parameter);
                     let name = original_hirs
                         .iter()
                         .sorted()
@@ -616,9 +614,7 @@ impl<'ctx> CodeGen<'ctx> {
                 candy_frontend::mir::Expression::Call {
                     function,
                     arguments,
-                    responsible,
                 } => {
-                    self.unrepresented_ids.insert(*responsible);
                     let mut args: Vec<_> = arguments
                         .iter()
                         .map(|arg| self.get_value_with_id(function_ctx, arg).unwrap().into())

--- a/compiler/cli/src/run.rs
+++ b/compiler/cli/src/run.rs
@@ -120,7 +120,6 @@ pub(crate) fn run(options: Options) -> ProgramResult {
                         unreachable!()
                     };
 
-                    print!(">> ");
                     io::stdout().flush().unwrap();
                     let input = {
                         let stdin = io::stdin();

--- a/compiler/frontend/src/builtin_functions.rs
+++ b/compiler/frontend/src/builtin_functions.rs
@@ -111,7 +111,8 @@ impl BuiltinFunction {
 
     #[must_use]
     pub const fn num_parameters(&self) -> usize {
-        match self {
+        // Responsibility parameter.
+        1 + match self {
             Self::Equals => 2,
             Self::FunctionRun => 1,
             Self::GetArgumentCount => 1,

--- a/compiler/frontend/src/builtin_functions.rs
+++ b/compiler/frontend/src/builtin_functions.rs
@@ -41,6 +41,7 @@ pub enum BuiltinFunction {
     TagGetValue,         // tag -> any
     TagHasValue,         // tag -> booleanTag
     TagWithoutValue,     // tag -> tag
+    TagWithValue,        // tag value -> tag
     TextCharacters,      // text -> (listOfText: list)
     TextConcatenate,     // (textA: text) (textB: text) -> (concatenated: text)
     TextContains,        // text (pattern: text) -> booleanTag
@@ -94,6 +95,7 @@ impl BuiltinFunction {
             Self::TagGetValue => true,
             Self::TagHasValue => true,
             Self::TagWithoutValue => true,
+            Self::TagWithValue => true,
             Self::TextCharacters => true,
             Self::TextConcatenate => true,
             Self::TextContains => true,
@@ -145,6 +147,7 @@ impl BuiltinFunction {
             Self::TagGetValue => 1,
             Self::TagHasValue => 1,
             Self::TagWithoutValue => 1,
+            Self::TagWithValue => 2,
             Self::TextCharacters => 1,
             Self::TextConcatenate => 2,
             Self::TextContains => 2,

--- a/compiler/frontend/src/hir_to_mir.rs
+++ b/compiler/frontend/src/hir_to_mir.rs
@@ -94,7 +94,7 @@ fn generate_needs_function(body: &mut BodyBuilder) -> Id {
         let true_tag = body.push_bool(true);
         let false_tag = body.push_bool(false);
         let is_condition_true =
-            body.push_call(builtin_equals, vec![condition, true_tag], needs_code);
+            body.push_call(builtin_equals, vec![condition, true_tag, needs_code]);
         let is_condition_bool = body.push_if_else(
             &needs_id.child("isConditionTrue"),
             is_condition_true,
@@ -102,7 +102,7 @@ fn generate_needs_function(body: &mut BodyBuilder) -> Id {
                 body.push_reference(true_tag);
             },
             |body| {
-                body.push_call(builtin_equals, vec![condition, false_tag], needs_code);
+                body.push_call(builtin_equals, vec![condition, false_tag, needs_code]);
             },
             needs_code,
         );
@@ -122,12 +122,11 @@ fn generate_needs_function(body: &mut BodyBuilder) -> Id {
 
         // Make sure the reason is a text.
         let builtin_type_of = body.push_builtin(BuiltinFunction::TypeOf);
-        let type_of_reason = body.push_call(builtin_type_of, vec![reason], responsible_for_call);
+        let type_of_reason = body.push_call(builtin_type_of, vec![reason, responsible_for_call]);
         let text_tag = body.push_tag("Text".to_string(), None);
         let is_reason_text = body.push_call(
             builtin_equals,
-            vec![type_of_reason, text_tag],
-            responsible_for_call,
+            vec![type_of_reason, text_tag, responsible_for_call],
         );
         body.push_if_else(
             &needs_id.child("isReasonText"),
@@ -270,8 +269,7 @@ impl<'a> LoweringContext<'a> {
                             let one = body.push_int(1.into());
                             let reason = body.push_call(
                                 list_get_function,
-                                vec![pattern_result, one],
-                                responsible,
+                                vec![pattern_result, one, responsible],
                             );
 
                             body.push_panic(reason, responsible);
@@ -290,7 +288,7 @@ impl<'a> LoweringContext<'a> {
                     let list_get = body.push_builtin(BuiltinFunction::ListGet);
                     let index = body.push_int((identifier_id.0 + 1).into());
                     let responsible = body.push_hir_id(hir_id.clone());
-                    body.push_call(list_get, vec![result, index], responsible)
+                    body.push_call(list_get, vec![result, index, responsible])
                 }
             }
             hir::Expression::Match { expression, cases } => {
@@ -346,22 +344,21 @@ impl<'a> LoweringContext<'a> {
                 function,
                 arguments,
             } => {
-                let responsible = body.push_hir_id(hir_id.clone());
+                let call_site = body.push_hir_id(hir_id.clone());
                 let arguments = arguments
                     .iter()
                     .map(|argument| self.mapping[argument])
+                    .chain([call_site])
                     .collect_vec();
 
                 if self.tracing.calls.is_enabled() {
-                    let hir_call = body.push_hir_id(hir_id.clone());
                     body.push(Expression::TraceCallStarts {
-                        hir_call,
+                        hir_call: call_site,
                         function: self.mapping[function],
                         arguments: arguments.clone(),
-                        responsible,
                     });
                 }
-                let call = body.push_call(self.mapping[function], arguments, responsible);
+                let call = body.push_call(self.mapping[function], arguments);
                 if self.tracing.calls.is_enabled() {
                     body.push(Expression::TraceCallEnds { return_value: call });
                     body.push_reference(call)
@@ -389,8 +386,8 @@ impl<'a> LoweringContext<'a> {
                         self.mapping[condition],
                         self.mapping[reason],
                         responsible_for_needs,
+                        responsible,
                     ],
-                    responsible,
                 )
             }
             hir::Expression::Error { errors, .. } => {
@@ -474,8 +471,7 @@ impl<'a> LoweringContext<'a> {
                     let one = body.push_int(1.into());
                     let reason = body.push_call(
                         list_get_function,
-                        vec![pattern_result, one],
-                        responsible_for_match,
+                        vec![pattern_result, one, responsible_for_match],
                     );
                     no_match_reasons.push(reason);
 
@@ -492,8 +488,12 @@ impl<'a> LoweringContext<'a> {
                 });
                 body.push_call(
                     builtin_if_else,
-                    vec![is_match, then_function, else_function],
-                    responsible_for_match,
+                    vec![
+                        is_match,
+                        then_function,
+                        else_function,
+                        responsible_for_match,
+                    ],
                 )
             }
         }
@@ -544,18 +544,17 @@ impl PatternLoweringContext {
                         body.push_builtin(BuiltinFunction::TagWithoutValue);
                     let actual_symbol = body.push_call(
                         builtin_tag_without_value,
-                        vec![expression],
-                        self.responsible,
+                        vec![expression, self.responsible],
                     );
                     let expected_symbol = body.push_tag(symbol.clone(), None);
                     self.compile_equals(body, expected_symbol, actual_symbol, |body| {
                         let builtin_tag_has_value = body.push_builtin(BuiltinFunction::TagHasValue);
-                        let actual_has_value = body.push_call(builtin_tag_has_value, vec![expression], self.responsible);
+                        let actual_has_value = body.push_call(builtin_tag_has_value, vec![expression, self.responsible]);
                         let expected_has_value = body.push_bool(value.is_some());
                         self.compile_equals(body, expected_has_value, actual_has_value, |body| {
                             if let Some(value) = value {
                                 let builtin_tag_get_value = body.push_builtin(BuiltinFunction::TagGetValue);
-                                let actual_value = body.push_call(builtin_tag_get_value, vec![expression], self.responsible);
+                                let actual_value = body.push_call(builtin_tag_get_value, vec![expression, self.responsible]);
                                 self.compile(body, actual_value, value);
                             } else {
                                 self.push_match(body, vec![]);
@@ -567,9 +566,9 @@ impl PatternLoweringContext {
                                 ]
                             } else {
                                 let builtin_tag_get_value = body.push_builtin(BuiltinFunction::TagGetValue);
-                                let actual_value = body.push_call(builtin_tag_get_value, vec![expression], self.responsible);
+                                let actual_value = body.push_call(builtin_tag_get_value, vec![expression, self.responsible]);
                                 let builtin_to_debug_text = body.push_builtin(BuiltinFunction::ToDebugText);
-                                let actual_value_text = body.push_call(builtin_to_debug_text, vec![actual_value], self.responsible);
+                                let actual_value_text = body.push_call(builtin_to_debug_text, vec![actual_value, self.responsible]);
                                 vec![
                                     body.push_text("Expected tag to not have a value, but it has one: `".to_string()),
                                     actual_value_text,
@@ -598,7 +597,7 @@ impl PatternLoweringContext {
                     let expected = body.push_int(list.len().into());
                     let builtin_list_length = body.push_builtin(BuiltinFunction::ListLength);
                     let actual_length =
-                        body.push_call(builtin_list_length, vec![expression], self.responsible);
+                        body.push_call(builtin_list_length, vec![expression, self.responsible]);
                     self.compile_equals(
                         body,
                         expected,
@@ -614,8 +613,7 @@ impl PatternLoweringContext {
                                         let index = body.push_int(index.into());
                                         let item = body.push_call(
                                             builtin_list_get,
-                                            vec![expression, index],
-                                            self.responsible,
+                                            vec![expression, index, self.responsible],
                                         );
                                         let result = self.compile(body, item, item_pattern);
                                         (result, item_pattern.captured_identifier_count())
@@ -651,8 +649,7 @@ impl PatternLoweringContext {
                                 let key = self.compile_pattern_to_key_expression(body, key_pattern);
                                 let has_key = body.push_call(
                                     builtin_struct_has_key,
-                                    vec![expression, key],
-                                    self.responsible,
+                                    vec![expression, key, self.responsible,],
                                 );
 
                                 let result = body.push_if_else(
@@ -661,8 +658,7 @@ impl PatternLoweringContext {
                                     |body| {
                                         let value = body.push_call(
                                             builtin_struct_get,
-                                            vec![expression, key],
-                                            self.responsible,
+                                            vec![expression, key, self.responsible],
                                         );
                                         self.compile(body, value, value_pattern);
                                     },
@@ -672,14 +668,12 @@ impl PatternLoweringContext {
 
                                         let key_as_text = body.push_call(
                                             to_debug_text,
-                                            vec![key],
-                                            self.responsible,
+                                            vec![key, self.responsible],
                                         );
 
                                         let struct_as_text = body.push_call(
                                             to_debug_text,
-                                            vec![expression],
-                                            self.responsible,
+                                            vec![expression, self.responsible],
                                         );
 
                                         let reason_parts = vec![
@@ -736,7 +730,7 @@ impl PatternLoweringContext {
                                     let Some(index) = index else { return body.push_reference(nothing); };
 
                                     let index = body.push_int((1 + index).into());
-                                    body.push_call(list_get_function, vec![result, index], self.responsible)
+                                    body.push_call(list_get_function, vec![result, index, self.responsible])
                                 })
                                 .collect();
                             self.push_match(body, captured_identifiers);
@@ -792,7 +786,7 @@ impl PatternLoweringContext {
     {
         let expected_type = body.push_tag(expected_type, None);
         let builtin_type_of = body.push_builtin(BuiltinFunction::TypeOf);
-        let type_ = body.push_call(builtin_type_of, vec![expression], self.responsible);
+        let type_ = body.push_call(builtin_type_of, vec![expression, self.responsible]);
         self.compile_equals(
             body,
             expected_type,
@@ -823,7 +817,7 @@ impl PatternLoweringContext {
         E: FnOnce(&mut BodyBuilder, Id, Id) -> Vec<Id>,
     {
         let builtin_equals = body.push_builtin(BuiltinFunction::Equals);
-        let equals = body.push_call(builtin_equals, vec![expected, actual], self.responsible);
+        let equals = body.push_call(builtin_equals, vec![expected, actual, self.responsible]);
 
         body.push_if_else(
             &self.hir_id.child("equals"),
@@ -832,8 +826,8 @@ impl PatternLoweringContext {
             |body| {
                 let to_debug_text = body.push_builtin(BuiltinFunction::ToDebugText);
                 let expected_as_text =
-                    body.push_call(to_debug_text, vec![expected], self.responsible);
-                let actual_as_text = body.push_call(to_debug_text, vec![actual], self.responsible);
+                    body.push_call(to_debug_text, vec![expected, self.responsible]);
+                let actual_as_text = body.push_call(to_debug_text, vec![actual, self.responsible]);
                 let reason_parts = reason_factory(body, expected_as_text, actual_as_text);
                 let reason = self.push_text_concatenate(body, reason_parts);
                 self.push_no_match(body, reason);
@@ -897,8 +891,7 @@ impl PatternLoweringContext {
                     let index = body.push_int((index + 1).into());
                     let captured_identifier = body.push_call(
                         list_get_function,
-                        vec![return_value, index],
-                        self.responsible,
+                        vec![return_value, index, self.responsible],
                     );
                     captured_identifiers.push(captured_identifier);
                 }
@@ -920,8 +913,7 @@ impl PatternLoweringContext {
             .reduce(|left, right| {
                 body.push_call(
                     builtin_text_concatenate,
-                    vec![left, right],
-                    self.responsible,
+                    vec![left, right, self.responsible],
                 )
             })
             .unwrap()
@@ -952,16 +944,14 @@ impl BodyBuilder {
         let zero = self.push_int(0.into());
         let match_or_no_match_tag = self.push_call(
             list_get_function,
-            vec![match_or_no_match, zero],
-            responsible,
+            vec![match_or_no_match, zero, responsible],
         );
 
         let equals_function = self.push_builtin(BuiltinFunction::Equals);
         let match_tag = self.push_match_tag();
         self.push_call(
             equals_function,
-            vec![match_or_no_match_tag, match_tag],
-            responsible,
+            vec![match_or_no_match_tag, match_tag, responsible],
         )
     }
 

--- a/compiler/frontend/src/lir/body.rs
+++ b/compiler/frontend/src/lir/body.rs
@@ -73,24 +73,7 @@ impl ToRichIr for Bodies {
                 builder.push_definition(parameter_id, range);
             }
 
-            let responsible_parameter_id = body.responsible_parameter_id();
-            builder.push(
-                if body.parameter_count == 0 {
-                    " (responsible "
-                } else {
-                    " (+ responsible "
-                },
-                None,
-                EnumSet::empty(),
-            );
-            let range = builder.push(
-                responsible_parameter_id.to_string(),
-                TokenType::Parameter,
-                EnumSet::empty(),
-            );
-            builder.push_definition(responsible_parameter_id, range);
-
-            builder.push(") =", None, EnumSet::empty());
+            builder.push(" =", None, EnumSet::empty());
 
             builder.indent();
             builder.push_newline();
@@ -106,7 +89,6 @@ impl ToRichIr for Bodies {
 ///
 /// - captured variables
 /// - parameters
-/// - responsible parameter
 /// - locals
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Body {
@@ -152,16 +134,12 @@ impl Body {
         (self.captured_count..self.captured_count + self.parameter_count).map(Id::from_usize)
     }
 
-    fn responsible_parameter_id(&self) -> Id {
-        Id::from_usize(self.captured_count + self.parameter_count)
-    }
-
     #[must_use]
     pub fn expressions(&self) -> &[Expression] {
         &self.expressions
     }
     pub fn ids_and_expressions(&self) -> impl Iterator<Item = (Id, &Expression)> {
-        let offset = self.captured_count + self.parameter_count + 1;
+        let offset = self.captured_count + self.parameter_count;
         self.expressions
             .iter()
             .enumerate()

--- a/compiler/frontend/src/lir/expression.rs
+++ b/compiler/frontend/src/lir/expression.rs
@@ -42,7 +42,6 @@ pub enum Expression {
     Call {
         function: Id,
         arguments: Vec<Id>,
-        responsible: Id,
     },
 
     Panic {
@@ -54,7 +53,6 @@ pub enum Expression {
         hir_call: Id,
         function: Id,
         arguments: Vec<Id>,
-        responsible: Id,
     },
 
     TraceCallEnds {
@@ -128,7 +126,6 @@ impl ToRichIr for Expression {
             Self::Call {
                 function,
                 arguments,
-                responsible,
             } => {
                 builder.push("call ", None, EnumSet::empty());
                 function.build_rich_ir(builder);
@@ -138,9 +135,6 @@ impl ToRichIr for Expression {
                 } else {
                     builder.push_children(arguments, " ");
                 }
-                builder.push(" (", None, EnumSet::empty());
-                responsible.build_rich_ir(builder);
-                builder.push(" is responsible)", None, EnumSet::empty());
             }
             Self::Panic {
                 reason,
@@ -148,23 +142,20 @@ impl ToRichIr for Expression {
             } => {
                 builder.push("panicking because ", None, EnumSet::empty());
                 reason.build_rich_ir(builder);
-                builder.push(" (", None, EnumSet::empty());
+                builder.push(", ", None, EnumSet::empty());
                 responsible.build_rich_ir(builder);
-                builder.push(" is at fault)", None, EnumSet::empty());
+                builder.push(" is at fault", None, EnumSet::empty());
             }
             Self::TraceCallStarts {
                 hir_call,
                 function,
                 arguments,
-                responsible,
             } => {
                 builder.push("trace: start of call of ", None, EnumSet::empty());
                 function.build_rich_ir(builder);
                 builder.push(" with ", None, EnumSet::empty());
                 builder.push_children(arguments, " ");
-                builder.push(" (", None, EnumSet::empty());
-                responsible.build_rich_ir(builder);
-                builder.push(" is responsible, code is at ", None, EnumSet::empty());
+                builder.push(" (code is at ", None, EnumSet::empty());
                 hir_call.build_rich_ir(builder);
                 builder.push(")", None, EnumSet::empty());
             }

--- a/compiler/frontend/src/mir/body.rs
+++ b/compiler/frontend/src/mir/body.rs
@@ -240,21 +240,16 @@ impl Body {
         visitor: &mut dyn FnMut(Id, &mut Expression, &VisibleExpressions, bool),
     ) {
         if let Expression::Function {
-            parameters,
-            responsible_parameter,
-            body,
-            ..
+            parameters, body, ..
         } = expression
         {
             for parameter in &*parameters {
                 visible.insert(*parameter, Expression::Parameter);
             }
-            visible.insert(*responsible_parameter, Expression::Parameter);
             body.visit_with_visible_rec(visible, visitor);
             for parameter in &*parameters {
                 visible.remove(*parameter);
             }
-            visible.remove(*responsible_parameter);
         }
 
         visitor(id, expression, visible, is_returned);
@@ -306,8 +301,11 @@ impl FunctionBodyBuilder {
         let (id_generator, body) = self.body_builder.finish();
         let function = Expression::Function {
             original_hirs: vec![self.hir_id].into_iter().collect(),
-            parameters: self.parameters,
-            responsible_parameter: self.responsible_parameter,
+            parameters: self
+                .parameters
+                .into_iter()
+                .chain([self.responsible_parameter])
+                .collect(),
             body,
         };
         (id_generator, function)
@@ -381,11 +379,10 @@ impl BodyBuilder {
         self.push(function)
     }
 
-    pub fn push_call(&mut self, function: Id, arguments: Vec<Id>, responsible: Id) -> Id {
+    pub fn push_call(&mut self, function: Id, arguments: Vec<Id>) -> Id {
         self.push(Expression::Call {
             function,
             arguments,
-            responsible,
         })
     }
     pub fn push_if_else<T, E>(
@@ -405,8 +402,7 @@ impl BodyBuilder {
         let else_function = self.push_function(hir_id.child("else"), |body, _| else_builder(body));
         self.push_call(
             builtin_if_else,
-            vec![condition, then_function, else_function],
-            responsible,
+            vec![condition, then_function, else_function, responsible],
         )
     }
 

--- a/compiler/frontend/src/mir_optimize/common_subtree_elimination.rs
+++ b/compiler/frontend/src/mir_optimize/common_subtree_elimination.rs
@@ -172,11 +172,10 @@ impl NormalizationState {
             self.register_defined_id(*id);
         }
     }
-    fn register_function_ids(&mut self, parameters: &[Id], responsible_parameter: Id) {
+    fn register_function_ids(&mut self, parameters: &[Id]) {
         for parameter in parameters {
             self.register_defined_id(*parameter);
         }
-        self.register_defined_id(responsible_parameter);
     }
     fn register_defined_id(&mut self, id: Id) {
         let replacement = self.id_generator.generate();
@@ -390,28 +389,20 @@ impl NormalizedComparison for Expression {
                 Self::Function {
                     original_hirs: _,
                     parameters: self_parameters,
-                    responsible_parameter: self_responsible_parameter,
                     body: self_body,
                 },
                 Self::Function {
                     original_hirs: _,
                     parameters: other_parameters,
-                    responsible_parameter: other_responsible_parameter,
                     body: other_body,
                 },
             ) => {
-                self_normalization
-                    .register_function_ids(self_parameters, *self_responsible_parameter);
-                other_normalization
-                    .register_function_ids(other_parameters, *other_responsible_parameter);
+                self_normalization.register_function_ids(self_parameters);
+                other_normalization.register_function_ids(other_parameters);
 
                 self_parameters.equals_normalized(
                     self_normalization,
                     other_parameters,
-                    other_normalization,
-                ) && self_responsible_parameter.equals_normalized(
-                    self_normalization,
-                    other_responsible_parameter,
                     other_normalization,
                 ) && self_body.equals_normalized(
                     self_normalization,
@@ -424,12 +415,10 @@ impl NormalizedComparison for Expression {
                 Self::Call {
                     function: self_function,
                     arguments: self_arguments,
-                    responsible: self_responsible,
                 },
                 Self::Call {
                     function: other_function,
                     arguments: other_arguments,
-                    responsible: other_responsible,
                 },
             ) => {
                 self_function.equals_normalized(
@@ -439,10 +428,6 @@ impl NormalizedComparison for Expression {
                 ) && self_arguments.equals_normalized(
                     self_normalization,
                     other_arguments,
-                    other_normalization,
-                ) && self_responsible.equals_normalized(
-                    self_normalization,
-                    other_responsible,
                     other_normalization,
                 )
             }
@@ -494,13 +479,11 @@ impl NormalizedComparison for Expression {
                     hir_call: self_hir_call,
                     function: self_function,
                     arguments: self_arguments,
-                    responsible: self_responsible,
                 },
                 Self::TraceCallStarts {
                     hir_call: other_hir_call,
                     function: other_function,
                     arguments: other_arguments,
-                    responsible: other_responsible,
                 },
             ) => {
                 self_hir_call.equals_normalized(
@@ -514,10 +497,6 @@ impl NormalizedComparison for Expression {
                 ) && self_arguments.equals_normalized(
                     self_normalization,
                     other_arguments,
-                    other_normalization,
-                ) && self_responsible.equals_normalized(
-                    self_normalization,
-                    other_responsible,
                     other_normalization,
                 )
             }
@@ -594,24 +573,20 @@ impl NormalizedComparison for Expression {
             Self::Function {
                 original_hirs: _,
                 parameters,
-                responsible_parameter,
                 body,
             } => {
-                normalization.register_function_ids(parameters, *responsible_parameter);
+                normalization.register_function_ids(parameters);
 
                 parameters.hash_normalized(normalization, state);
-                responsible_parameter.hash_normalized(normalization, state);
                 body.hash_normalized(normalization, state);
             }
             Self::Parameter => {}
             Self::Call {
                 function,
                 arguments,
-                responsible,
             } => {
                 function.hash_normalized(normalization, state);
                 arguments.hash_normalized(normalization, state);
-                responsible.hash_normalized(normalization, state);
             }
             Self::UseModule {
                 current_module,
@@ -633,12 +608,10 @@ impl NormalizedComparison for Expression {
                 hir_call,
                 function,
                 arguments,
-                responsible,
             } => {
                 hir_call.hash_normalized(normalization, state);
                 function.hash_normalized(normalization, state);
                 arguments.hash_normalized(normalization, state);
-                responsible.hash_normalized(normalization, state);
             }
             Self::TraceCallEnds { return_value } => {
                 return_value.hash_normalized(normalization, state);

--- a/compiler/frontend/src/mir_optimize/constant_folding.rs
+++ b/compiler/frontend/src/mir_optimize/constant_folding.rs
@@ -60,7 +60,7 @@ pub fn fold_constants(context: &mut Context, expression: &mut CurrentExpression)
     };
 
     let function = context.visible.get(*function);
-    if let Expression::Tag { symbol, value: None } = function && arguments.len() == 1 {
+    if let Expression::Tag { symbol, value: None } = function && arguments.len() == 2 {
         **expression = Expression::Tag { symbol: symbol.clone(), value: Some(arguments[0]) };
         return;
     }

--- a/compiler/frontend/src/mir_optimize/constant_folding.rs
+++ b/compiler/frontend/src/mir_optimize/constant_folding.rs
@@ -412,6 +412,18 @@ fn run_builtin(
                 value: None,
             }
         }
+        BuiltinFunction::TagWithValue => {
+            let [tag, value] = arguments else {
+                unreachable!()
+            };
+            let Expression::Tag { symbol, .. } = visible.get(*tag) else {
+                return None;
+            };
+            Expression::Tag {
+                symbol: symbol.clone(),
+                value: Some(*value),
+            }
+        }
         BuiltinFunction::TextCharacters => {
             let [text] = arguments else { unreachable!() };
             let Expression::Text(text) = visible.get(*text) else {
@@ -658,6 +670,7 @@ fn run_builtin(
                         BuiltinFunction::TagGetValue => return None,
                         BuiltinFunction::TagHasValue => "Tag",
                         BuiltinFunction::TagWithoutValue => "Tag",
+                        BuiltinFunction::TagWithValue => "Tag",
                         BuiltinFunction::TextCharacters => "List",
                         BuiltinFunction::TextConcatenate => "Text",
                         BuiltinFunction::TextContains => "Tag",

--- a/compiler/frontend/src/mir_optimize/inlining.rs
+++ b/compiler/frontend/src/mir_optimize/inlining.rs
@@ -77,7 +77,6 @@ impl Context<'_> {
         let Expression::Call {
             function,
             arguments,
-            responsible: responsible_argument,
         } = &**expression
         else {
             // Expression is not a call.
@@ -91,7 +90,6 @@ impl Context<'_> {
         let Expression::Function {
             original_hirs: _,
             parameters,
-            responsible_parameter,
             body,
         } = self.visible.get(*function)
         else {
@@ -107,7 +105,6 @@ impl Context<'_> {
             .iter()
             .zip(arguments.iter())
             .map(|(parameter, argument)| (*parameter, *argument))
-            .chain([(*responsible_parameter, *responsible_argument)])
             .chain(
                 body.defined_ids()
                     .into_iter()

--- a/compiler/frontend/src/mir_optimize/mod.rs
+++ b/compiler/frontend/src/mir_optimize/mod.rs
@@ -212,7 +212,7 @@ impl Context<'_> {
         if let Expression::Call { function, arguments, .. } = &**expression
             && let Expression::Function { original_hirs, .. } = self.visible.get(*function)
             && original_hirs.contains(&hir::Id::needs())
-            && arguments.len() == 3
+            && arguments.len() == 4
             && let Expression::Tag { symbol, value: None  } = self.visible.get(arguments[0])
             && symbol == "True" {
             **expression = Expression::nothing();

--- a/compiler/frontend/src/mir_optimize/mod.rs
+++ b/compiler/frontend/src/mir_optimize/mod.rs
@@ -166,26 +166,19 @@ impl Context<'_> {
     fn optimize_expression(&mut self, expression: &mut CurrentExpression) {
         'outer: loop {
             if let Expression::Function {
-                parameters,
-                responsible_parameter,
-                body,
-                ..
+                parameters, body, ..
             } = &mut **expression
             {
                 for parameter in &*parameters {
                     self.visible.insert(*parameter, Expression::Parameter);
                 }
-                self.visible
-                    .insert(*responsible_parameter, Expression::Parameter);
-                self.pureness
-                    .enter_function(parameters, *responsible_parameter);
+                self.pureness.enter_function(parameters);
 
                 self.optimize_body(body);
 
                 for parameter in &*parameters {
                     self.visible.remove(*parameter);
                 }
-                self.visible.remove(*responsible_parameter);
             }
 
             loop {

--- a/compiler/frontend/src/mir_optimize/pure.rs
+++ b/compiler/frontend/src/mir_optimize/pure.rs
@@ -60,20 +60,12 @@ impl PurenessInsights {
         // TODO: Don't optimize lifted constants again.
         // Then, we can also add asserts here about not visiting them twice.
     }
-    pub(super) fn enter_function(&mut self, parameters: &[Id], responsible_parameter: Id) {
+    pub(super) fn enter_function(&mut self, parameters: &[Id]) {
         self.definition_pureness
             .extend(parameters.iter().map(|id| (*id, true)));
-        let _existing = self.definition_pureness.insert(responsible_parameter, true);
-        // TODO: Handle lifted constants properly.
-        // assert!(existing.is_none());
 
         self.definition_constness
             .extend(parameters.iter().map(|id| (*id, false)));
-        let _existing = self
-            .definition_constness
-            .insert(responsible_parameter, false);
-        // TODO: Handle lifted constants properly.
-        // assert!(existing.is_none());
     }
     pub(super) fn on_normalize_ids(&mut self, mapping: &FxHashMap<Id, Id>) {
         fn update(values: &mut FxHashMap<Id, bool>, mapping: &FxHashMap<Id, Id>) {

--- a/compiler/frontend/src/mir_optimize/utils.rs
+++ b/compiler/frontend/src/mir_optimize/utils.rs
@@ -15,14 +15,10 @@ impl Expression {
     }
     fn collect_defined_ids(&self, defined: &mut Vec<Id>) {
         if let Self::Function {
-            parameters,
-            responsible_parameter,
-            body,
-            ..
+            parameters, body, ..
         } = self
         {
             defined.extend(parameters);
-            defined.push(*responsible_parameter);
             body.collect_defined_ids(defined);
         }
     }
@@ -79,11 +75,9 @@ impl Expression {
             Self::Call {
                 function,
                 arguments,
-                responsible,
             } => {
                 referenced.insert(*function);
                 referenced.extend(arguments);
-                referenced.insert(*responsible);
             }
             Self::UseModule {
                 current_module: _,
@@ -104,12 +98,10 @@ impl Expression {
                 hir_call,
                 function,
                 arguments,
-                responsible,
             } => {
                 referenced.insert(*hir_call);
                 referenced.insert(*function);
                 referenced.extend(arguments);
-                referenced.insert(*responsible);
             }
             Self::TraceCallEnds { return_value } => {
                 referenced.insert(*return_value);
@@ -223,26 +215,22 @@ impl Expression {
             Self::Function {
                 original_hirs: _,
                 parameters,
-                responsible_parameter,
                 body,
             } => {
                 for parameter in parameters {
                     replacer(parameter);
                 }
-                replacer(responsible_parameter);
                 body.replace_id_references(replacer);
             }
             Self::Parameter => {}
             Self::Call {
                 function,
                 arguments,
-                responsible,
             } => {
                 replacer(function);
                 for argument in arguments {
                     replacer(argument);
                 }
-                replacer(responsible);
             }
             Self::UseModule {
                 current_module: _,
@@ -263,14 +251,12 @@ impl Expression {
                 hir_call,
                 function,
                 arguments,
-                responsible,
             } => {
                 replacer(hir_call);
                 replacer(function);
                 for argument in arguments {
                     replacer(argument);
                 }
-                replacer(responsible);
             }
             Self::TraceCallEnds { return_value } => {
                 replacer(return_value);
@@ -308,13 +294,11 @@ impl Expression {
             Self::Function {
                 original_hirs: _,
                 parameters,
-                responsible_parameter,
                 body,
             } => {
                 for parameter in parameters {
                     replacer(parameter);
                 }
-                replacer(responsible_parameter);
                 body.replace_ids(replacer);
             }
             // All other expressions don't define IDs and instead only contain

--- a/compiler/frontend/src/mir_optimize/validate.rs
+++ b/compiler/frontend/src/mir_optimize/validate.rs
@@ -27,13 +27,11 @@ impl Body {
             if let Expression::Function {
                 original_hirs: _,
                 parameters,
-                responsible_parameter,
                 body,
             } = expression
             {
                 let mut inner_visible = visible.clone();
                 inner_visible.extend(parameters.iter().copied());
-                inner_visible.insert(*responsible_parameter);
                 body.validate(defined_ids, inner_visible);
             }
 

--- a/compiler/frontend/src/mir_to_lir.rs
+++ b/compiler/frontend/src/mir_to_lir.rs
@@ -92,7 +92,7 @@ impl CurrentBody {
             .enumerate()
             .map(|(index, id)| (id, lir::Id::from_usize(index)))
             .collect();
-        let ids_to_drop = id_mapping.iter().map(|(_, v)| v).copied().collect();
+        let ids_to_drop = id_mapping.values().copied().collect();
         Self {
             id_mapping,
             captured_count,

--- a/compiler/frontend/src/mir_to_lir.rs
+++ b/compiler/frontend/src/mir_to_lir.rs
@@ -92,7 +92,14 @@ impl CurrentBody {
             .enumerate()
             .map(|(index, id)| (id, lir::Id::from_usize(index)))
             .collect();
-        let ids_to_drop = id_mapping.values().copied().collect();
+
+        // Don't drop responsible parameters because they are guaranteed to be
+        // constant and thereby not reference-counted.
+        let mut ids_to_drop: FxHashSet<lir::Id> = id_mapping.values().copied().collect();
+        if let Some(responsible_id) = parameters.last() {
+            ids_to_drop.remove(&id_mapping[responsible_id]);
+        }
+
         Self {
             id_mapping,
             captured_count,

--- a/compiler/fuzzer/src/runner.rs
+++ b/compiler/fuzzer/src/runner.rs
@@ -75,17 +75,16 @@ impl<L: Borrow<Lir> + Clone> Runner<L> {
             .clone_to_heap_with_mapping(&mut heap, &mut mapping)
             .try_into()
             .unwrap();
-        let arguments = input
+        let mut arguments = input
             .arguments
             .clone_to_heap_with_mapping(&mut heap, &mut mapping);
-        let responsible = HirId::create(&mut heap, true, Id::fuzzer());
+        arguments.push(HirId::create(&mut heap, true, Id::fuzzer()).into());
 
         let vm = Vm::for_function(
             lir.clone(),
             heap,
             function,
             &arguments,
-            responsible,
             StackTracer::default(),
         );
 

--- a/compiler/language_server/src/debug_adapter/session.rs
+++ b/compiler/language_server/src/debug_adapter/session.rs
@@ -214,8 +214,13 @@ impl DebugSession {
                 let environment = Struct::create(&mut heap, true, &FxHashMap::default()).into();
                 let platform = HirId::create(&mut heap, true, Id::platform());
                 let tracer = DebugTracer::default();
-                let vm =
-                    Vm::for_function(Rc::new(lir), heap, main, &[environment], platform, tracer);
+                let vm = Vm::for_function(
+                    Rc::new(lir),
+                    heap,
+                    main,
+                    &[environment, platform.into()],
+                    tracer,
+                );
 
                 // TODO: remove when we support pause and continue
                 let vm = match vm.run_n_without_handles(10000) {

--- a/compiler/language_server/src/debug_adapter/tracer.rs
+++ b/compiler/language_server/src/debug_adapter/tracer.rs
@@ -42,17 +42,10 @@ impl Tracer for DebugTracer {
     fn call_started(
         &mut self,
         heap: &mut Heap,
-        call_site: HirId,
         callee: InlineObject,
         arguments: Vec<InlineObject>,
-        responsible: HirId,
     ) {
-        let call = Call {
-            call_site,
-            callee,
-            arguments,
-            responsible,
-        };
+        let call = Call { callee, arguments };
         call.dup(heap);
         self.call_stack.push(StackFrame::new(call));
     }

--- a/compiler/language_server/src/features_candy/analyzer/static_panics.rs
+++ b/compiler/language_server/src/features_candy/analyzer/static_panics.rs
@@ -50,24 +50,22 @@ impl StaticPanicsOfExpression for Expression {
         let referenced = self.referenced_ids();
         match self {
             Expression::Function {
-                parameters,
-                responsible_parameter,
-                body,
-                ..
+                parameters, body, ..
             } => {
-                let is_fuzzable = referenced.contains(responsible_parameter);
+                parameters
+                    .last()
+                    .map(|responsible| referenced.contains(responsible))
+                    .unwrap_or(true);
 
                 for parameter in parameters.iter() {
                     visible.insert(*parameter, Expression::Parameter);
                 }
-                visible.insert(*responsible_parameter, Expression::Parameter);
 
                 body.collect_static_panics(visible, panics, is_fuzzable);
 
                 for parameter in parameters {
                     visible.remove(*parameter);
                 }
-                visible.remove(*responsible_parameter);
             }
             Expression::Panic {
                 reason,

--- a/compiler/vm/benches/utils.rs
+++ b/compiler/vm/benches/utils.rs
@@ -112,9 +112,14 @@ pub fn run(lir: impl Borrow<Lir>) -> (Heap, InlineObject) {
     // Run the `main` function.
     let environment = Struct::create(&mut heap, true, &FxHashMap::default());
     let responsible = HirId::create(&mut heap, true, hir::Id::user());
-    let VmFinished { heap, result, .. } =
-        Vm::for_function(lir, heap, main, &[environment.into()], responsible, tracer)
-            .run_forever_without_handles();
+    let VmFinished { heap, result, .. } = Vm::for_function(
+        lir,
+        heap,
+        main,
+        &[environment.into(), responsible.into()],
+        tracer,
+    )
+    .run_forever_without_handles();
     match result {
         Ok(return_value) => (heap, return_value),
         Err(panic) => {

--- a/compiler/vm/fuzz/fuzz_targets/vm.rs
+++ b/compiler/vm/fuzz/fuzz_targets/vm.rs
@@ -87,8 +87,7 @@ fuzz_target!(|data: &[u8]| {
         &lir,
         heap,
         main,
-        &[environment.into()],
-        responsible,
+        &[environment.into(), responsible.into()],
         DummyTracer,
     )
     .run_forever_without_handles();

--- a/compiler/vm/src/builtin_functions.rs
+++ b/compiler/vm/src/builtin_functions.rs
@@ -63,6 +63,7 @@ impl MachineState {
             BuiltinFunction::TagGetValue => self.heap.tag_get_value(args),
             BuiltinFunction::TagHasValue => self.heap.tag_has_value(args),
             BuiltinFunction::TagWithoutValue => self.heap.tag_without_value(args),
+            BuiltinFunction::TagWithValue => self.heap.tag_with_value(args),
             BuiltinFunction::TextCharacters => self.heap.text_characters(args),
             BuiltinFunction::TextConcatenate => self.heap.text_concatenate(args),
             BuiltinFunction::TextContains => self.heap.text_contains(args),
@@ -373,6 +374,13 @@ impl Heap {
     fn tag_without_value(&mut self, args: &[InlineObject]) -> BuiltinResult {
         unpack_and_later_drop!(self, args, |tag: Tag| {
             Return(tag.without_value().into())
+        })
+    }
+    fn tag_with_value(&mut self, args: &[InlineObject]) -> BuiltinResult {
+        unpack!(self, args, |tag: Tag, value: Any| {
+            let symbol = tag.symbol_id();
+            tag.object.drop(self);
+            Return(Tag::create_with_value(self, true, symbol, value.object).into())
         })
     }
 

--- a/compiler/vm/src/heap/object.rs
+++ b/compiler/vm/src/heap/object.rs
@@ -586,6 +586,10 @@ pub struct Handle(InlineHandle);
 
 impl Handle {
     pub fn new(heap: &mut Heap, argument_count: usize) -> Self {
+        assert!(
+            argument_count >= 1,
+            "Each handle needs to accept at least a responsibility parameter."
+        );
         let id = heap.handle_id_generator.generate();
         Self::create(heap, id, argument_count)
     }

--- a/compiler/vm/src/lir.rs
+++ b/compiler/vm/src/lir.rs
@@ -155,7 +155,6 @@ impl Instruction {
                 stack.push(top);
             }
             Instruction::Call { num_args } => {
-                stack.pop(); // responsible
                 stack.pop_multiple(*num_args);
                 stack.pop(); // function/builtin
                 stack.push(result); // return value
@@ -164,7 +163,6 @@ impl Instruction {
                 num_locals_to_pop,
                 num_args,
             } => {
-                stack.pop(); // responsible
                 stack.pop_multiple(*num_args);
                 stack.pop(); // function/builtin
                 stack.pop_multiple(*num_locals_to_pop);
@@ -181,7 +179,6 @@ impl Instruction {
             }
             Instruction::TraceCallStarts { num_args } => {
                 stack.pop(); // HIR ID
-                stack.pop(); // responsible
                 stack.pop_multiple(*num_args);
                 stack.pop(); // callee
             }

--- a/compiler/vm/src/mir_to_lir.rs
+++ b/compiler/vm/src/mir_to_lir.rs
@@ -71,7 +71,6 @@ where
         FxHashSet::from_iter([hir::Id::new(module, vec![])]),
         &FxHashSet::default(),
         &[],
-        Id::from_usize(0),
         &mir.body,
     );
     module_function.set_body(start);
@@ -85,7 +84,6 @@ fn compile_function(
     original_hirs: FxHashSet<hir::Id>,
     captured: &FxHashSet<Id>,
     parameters: &[Id],
-    responsible_parameter: Id,
     body: &Body,
 ) -> InstructionPointer {
     let mut context = LoweringContext {
@@ -100,14 +98,13 @@ fn compile_function(
     for parameter in parameters {
         context.stack.push(*parameter);
     }
-    context.stack.push(responsible_parameter);
 
     for (id, expression) in body.iter() {
         context.compile_expression(id, expression);
     }
     // Expressions may not push things onto the stack, but to the constant heap
     // instead.
-    if *context.stack.last().unwrap() != body.return_value() {
+    if context.stack.last() != Some(&body.return_value()) {
         context.emit_reference_to(body.return_value());
     }
 
@@ -240,7 +237,6 @@ impl<'c> LoweringContext<'c> {
             Expression::Function {
                 original_hirs,
                 parameters,
-                responsible_parameter,
                 body,
             } => {
                 let captured = expression
@@ -255,19 +251,18 @@ impl<'c> LoweringContext<'c> {
                     original_hirs.clone(),
                     &captured,
                     parameters,
-                    *responsible_parameter,
                     body,
                 );
 
                 if captured.is_empty() {
-                    let list = Function::create(
+                    let function = Function::create(
                         &mut self.lir.constant_heap,
                         false,
                         &[],
                         parameters.len(),
                         instructions,
                     );
-                    self.constants.insert(id, list.into());
+                    self.constants.insert(id, function.into());
                 } else {
                     for captured in &captured {
                         self.emit_reference_to(*captured);
@@ -291,13 +286,11 @@ impl<'c> LoweringContext<'c> {
             Expression::Call {
                 function,
                 arguments,
-                responsible,
             } => {
                 self.emit_reference_to(*function);
                 for argument in arguments {
                     self.emit_reference_to(*argument);
                 }
-                self.emit_reference_to(*responsible);
                 self.emit(
                     id,
                     Instruction::Call {
@@ -327,14 +320,12 @@ impl<'c> LoweringContext<'c> {
                 hir_call,
                 function,
                 arguments,
-                responsible,
             } => {
                 self.emit_reference_to(*hir_call);
                 self.emit_reference_to(*function);
                 for argument in arguments {
                     self.emit_reference_to(*argument);
                 }
-                self.emit_reference_to(*responsible);
                 self.emit(
                     id,
                     Instruction::TraceCallStarts {

--- a/compiler/vm/src/mir_to_lir.rs
+++ b/compiler/vm/src/mir_to_lir.rs
@@ -365,6 +365,9 @@ impl<'c> LoweringContext<'c> {
         }
     }
     fn emit(&mut self, id: Id, instruction: Instruction) {
+        if matches!(instruction, Instruction::PopMultipleBelowTop(0)) {
+            return;
+        }
         instruction.apply_to_stack(&mut self.stack, id);
         self.instructions.push(instruction);
     }

--- a/compiler/vm/src/tracer/mod.rs
+++ b/compiler/vm/src/tracer/mod.rs
@@ -20,10 +20,8 @@ pub trait Tracer {
     fn call_started(
         &mut self,
         _heap: &mut Heap,
-        _call_site: HirId,
         _callee: InlineObject,
         _arguments: Vec<InlineObject>,
-        _responsible: HirId,
     ) {
     }
     fn call_ended(&mut self, _heap: &mut Heap, _return_value: InlineObject) {}

--- a/compiler/vm/src/tracer/tuple.rs
+++ b/compiler/vm/src/tracer/tuple.rs
@@ -16,12 +16,10 @@ impl Tracer for Tuple {
     fn call_started(
         &mut self,
         heap: &mut Heap,
-        call_site: HirId,
         callee: InlineObject,
         arguments: Vec<InlineObject>,
-        responsible: HirId,
     ) {
-        for_tuples!( #(Tuple.call_started(heap, call_site, callee, arguments.clone(), responsible);)* );
+        for_tuples!( #(Tuple.call_started(heap, callee, arguments.clone());)* );
     }
     fn call_ended(&mut self, heap: &mut Heap, return_value: InlineObject) {
         for_tuples!( #(Tuple.call_ended(heap, return_value);)* );


### PR DESCRIPTION
Depends on #645

This PR makes it so that `Call` instruction can rely on more stuff:

- the callee is not a tag (there's now a `tagWithValue` builtin that associates a tag with a value)
- `✨.typeOf callee` is `Function`
- the number of arguments matches the expected count

### Checklist
<!-- Please check if your PR fulfills the following requirements: -->

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
