### PR TITLE
Avoid calling `bit_length()` on negative integer

### DIFF
--- a/compiler/fuzzer/src/values.rs
+++ b/compiler/fuzzer/src/values.rs
@@ -163,7 +163,7 @@ impl InlineObjectGeneration for InlineObject {
     fn complexity(self) -> usize {
         match self.into() {
             Data::Int(int) => match int {
-                Int::Inline(int) => int.get().bit_length() as usize,
+                Int::Inline(int) => int.get().abs().bit_length() as usize,
                 Int::Heap(int) => int.get().bits().try_into().unwrap_or(usize::MAX),
             },
             Data::Text(text) => text.byte_len() + 1,


### PR DESCRIPTION
<!-- Please enter the corresponding issue ID: -->
Closes: #830

<!-- Please summarize your changes: -->



### Checklist
<!-- Please check if your PR fulfills the following requirements: -->

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
