### PR TITLE
Fix declarative VS Code indentation rules

### DIFF
--- a/vscode_extension/declarative/language-configuration.json
+++ b/vscode_extension/declarative/language-configuration.json
@@ -14,7 +14,7 @@
     "lineComment": "#"
   },
   "indentationRules": {
-    "increaseIndentPattern": "^[^#]*(\\([^)#]*|\\[[^\\]#]*|\\{[^}#]*|=\\s*(#.*)?|\"[^\"]*)$",
+    "increaseIndentPattern": "^[^#]*(\\([^)]*|\\[[^\\]]*|\\{[^}]*|=\\s*(#.*)?|\"[^\"]*)$",
     "decreaseIndentPattern": "^[\\)\\]\\}].*$"
   },
   "onEnterRules": [

--- a/vscode_extension/declarative/language-configuration.json
+++ b/vscode_extension/declarative/language-configuration.json
@@ -14,10 +14,17 @@
     "lineComment": "#"
   },
   "indentationRules": {
-    "increaseIndentPattern": "^[^#]*(\\([^)]*|\\[[^\\]]*|\\{[^}]*|=\\s*(#.*)?|\"[^\"]*)$",
+    "increaseIndentPattern": "^[^#]*(\\([^)]*|\\[[^\\]]*|\\{[^}]*|\"[^\"]*)$",
     "decreaseIndentPattern": "^[\\)\\]\\}].*$"
   },
   "onEnterRules": [
+    {
+      // Assignment start with optional comment but no actual content.
+      "beforeText": "^[^#]*=\\s*(?:#.*)?$",
+      "action": {
+        "indent": "indent"
+      }
+    },
     {
       // Octothorpes without space when there's already an existing space after
       // so we don't need to insert one.


### PR DESCRIPTION
<!-- Please enter the corresponding issue ID: -->


<!-- Please summarize your changes: -->
The indentation rules for assignments are inspired by Python's: https://github.com/microsoft/vscode/blob/3cd6f481266dcbd2ca2fcff43b4465d747c78e2f/extensions/python/language-configuration.json#L50-L54


### Checklist
<!-- Please check if your PR fulfills the following requirements: -->

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
