### PR TITLE
Improve stack traces

### DIFF
--- a/compiler/cli/src/run.rs
+++ b/compiler/cli/src/run.rs
@@ -3,7 +3,7 @@ use crate::{
     utils::{module_for_path, packages_path},
     Exit, ProgramResult,
 };
-use candy_frontend::{ast_to_hir::AstToHir, hir, TracingConfig};
+use candy_frontend::{ast_to_hir::AstToHir, hir, TracingConfig, TracingMode};
 use candy_language_server::utils::LspPositionConversion;
 use candy_vm::{
     environment::DefaultEnvironment,
@@ -41,7 +41,11 @@ pub(crate) fn run(options: Options) -> ProgramResult {
     let db = Database::new_with_file_system_module_provider(packages_path.clone());
     let module = module_for_path(options.path)?;
 
-    let tracing = TracingConfig::off();
+    let tracing = TracingConfig {
+        register_fuzzables: TracingMode::Off,
+        calls: TracingMode::All,
+        evaluated_expressions: TracingMode::Off,
+    };
 
     debug!("Running {module}.");
 

--- a/compiler/cli/src/run.rs
+++ b/compiler/cli/src/run.rs
@@ -3,8 +3,7 @@ use crate::{
     utils::{module_for_path, packages_path},
     Exit, ProgramResult,
 };
-use candy_frontend::{ast_to_hir::AstToHir, hir, TracingConfig, TracingMode};
-use candy_language_server::utils::LspPositionConversion;
+use candy_frontend::{hir, TracingConfig, TracingMode};
 use candy_vm::{
     environment::DefaultEnvironment,
     heap::{Heap, HirId},
@@ -67,26 +66,10 @@ pub(crate) fn run(options: Options) -> ProgramResult {
         Err(panic) => {
             error!("The module panicked: {}", panic.reason);
             error!("{} is responsible.", panic.responsible);
-            if let Some(span) = db.hir_id_to_span(&panic.responsible) {
-                let current_package_path = module.package.to_path(&packages_path).unwrap();
-                let file = panic
-                    .responsible
-                    .module
-                    .try_to_path(&packages_path)
-                    .and_then(|it| {
-                        it.strip_prefix(current_package_path)
-                            .unwrap_or(&it)
-                            .to_str()
-                            .map(|it| it.to_string())
-                    })
-                    .unwrap_or_else(|| panic.responsible.module.to_string());
-                let range = db.range_to_lsp_range(panic.responsible.module.clone(), span);
-                error!(
-                    "{file}:{}:{} – {}:{}",
-                    range.start.line, range.start.character, range.end.line, range.end.character,
-                );
-            }
-            error!("This is the stack trace:\n{}", tracer.format(&db));
+            error!(
+                "This is the stack trace:\n{}",
+                tracer.format(&db, &packages_path),
+            );
             return Err(Exit::CodePanicked);
         }
     };
@@ -124,7 +107,10 @@ pub(crate) fn run(options: Options) -> ProgramResult {
         Err(panic) => {
             error!("The main function panicked: {}", panic.reason);
             error!("{} is responsible.", panic.responsible);
-            error!("This is the stack trace:\n{}", tracer.format(&db));
+            error!(
+                "This is the stack trace:\n{}",
+                tracer.format(&db, &packages_path),
+            );
             Err(Exit::CodePanicked)
         }
     };

--- a/compiler/frontend/src/error.rs
+++ b/compiler/frontend/src/error.rs
@@ -4,7 +4,7 @@ use super::{ast::AstError, cst, cst::CstError, hir::HirError};
 use crate::{
     mir::MirError,
     module::Module,
-    position::{Offset, PositionConversionDb},
+    position::{Offset, PositionConversionDb, RangeOfPosition},
     rich_ir::{ReferenceKey, RichIrBuilder, ToRichIr},
     string_to_rcst::ModuleError,
 };
@@ -37,15 +37,7 @@ impl CompilerError {
     }
     pub fn to_string_with_location(&self, db: &impl PositionConversionDb) -> String {
         let range = db.range_to_positions(self.module.clone(), self.span.clone());
-        format!(
-            "{}:{}:{} – {}:{}: {}",
-            self.module,
-            range.start.line,
-            range.start.character,
-            range.end.line,
-            range.end.character,
-            self.payload,
-        )
+        format!("{}:{}: {}", self.module, range.format(), self.payload)
     }
 }
 impl Display for CompilerErrorPayload {

--- a/compiler/frontend/src/position.rs
+++ b/compiler/frontend/src/position.rs
@@ -1,9 +1,12 @@
-use derive_more::{Deref, DerefMut, From};
-use std::{ops::Range, sync::Arc};
-
-use unicode_segmentation::UnicodeSegmentation;
-
 use crate::module::{Module, ModuleDb};
+use derive_more::{Deref, DerefMut, From};
+use extension_trait::extension_trait;
+use std::{
+    fmt::{self, Display, Formatter},
+    ops::Range,
+    sync::Arc,
+};
+use unicode_segmentation::UnicodeSegmentation;
 
 /// The offset of a character in a string as the number of bytes preceding it in
 /// UTF-8 encoding.
@@ -19,6 +22,17 @@ pub struct Position {
     pub line: usize,
     /// Zero-based character index (counting grapheme clusters)
     pub character: usize,
+}
+impl Display for Position {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        write!(f, "{}:{}", self.line + 1, self.character + 1)
+    }
+}
+#[extension_trait]
+pub impl RangeOfPosition for Range<Position> {
+    fn format(&self) -> String {
+        format!("{} – {}", self.start, self.end)
+    }
 }
 
 #[salsa::query_group(PositionConversionStorage)]

--- a/compiler/vm/src/tracer/stack_trace.rs
+++ b/compiler/vm/src/tracer/stack_trace.rs
@@ -105,7 +105,7 @@ impl StackTracer {
                         }
                     })
                     .unwrap_or_else(|| callee.to_string()),
-                arguments.iter().map(|arg| format!("{arg:?}")).join(" "),
+                arguments.iter().join(" "),
             );
             caller_locations_and_calls.push((caller_location_string, call_string));
         }

--- a/compiler/vm/src/tracer/stack_trace.rs
+++ b/compiler/vm/src/tracer/stack_trace.rs
@@ -1,8 +1,14 @@
 use super::Tracer;
 use crate::heap::{Heap, HirId, InlineObject};
-use candy_frontend::{ast_to_hir::AstToHir, cst::CstKind, position::PositionConversionDb};
+use candy_frontend::{
+    ast_to_hir::AstToHir,
+    cst::CstKind,
+    module::PackagesPath,
+    position::{PositionConversionDb, RangeOfPosition},
+};
 use itertools::Itertools;
 use pad::PadStr;
+use std::{env::current_dir, path::Path};
 
 #[derive(Debug, Default)]
 pub struct StackTracer {
@@ -62,53 +68,17 @@ impl Tracer for StackTracer {
 }
 
 impl StackTracer {
-    pub fn format<DB>(&self, db: &DB) -> String
+    pub fn format<DB>(&self, db: &DB, packages_path: &PackagesPath) -> String
     where
         DB: AstToHir + PositionConversionDb,
     {
-        let mut caller_locations_and_calls = vec![];
-
-        for Call {
-            call_site,
-            callee,
-            arguments,
-            ..
-        } in self.call_stack.iter().rev()
-        {
-            let hir_id = call_site.get();
-            let module = hir_id.module.clone();
-            let cst_id = if module.package.is_tooling() {
-                None
-            } else {
-                db.hir_to_cst_id(hir_id)
-            };
-            let cst = cst_id.map(|id| db.find_cst(module.clone(), id));
-            let span = cst.map(|cst| db.range_to_positions(module.clone(), cst.data.span));
-            let caller_location_string = format!(
-                "{hir_id} {}",
-                span.map_or_else(
-                    || "<no location>".to_owned(),
-                    |it| format!(
-                        "{}:{} – {}:{}",
-                        it.start.line, it.start.character, it.end.line, it.end.character,
-                    )
-                ),
-            );
-            let call_string = format!(
-                "{} {}",
-                cst_id
-                    .and_then(|id| {
-                        let cst = db.find_cst(hir_id.module.clone(), id);
-                        match cst.kind {
-                            CstKind::Call { receiver, .. } => extract_receiver_name(&receiver),
-                            _ => None,
-                        }
-                    })
-                    .unwrap_or_else(|| callee.to_string()),
-                arguments.iter().join(" "),
-            );
-            caller_locations_and_calls.push((caller_location_string, call_string));
-        }
+        let current_package_path = current_dir().ok(); // current_package.to_path(packages_path).unwrap();
+        let caller_locations_and_calls = self
+            .call_stack
+            .iter()
+            .rev()
+            .map(|it| Self::format_call(db, packages_path, current_package_path.as_deref(), it))
+            .collect_vec();
 
         let longest_location = caller_locations_and_calls
             .iter()
@@ -120,6 +90,74 @@ impl StackTracer {
             .into_iter()
             .map(|(location, call)| format!("{} {}", location.pad_to_width(longest_location), call))
             .join("\n")
+    }
+
+    fn format_call<DB>(
+        db: &DB,
+        packages_path: &PackagesPath,
+        current_directory: Option<&Path>,
+        call: &Call,
+    ) -> (String, String)
+    where
+        DB: AstToHir + PositionConversionDb,
+    {
+        let Call {
+            call_site,
+            callee,
+            arguments,
+            ..
+        } = call;
+
+        let hir_id = call_site.get();
+        let module = hir_id.module.clone();
+        let cst_id = if module.package.is_tooling() {
+            None
+        } else {
+            db.hir_to_cst_id(hir_id)
+        };
+
+        let span_string = cst_id.map(|id| {
+            let cst = db.find_cst(module.clone(), id);
+            db.range_to_positions(module.clone(), cst.data.span)
+                .format()
+        });
+        #[allow(clippy::map_unwrap_or)]
+        let caller_location_string = hir_id
+            .module
+            .try_to_path(packages_path)
+            .map(|path| {
+                current_directory
+                    .and_then(|it| path.strip_prefix(it).ok())
+                    .unwrap_or(&path)
+                    .to_string_lossy()
+                    .into_owned()
+            })
+            .map(|path| {
+                span_string
+                    .as_deref()
+                    .map(|span_string| format!("{path}:{span_string}"))
+                    .unwrap_or(path)
+            })
+            .unwrap_or_else(|| {
+                span_string
+                    .map(|span_string| format!("{hir_id}  {span_string}"))
+                    .unwrap_or_else(|| hir_id.to_string())
+            });
+
+        let call_string = format!(
+            "{} {}",
+            cst_id
+                .and_then(|id| {
+                    let cst = db.find_cst(hir_id.module.clone(), id);
+                    match cst.kind {
+                        CstKind::Call { receiver, .. } => extract_receiver_name(&receiver),
+                        _ => None,
+                    }
+                })
+                .unwrap_or_else(|| callee.to_string()),
+            arguments.iter().join(" "),
+        );
+        (caller_location_string, call_string)
     }
 }
 


### PR DESCRIPTION
<!-- Please enter the corresponding issue ID: -->


<!-- Please summarize your changes: -->
It turns out that stack traces get much better when function call tracing is also enabled! Also, we now print file paths instead of HIR IDs (if possible) and use one-based line and column numbers (so that ctrl-clicking them in VS Code works as expected).

![image](https://github.com/candy-lang/candy/assets/19330937/1d74aca5-97bf-4dd4-9d74-d6037a5e6179)



### Checklist
<!-- Please check if your PR fulfills the following requirements: -->

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
