### PR TITLE
Rename VM LIR to ByteCode

### DIFF
--- a/compiler/cli/src/debug.rs
+++ b/compiler/cli/src/debug.rs
@@ -16,7 +16,7 @@ use candy_frontend::{
     utils::DoHash,
     TracingConfig, TracingMode,
 };
-use candy_vm::{heap::HeapData, lir::RichIrForLir, mir_to_lir::compile_lir};
+use candy_vm::{byte_code::RichIrForByteCode, heap::HeapData, mir_to_byte_code::compile_byte_code};
 use clap::{Parser, ValueHint};
 use colored::{Color, Colorize};
 use diffy::{create_patch, PatchFormatter};
@@ -143,7 +143,7 @@ pub(crate) fn debug(options: Options) -> ProgramResult {
         Options::VmByteCode(options) => {
             let module = module_for_path(options.path.clone())?;
             let tracing = options.to_tracing_config();
-            let (vm_byte_code, _) = compile_lir(&db, module.clone(), tracing.clone());
+            let (vm_byte_code, _) = compile_byte_code(&db, module.clone(), tracing.clone());
             Some(RichIr::for_byte_code(&module, &vm_byte_code, &tracing))
         }
         Options::Gold(options) => return options.run(&db),
@@ -333,19 +333,20 @@ impl GoldOptions {
             let lir = RichIr::for_lir(&module, &lir, &Self::TRACING_CONFIG);
             visit("LIR", lir.text);
 
-            let (vm_byte_code, _) = compile_lir(db, module.clone(), Self::TRACING_CONFIG.clone());
+            let (vm_byte_code, _) =
+                compile_byte_code(db, module.clone(), Self::TRACING_CONFIG.clone());
             let vm_byte_code_rich_ir =
                 RichIr::for_byte_code(&module, &vm_byte_code, &Self::TRACING_CONFIG);
             visit(
                 "VM Byte Code",
-                Self::format_lir(&vm_byte_code, &vm_byte_code_rich_ir),
+                Self::format_byte_code(&vm_byte_code, &vm_byte_code_rich_ir),
             );
         }
         Ok(())
     }
 
-    fn format_lir(lir: &candy_vm::lir::Lir, rich_ir: &RichIr) -> String {
-        let address_replacements: FxHashMap<_, _> = lir
+    fn format_byte_code(byte_code: &candy_vm::byte_code::ByteCode, rich_ir: &RichIr) -> String {
+        let address_replacements: FxHashMap<_, _> = byte_code
             .constant_heap
             .iter()
             .map(|constant| {
@@ -361,7 +362,7 @@ impl GoldOptions {
 
         // Replace addresses of constants with content hashes since addresses
         // are random.
-        let lir = ADDRESS_REGEX.replace_all(&rich_ir.text, |captures: &Captures| {
+        let byte_code = ADDRESS_REGEX.replace_all(&rich_ir.text, |captures: &Captures| {
             let full_match = captures.get(0).unwrap();
             let full_match_str = full_match.as_str();
             let address = captures.iter().skip(1).find_map(|it| it).unwrap();
@@ -375,7 +376,7 @@ impl GoldOptions {
 
         // Sort the constant heap alphabetically to make the output more
         // stable.
-        let mut lines = lir.lines().collect_vec();
+        let mut lines = byte_code.lines().collect_vec();
         let (constants_start, _) = lines
             .iter()
             .find_position(|&&it| it == "# Constant heap")

--- a/compiler/fuzzer/src/fuzzer.rs
+++ b/compiler/fuzzer/src/fuzzer.rs
@@ -8,8 +8,8 @@ use crate::{
 };
 use candy_frontend::hir::Id;
 use candy_vm::{
+    byte_code::ByteCode,
     heap::{Data, Function, Heap},
-    lir::Lir,
     tracer::stack_trace::StackTracer,
     Panic,
 };
@@ -18,7 +18,7 @@ use std::rc::Rc;
 use tracing::debug;
 
 pub struct Fuzzer {
-    pub lir: Rc<Lir>,
+    pub byte_code: Rc<ByteCode>,
     pub function_heap: Heap,
     pub function: Function,
     pub function_id: Id,
@@ -31,7 +31,7 @@ pub struct Fuzzer {
 pub enum Status {
     StillFuzzing {
         total_coverage: Coverage,
-        runner: Runner<Rc<Lir>>,
+        runner: Runner<Rc<ByteCode>>,
     },
     // TODO: In the future, also add a state for trying to simplify the input.
     FoundPanic {
@@ -44,7 +44,7 @@ pub enum Status {
 
 impl Fuzzer {
     #[must_use]
-    pub fn new(lir: Rc<Lir>, function: Function, function_id: Id) -> Self {
+    pub fn new(byte_code: Rc<ByteCode>, function: Function, function_id: Id) -> Self {
         let mut heap = Heap::default();
         let function: Function = Data::from(function.clone_to_heap(&mut heap))
             .try_into()
@@ -55,11 +55,11 @@ impl Fuzzer {
             function.argument_count(),
             collect_symbols_in_heap(&heap).into_iter().collect_vec(),
         );
-        let runner = Runner::new(lir.clone(), function, pool.generate_new_input());
+        let runner = Runner::new(byte_code.clone(), function, pool.generate_new_input());
 
-        let num_instructions = lir.instructions.len();
+        let num_instructions = byte_code.instructions.len();
         Self {
-            lir,
+            byte_code,
             function_heap: heap,
             function,
             function_id,
@@ -72,8 +72,8 @@ impl Fuzzer {
     }
 
     #[must_use]
-    pub fn lir(&self) -> Rc<Lir> {
-        self.lir.clone()
+    pub fn byte_code(&self) -> Rc<ByteCode> {
+        self.byte_code.clone()
     }
 
     #[must_use]
@@ -122,7 +122,7 @@ impl Fuzzer {
         &mut self,
         instructions_left: &mut usize,
         total_coverage: Coverage,
-        mut runner: Runner<Rc<Lir>>,
+        mut runner: Runner<Rc<ByteCode>>,
     ) -> Status {
         runner.run(instructions_left);
         let Some(result) = runner.take_result() else {
@@ -144,7 +144,7 @@ impl Fuzzer {
         match result {
             RunResult::Timeout => self.create_new_fuzzing_case(total_coverage),
             RunResult::Done { .. } | RunResult::NeedsUnfulfilled { .. } => {
-                let function_range = self.lir.range_of_function(&self.function_id);
+                let function_range = self.byte_code.range_of_function(&self.function_id);
                 let function_coverage = total_coverage.in_range(&function_range);
 
                 // We favor small inputs with good code coverage.
@@ -177,7 +177,7 @@ impl Fuzzer {
     }
     fn create_new_fuzzing_case(&self, total_coverage: Coverage) -> Status {
         let runner = Runner::new(
-            self.lir.clone(),
+            self.byte_code.clone(),
             self.function,
             self.pool.generate_new_input(),
         );

--- a/compiler/language_server/src/debug_adapter/mod.rs
+++ b/compiler/language_server/src/debug_adapter/mod.rs
@@ -1,7 +1,7 @@
 use self::{session::run_debug_session, tracer::DebugTracer};
 use crate::server::Server;
 use candy_frontend::module::PackagesPath;
-use candy_vm::{lir::Lir, Vm};
+use candy_vm::{byte_code::ByteCode, Vm};
 use dap::{prelude::EventBody, requests::Request, responses::Response};
 use derive_more::{Display, From};
 use lsp_types::notification::Notification;
@@ -16,7 +16,7 @@ mod paused;
 mod session;
 mod tracer;
 
-type DebugVm = Vm<Rc<Lir>, DebugTracer>;
+type DebugVm = Vm<Rc<ByteCode>, DebugTracer>;
 
 #[derive(Clone, Debug, Deserialize, Display, Eq, Hash, PartialEq, Serialize)]
 #[serde(transparent)]

--- a/compiler/language_server/src/debug_adapter/paused/variable.rs
+++ b/compiler/language_server/src/debug_adapter/paused/variable.rs
@@ -51,7 +51,7 @@ impl PausedState {
                                 .as_ref()
                                 .unwrap()
                                 .vm
-                                .lir()
+                                .byte_code()
                                 .functions_behind(function.body());
                             assert_eq!(functions.len(), 1);
                             let function: &hir::Id = functions.iter().next().unwrap();

--- a/compiler/language_server/src/features_candy/analyzer/insights.rs
+++ b/compiler/language_server/src/features_candy/analyzer/insights.rs
@@ -93,7 +93,7 @@ impl Insight {
 
         let coverage = match fuzzer.status() {
             Status::StillFuzzing { total_coverage, .. } => {
-                let function_range = fuzzer.lir().range_of_function(&id);
+                let function_range = fuzzer.byte_code().range_of_function(&id);
                 let function_coverage = total_coverage.in_range(&function_range);
                 function_coverage.relative_coverage()
             }

--- a/compiler/language_server/src/features_ir.rs
+++ b/compiler/language_server/src/features_ir.rs
@@ -117,7 +117,7 @@ impl IrFeatures {
             ),
             Ir::VmByteCode(tracing_config) => Self::rich_ir_for_vm_byte_code(
                 &config.module,
-                &candy_vm::mir_to_lir::compile_lir(
+                &candy_vm::mir_to_byte_code::compile_byte_code(
                     db,
                     config.module.clone(),
                     tracing_config.to_owned(),
@@ -181,7 +181,7 @@ impl IrFeatures {
     }
     fn rich_ir_for_vm_byte_code(
         module: &Module,
-        byte_code: &candy_vm::lir::Lir,
+        byte_code: &candy_vm::byte_code::ByteCode,
         tracing_config: &TracingConfig,
     ) -> RichIr {
         Self::rich_ir_for("VM Byte Code", module, tracing_config, |builder| {

--- a/compiler/vm/README.md
+++ b/compiler/vm/README.md
@@ -1,7 +1,7 @@
 # Candy VM
 
 The Candy VM is a stack-based virtual machine.
-It can execute the LIR ("Low-Level Intermediate Representation") of a given program.
+It can execute the byte code of a given program.
 
 ## Benchmarks
 

--- a/compiler/vm/benches/utils.rs
+++ b/compiler/vm/benches/utils.rs
@@ -16,9 +16,9 @@ use candy_frontend::{
     TracingConfig,
 };
 use candy_vm::{
+    byte_code::ByteCode,
     heap::{Heap, HirId, InlineObject, Struct},
-    lir::Lir,
-    mir_to_lir::compile_lir,
+    mir_to_byte_code::compile_byte_code,
     tracer::DummyTracer,
     PopulateInMemoryProviderFromFileSystem, Vm, VmFinished,
 };
@@ -70,7 +70,7 @@ impl MutableModuleProviderOwner for Database {
     }
 }
 
-pub fn setup_and_compile(source_code: &str) -> Lir {
+pub fn setup_and_compile(source_code: &str) -> ByteCode {
     let mut db = setup();
     compile(&mut db, source_code)
 }
@@ -82,7 +82,7 @@ pub fn setup() -> Database {
     db.module_provider.add_str(&MODULE, r#"_ = use "Core""#);
 
     // Load `Core` into the cache.
-    let errors = compile_lir(&db, MODULE.clone(), TRACING.clone()).1;
+    let errors = compile_byte_code(&db, MODULE.clone(), TRACING.clone()).1;
     if !errors.is_empty() {
         for error in errors.iter() {
             warn!("{}", error.to_string_with_location(&db));
@@ -93,15 +93,15 @@ pub fn setup() -> Database {
     db
 }
 
-pub fn compile(db: &mut Database, source_code: &str) -> Lir {
+pub fn compile(db: &mut Database, source_code: &str) -> ByteCode {
     db.did_open_module(&MODULE, source_code.as_bytes().to_owned());
-    compile_lir(db, MODULE.clone(), TRACING.clone()).0
+    compile_byte_code(db, MODULE.clone(), TRACING.clone()).0
 }
 
-pub fn run(lir: impl Borrow<Lir>) -> (Heap, InlineObject) {
+pub fn run(byte_code: impl Borrow<ByteCode>) -> (Heap, InlineObject) {
     let mut heap = Heap::default();
-    let VmFinished { tracer, result } =
-        Vm::for_module(lir.borrow(), &mut heap, DummyTracer).run_forever_without_handles(&mut heap);
+    let VmFinished { tracer, result } = Vm::for_module(byte_code.borrow(), &mut heap, DummyTracer)
+        .run_forever_without_handles(&mut heap);
     let main = result
         .expect("Module panicked.")
         .into_main_function(&heap)
@@ -111,7 +111,7 @@ pub fn run(lir: impl Borrow<Lir>) -> (Heap, InlineObject) {
     let environment = Struct::create(&mut heap, true, &FxHashMap::default());
     let responsible = HirId::create(&mut heap, true, hir::Id::user());
     let VmFinished { result, .. } = Vm::for_function(
-        lir,
+        byte_code,
         &mut heap,
         main,
         &[environment.into()],

--- a/compiler/vm/src/byte_code.rs
+++ b/compiler/vm/src/byte_code.rs
@@ -17,7 +17,7 @@ use rustc_hash::FxHashSet;
 use std::ops::Range;
 use strum::{EnumDiscriminants, IntoStaticStr};
 
-pub struct Lir {
+pub struct ByteCode {
     pub module: Module,
     pub constant_heap: Heap,
     pub instructions: Vec<Instruction>,
@@ -208,7 +208,7 @@ impl StackExt for Vec<Id> {
     }
 }
 
-impl Lir {
+impl ByteCode {
     #[must_use]
     pub fn functions_behind(&self, ip: InstructionPointer) -> &FxHashSet<hir::Id> {
         &self.origins[*ip]
@@ -231,7 +231,7 @@ impl Lir {
     }
 }
 
-impl ToRichIr for Lir {
+impl ToRichIr for ByteCode {
     fn build_rich_ir(&self, builder: &mut RichIrBuilder) {
         builder.push("# Constant heap", TokenType::Comment, EnumSet::empty());
         for constant in self.constant_heap.iter() {
@@ -395,8 +395,12 @@ const fn arguments_plural(num_args: usize) -> &'static str {
 }
 
 #[extension_trait]
-pub impl RichIrForLir for RichIr {
-    fn for_byte_code(module: &Module, byte_code: &Lir, tracing_config: &TracingConfig) -> RichIr {
+pub impl RichIrForByteCode for RichIr {
+    fn for_byte_code(
+        module: &Module,
+        byte_code: &ByteCode,
+        tracing_config: &TracingConfig,
+    ) -> RichIr {
         let mut builder = RichIrBuilder::default();
         builder.push(
             format!("# VM Byte Code for module {module}"),

--- a/compiler/vm/src/instructions.rs
+++ b/compiler/vm/src/instructions.rs
@@ -1,6 +1,6 @@
 use crate::{
+    byte_code::Instruction,
     heap::{Data, Function, Heap, HirId, InlineObject, List, Pointer, Struct, Tag, Text},
-    lir::Instruction,
     tracer::Tracer,
     vm::{CallHandle, MachineState, Panic},
 };
@@ -158,7 +158,7 @@ impl MachineState {
                     // where we have validated the inputs before calling the
                     // instructions, or when lowering compiler errors from the
                     // HIR to the MIR.
-                    panic!("We should never generate a LIR where the reason is not a text.");
+                    panic!("We should never generate byte code where the reason is not a text.");
                 };
                 let responsible: HirId = responsible_for_panic.try_into().unwrap();
 

--- a/compiler/vm/src/lib.rs
+++ b/compiler/vm/src/lib.rs
@@ -30,13 +30,13 @@ pub use utils::PopulateInMemoryProviderFromFileSystem;
 pub use vm::{Panic, StateAfterRun, StateAfterRunForever, Vm, VmFinished};
 
 mod builtin_functions;
+pub mod byte_code;
 pub mod environment;
 mod handle_id;
 pub mod heap;
 mod instruction_pointer;
 mod instructions;
-pub mod lir;
-pub mod mir_to_lir;
+pub mod mir_to_byte_code;
 pub mod tracer;
 mod utils;
 mod vm;

--- a/compiler/vm/src/mir_to_byte_code.rs
+++ b/compiler/vm/src/mir_to_byte_code.rs
@@ -1,7 +1,7 @@
 use crate::{
+    byte_code::{ByteCode, Instruction, StackOffset},
     heap::{Builtin, Function, Heap, HirId, InlineObject, Int, List, Struct, Tag, Text},
     instruction_pointer::InstructionPointer,
-    lir::{Instruction, Lir, StackOffset},
 };
 use candy_frontend::{
     cst::CstDb,
@@ -18,11 +18,11 @@ use itertools::Itertools;
 use rustc_hash::{FxHashMap, FxHashSet};
 use std::sync::Arc;
 
-pub fn compile_lir<Db>(
+pub fn compile_byte_code<Db>(
     db: &Db,
     module: Module,
     tracing: TracingConfig,
-) -> (Lir, Arc<FxHashSet<CompilerError>>)
+) -> (ByteCode, Arc<FxHashSet<CompilerError>>)
 where
     Db: CstDb + OptimizeMir,
 {
@@ -54,7 +54,7 @@ where
         hir::Id::new(module.clone(), vec![]),
     );
 
-    let mut lir = Lir {
+    let mut byte_code = ByteCode {
         module: module.clone(),
         constant_heap,
         instructions: vec![],
@@ -64,7 +64,7 @@ where
     };
 
     let start = compile_function(
-        &mut lir,
+        &mut byte_code,
         &mut FxHashMap::default(),
         &FxHashSet::from_iter([hir::Id::new(module, vec![])]),
         &FxHashSet::default(),
@@ -74,11 +74,11 @@ where
     );
     module_function.set_body(start);
 
-    (lir, errors)
+    (byte_code, errors)
 }
 
 fn compile_function(
-    lir: &mut Lir,
+    byte_code: &mut ByteCode,
     constants: &mut FxHashMap<Id, InlineObject>,
     original_hirs: &FxHashSet<hir::Id>,
     captured: &FxHashSet<Id>,
@@ -87,7 +87,7 @@ fn compile_function(
     body: &Body,
 ) -> InstructionPointer {
     let mut context = LoweringContext {
-        lir,
+        byte_code,
         constants,
         stack: vec![],
         instructions: vec![],
@@ -131,15 +131,16 @@ fn compile_function(
 
     let mut instructions = context.instructions;
     let num_instructions = instructions.len();
-    let start = lir.instructions.len().into();
-    lir.instructions.append(&mut instructions);
-    lir.origins
+    let start = byte_code.instructions.len().into();
+    byte_code.instructions.append(&mut instructions);
+    byte_code
+        .origins
         .extend((0..num_instructions).map(|_| original_hirs.clone()));
     start
 }
 
 struct LoweringContext<'c> {
-    lir: &'c mut Lir,
+    byte_code: &'c mut ByteCode,
     constants: &'c mut FxHashMap<Id, InlineObject>,
     stack: Vec<Id>,
     instructions: Vec<Instruction>,
@@ -148,11 +149,12 @@ impl<'c> LoweringContext<'c> {
     fn compile_expression(&mut self, id: Id, expression: &Expression) {
         match expression {
             Expression::Int(int) => {
-                let int = Int::create_from_bigint(&mut self.lir.constant_heap, false, int.clone());
+                let int =
+                    Int::create_from_bigint(&mut self.byte_code.constant_heap, false, int.clone());
                 self.constants.insert(id, int.into());
             }
             Expression::Text(text) => {
-                let text = Text::create(&mut self.lir.constant_heap, false, text);
+                let text = Text::create(&mut self.byte_code.constant_heap, false, text);
                 self.constants.insert(id, text.into());
             }
             Expression::Reference(referenced) => {
@@ -165,16 +167,18 @@ impl<'c> LoweringContext<'c> {
             }
             Expression::Tag { symbol, value } => {
                 let symbol = self
-                    .lir
+                    .byte_code
                     .constant_heap
                     .default_symbols()
                     .get(symbol)
-                    .unwrap_or_else(|| Text::create(&mut self.lir.constant_heap, false, symbol));
+                    .unwrap_or_else(|| {
+                        Text::create(&mut self.byte_code.constant_heap, false, symbol)
+                    });
 
                 if let Some(value) = value {
                     if let Some(value) = self.constants.get(value) {
                         let tag = Tag::create_with_value(
-                            &mut self.lir.constant_heap,
+                            &mut self.byte_code.constant_heap,
                             false,
                             symbol,
                             *value,
@@ -199,7 +203,7 @@ impl<'c> LoweringContext<'c> {
                     .map(|item| self.constants.get(item).copied())
                     .collect::<Option<Vec<_>>>()
                 {
-                    let list = List::create(&mut self.lir.constant_heap, false, &items);
+                    let list = List::create(&mut self.byte_code.constant_heap, false, &items);
                     self.constants.insert(id, list.into());
                 } else {
                     for item in items {
@@ -221,7 +225,7 @@ impl<'c> LoweringContext<'c> {
                     })
                     .collect::<Option<FxHashMap<_, _>>>()
                 {
-                    let struct_ = Struct::create(&mut self.lir.constant_heap, false, &fields);
+                    let struct_ = Struct::create(&mut self.byte_code.constant_heap, false, &fields);
                     self.constants.insert(id, struct_.into());
                 } else {
                     for (key, value) in fields {
@@ -237,7 +241,8 @@ impl<'c> LoweringContext<'c> {
                 }
             }
             Expression::HirId(hir_id) => {
-                let hir_id = HirId::create(&mut self.lir.constant_heap, false, hir_id.clone());
+                let hir_id =
+                    HirId::create(&mut self.byte_code.constant_heap, false, hir_id.clone());
                 self.constants.insert(id, hir_id.into());
             }
             Expression::Function {
@@ -253,7 +258,7 @@ impl<'c> LoweringContext<'c> {
                     .collect();
 
                 let instructions = compile_function(
-                    self.lir,
+                    self.byte_code,
                     self.constants,
                     original_hirs,
                     &captured,
@@ -264,7 +269,7 @@ impl<'c> LoweringContext<'c> {
 
                 if captured.is_empty() {
                     let list = Function::create(
-                        &mut self.lir.constant_heap,
+                        &mut self.byte_code.constant_heap,
                         false,
                         &[],
                         parameters.len(),


### PR DESCRIPTION
Renames the LIR in the VM to ByteCode.

### Checklist
<!-- Please check if your PR fulfills the following requirements: -->

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
