### PR TITLE
Support all `TracingMode`s in CLI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -166,6 +166,7 @@ dependencies = [
 name = "candy_frontend"
 version = "0.1.0"
 dependencies = [
+ "clap",
  "derive_more",
  "dunce",
  "enumset",

--- a/compiler/cli/src/debug.rs
+++ b/compiler/cli/src/debug.rs
@@ -93,7 +93,7 @@ pub struct PathAndExecutionTargetAndTracing {
     // The tracing modes can be specified as follows:
     //
     // - not specified or `--register-fuzzables=off`: off
-    // - `--register-fuzzables` of `--register-fuzzables=only-current`: only current
+    // - `--register-fuzzables` or `--register-fuzzables=only-current`: only current
     // - `--register-fuzzables=all`: all
     //
     // (Same for `trace-calls` and `evaluated-expressions`.)

--- a/compiler/cli/src/debug.rs
+++ b/compiler/cli/src/debug.rs
@@ -165,40 +165,40 @@ pub fn debug(options: Options) -> ProgramResult {
             let module = module_for_path(options.path.clone())?;
             let execution_target = options.execution_target.resolve(module.clone());
             let tracing = options.to_tracing_config();
-            let mir = db.mir(execution_target, tracing.clone());
+            let mir = db.mir(execution_target, tracing);
             mir.ok()
-                .map(|(mir, _)| RichIr::for_mir(&module, &mir, &tracing))
+                .map(|(mir, _)| RichIr::for_mir(&module, &mir, tracing))
         }
         Options::OptimizedMir(options) => {
             let module = module_for_path(options.path.clone())?;
             let execution_target = options.execution_target.resolve(module.clone());
             let tracing = options.to_tracing_config();
-            let mir = db.optimized_mir(execution_target, tracing.clone());
+            let mir = db.optimized_mir(execution_target, tracing);
             mir.ok()
-                .map(|(mir, _, _)| RichIr::for_optimized_mir(&module, &mir, &tracing))
+                .map(|(mir, _, _)| RichIr::for_optimized_mir(&module, &mir, tracing))
         }
         Options::Lir(options) => {
             let module = module_for_path(options.path.clone())?;
             let execution_target = options.execution_target.resolve(module.clone());
             let tracing = options.to_tracing_config();
-            let lir = db.lir(execution_target, tracing.clone());
+            let lir = db.lir(execution_target, tracing);
             lir.ok()
-                .map(|(lir, _)| RichIr::for_lir(&module, &lir, &tracing))
+                .map(|(lir, _)| RichIr::for_lir(&module, &lir, tracing))
         }
         Options::OptimizedLir(options) => {
             let module = module_for_path(options.path.clone())?;
             let execution_target = options.execution_target.resolve(module.clone());
             let tracing = options.to_tracing_config();
-            let lir = db.optimized_lir(execution_target, tracing.clone());
+            let lir = db.optimized_lir(execution_target, tracing);
             lir.ok()
-                .map(|(lir, _)| RichIr::for_optimized_lir(&module, &lir, &tracing))
+                .map(|(lir, _)| RichIr::for_optimized_lir(&module, &lir, tracing))
         }
         Options::VmByteCode(options) => {
             let module = module_for_path(options.path.clone())?;
             let execution_target = options.execution_target.resolve(module.clone());
             let tracing = options.to_tracing_config();
-            let (vm_byte_code, _) = compile_byte_code(&db, execution_target, tracing.clone());
-            Some(RichIr::for_byte_code(&module, &vm_byte_code, &tracing))
+            let (vm_byte_code, _) = compile_byte_code(&db, execution_target, tracing);
+            Some(RichIr::for_byte_code(&module, &vm_byte_code, tracing))
         }
         #[cfg(feature = "inkwell")]
         Options::LlvmIr(options) => {
@@ -382,33 +382,33 @@ impl GoldOptions {
             let (mir, _) = db
                 .mir(execution_target.clone(), Self::TRACING_CONFIG.clone())
                 .unwrap();
-            let mir = RichIr::for_mir(&module, &mir, &Self::TRACING_CONFIG);
+            let mir = RichIr::for_mir(&module, &mir, Self::TRACING_CONFIG);
             visit("MIR", mir.text);
 
             let (optimized_mir, _, _) = db
                 .optimized_mir(execution_target.clone(), Self::TRACING_CONFIG.clone())
                 .unwrap();
             let optimized_mir =
-                RichIr::for_optimized_mir(&module, &optimized_mir, &Self::TRACING_CONFIG);
+                RichIr::for_optimized_mir(&module, &optimized_mir, Self::TRACING_CONFIG);
             visit("Optimized MIR", optimized_mir.text);
 
             let (lir, _) = db
                 .lir(execution_target.clone(), Self::TRACING_CONFIG.clone())
                 .unwrap();
-            let lir = RichIr::for_lir(&module, &lir, &Self::TRACING_CONFIG);
+            let lir = RichIr::for_lir(&module, &lir, Self::TRACING_CONFIG);
             visit("LIR", lir.text);
 
             let (optimized_lir, _) = db
                 .optimized_lir(execution_target.clone(), Self::TRACING_CONFIG.clone())
                 .unwrap();
             let optimized_lir =
-                RichIr::for_optimized_lir(&module, &optimized_lir, &Self::TRACING_CONFIG);
+                RichIr::for_optimized_lir(&module, &optimized_lir, Self::TRACING_CONFIG);
             visit("Optimized LIR", optimized_lir.text);
 
             let (vm_byte_code, _) =
                 compile_byte_code(db, execution_target.clone(), Self::TRACING_CONFIG.clone());
             let vm_byte_code_rich_ir =
-                RichIr::for_byte_code(&module, &vm_byte_code, &Self::TRACING_CONFIG);
+                RichIr::for_byte_code(&module, &vm_byte_code, Self::TRACING_CONFIG);
             visit(
                 "VM Byte Code",
                 Self::format_byte_code(&vm_byte_code, &vm_byte_code_rich_ir),

--- a/compiler/frontend/Cargo.toml
+++ b/compiler/frontend/Cargo.toml
@@ -7,6 +7,7 @@ rust-version = "1.56"
 [lib]
 
 [dependencies]
+clap = { version = "4.1.8", features = ["derive"] }
 derive_more = "0.99.17"
 dunce = "1.0.4"
 enumset = "1.0.12"

--- a/compiler/frontend/src/hir_to_mir.rs
+++ b/compiler/frontend/src/hir_to_mir.rs
@@ -56,7 +56,7 @@ fn mir(db: &dyn HirToMir, target: ExecutionTarget, tracing: TracingConfig) -> Mi
                 module,
                 target_is_main_function,
                 &hir,
-                &tracing,
+                tracing,
                 &mut errors,
             );
             (mir, errors)
@@ -185,7 +185,7 @@ fn generate_needs_function(body: &mut BodyBuilder) -> Id {
 struct LoweringContext<'a> {
     mapping: &'a mut FxHashMap<hir::Id, Id>,
     needs_function: Id,
-    tracing: &'a TracingConfig,
+    tracing: TracingConfig,
     ongoing_destructuring: Option<OngoingDestructuring>,
     errors: &'a mut FxHashSet<CompilerError>,
 }
@@ -202,7 +202,7 @@ impl<'a> LoweringContext<'a> {
         module: Module,
         target_is_main_function: bool,
         hir: &hir::Body,
-        tracing: &TracingConfig,
+        tracing: TracingConfig,
         errors: &mut FxHashSet<CompilerError>,
     ) -> Mir {
         Mir::build(|body| {

--- a/compiler/frontend/src/mir_optimize/mod.rs
+++ b/compiler/frontend/src/mir_optimize/mod.rs
@@ -95,7 +95,7 @@ fn optimized_mir(
 ) -> OptimizedMirResult {
     let module = target.module();
     debug!("{module}: Compiling.");
-    let (mir, errors) = db.mir(target.clone(), tracing.clone())?;
+    let (mir, errors) = db.mir(target.clone(), tracing)?;
     let mut mir = (*mir).clone();
     let mut pureness = PurenessInsights::default();
     let mut errors = (*errors).clone();
@@ -216,7 +216,7 @@ impl Context<'_> {
     }
 }
 
-#[allow(clippy::unnecessary_wraps)]
+#[allow(clippy::trivially_copy_pass_by_ref, clippy::unnecessary_wraps)]
 fn recover_from_cycle(
     _db: &dyn OptimizeMir,
     cycle: &[String],

--- a/compiler/frontend/src/rich_ir.rs
+++ b/compiler/frontend/src/rich_ir.rs
@@ -290,8 +290,8 @@ impl RichIrBuilder {
             .push(range);
     }
 
-    pub fn push_tracing_config(&mut self, tracing_config: &TracingConfig) {
-        fn push_mode(builder: &mut RichIrBuilder, title: &str, mode: &TracingMode) {
+    pub fn push_tracing_config(&mut self, tracing_config: TracingConfig) {
+        fn push_mode(builder: &mut RichIrBuilder, title: &str, mode: TracingMode) {
             builder.push_comment_line(format!(
                 "• {title} {}",
                 match mode {
@@ -308,13 +308,13 @@ impl RichIrBuilder {
         push_mode(
             self,
             "Include tracing of fuzzable functions?",
-            &tracing_config.register_fuzzables,
+            tracing_config.register_fuzzables,
         );
-        push_mode(self, "Include tracing of calls?", &tracing_config.calls);
+        push_mode(self, "Include tracing of calls?", tracing_config.calls);
         push_mode(
             self,
             "Include tracing of evaluated expressions?",
-            &tracing_config.evaluated_expressions,
+            tracing_config.evaluated_expressions,
         );
     }
 
@@ -373,25 +373,25 @@ impl RichIr {
         Self::for_ir("HIR", module, None, |builder| body.build_rich_ir(builder))
     }
     #[must_use]
-    pub fn for_mir(module: &Module, mir: &Mir, tracing_config: &TracingConfig) -> Self {
+    pub fn for_mir(module: &Module, mir: &Mir, tracing_config: TracingConfig) -> Self {
         Self::for_ir("MIR", module, tracing_config, |builder| {
             mir.build_rich_ir(builder);
         })
     }
     #[must_use]
-    pub fn for_optimized_mir(module: &Module, mir: &Mir, tracing_config: &TracingConfig) -> Self {
+    pub fn for_optimized_mir(module: &Module, mir: &Mir, tracing_config: TracingConfig) -> Self {
         Self::for_ir("Optimized MIR", module, tracing_config, |builder| {
             mir.build_rich_ir(builder);
         })
     }
     #[must_use]
-    pub fn for_lir(module: &Module, lir: &Lir, tracing_config: &TracingConfig) -> Self {
+    pub fn for_lir(module: &Module, lir: &Lir, tracing_config: TracingConfig) -> Self {
         Self::for_ir("LIR", module, tracing_config, |builder| {
             lir.build_rich_ir(builder);
         })
     }
     #[must_use]
-    pub fn for_optimized_lir(module: &Module, lir: &Lir, tracing_config: &TracingConfig) -> Self {
+    pub fn for_optimized_lir(module: &Module, lir: &Lir, tracing_config: TracingConfig) -> Self {
         Self::for_ir("Optimized LIR", module, tracing_config, |builder| {
             lir.build_rich_ir(builder);
         })
@@ -400,7 +400,7 @@ impl RichIr {
     fn for_ir(
         ir_name: &str,
         module: &Module,
-        tracing_config: impl Into<Option<&TracingConfig>>,
+        tracing_config: impl Into<Option<TracingConfig>>,
         build_rich_ir: impl FnOnce(&mut RichIrBuilder),
     ) -> Self {
         let mut builder = RichIrBuilder::default();

--- a/compiler/frontend/src/tracing.rs
+++ b/compiler/frontend/src/tracing.rs
@@ -1,3 +1,4 @@
+use clap::ValueEnum;
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
@@ -27,7 +28,7 @@ impl TracingConfig {
     }
 }
 
-#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, Serialize, Deserialize, ValueEnum)]
 #[serde(rename_all = "camelCase")]
 pub enum TracingMode {
     Off,

--- a/compiler/frontend/src/tracing.rs
+++ b/compiler/frontend/src/tracing.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-#[derive(PartialEq, Eq, Hash, Debug, Clone, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct TracingConfig {
     pub register_fuzzables: TracingMode,
@@ -27,7 +27,7 @@ impl TracingConfig {
     }
 }
 
-#[derive(PartialEq, Eq, Hash, Debug, Clone, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub enum TracingMode {
     Off,

--- a/compiler/language_server/src/debug_adapter/session.rs
+++ b/compiler/language_server/src/debug_adapter/session.rs
@@ -192,7 +192,7 @@ impl DebugSession {
                 let byte_code = compile_byte_code(
                     &self.db,
                     ExecutionTarget::MainFunction(module.clone()),
-                    tracing.clone(),
+                    tracing,
                 )
                 .0;
 

--- a/compiler/language_server/src/features_ir.rs
+++ b/compiler/language_server/src/features_ir.rs
@@ -110,43 +110,43 @@ impl IrFeatures {
                 &config.module,
                 db.mir(
                     ExecutionTarget::Module(config.module.clone()),
-                    tracing_config.clone(),
+                    *tracing_config,
                 ),
-                tracing_config,
+                *tracing_config,
             ),
             Ir::OptimizedMir(tracing_config) => Self::rich_ir_for_optimized_mir(
                 &config.module,
                 db.optimized_mir(
                     ExecutionTarget::Module(config.module.clone()),
-                    tracing_config.clone(),
+                    *tracing_config,
                 ),
-                tracing_config,
+                *tracing_config,
             ),
             Ir::Lir(tracing_config) => Self::rich_ir_for_lir(
                 &config.module,
                 &db.lir(
                     ExecutionTarget::Module(config.module.clone()),
-                    tracing_config.clone(),
+                    *tracing_config,
                 ),
-                tracing_config,
+                *tracing_config,
             ),
             Ir::OptimizedLir(tracing_config) => Self::rich_ir_for_optimized_lir(
                 &config.module,
                 db.optimized_lir(
                     ExecutionTarget::Module(config.module.clone()),
-                    tracing_config.clone(),
+                    *tracing_config,
                 ),
-                tracing_config,
+                *tracing_config,
             ),
             Ir::VmByteCode(tracing_config) => Self::rich_ir_for_vm_byte_code(
                 &config.module,
                 &candy_vm::lir_to_byte_code::compile_byte_code(
                     db,
                     ExecutionTarget::Module(config.module.clone()),
-                    tracing_config.clone(),
+                    *tracing_config,
                 )
                 .0,
-                tracing_config,
+                *tracing_config,
             ),
             #[cfg(feature = "inkwell")]
             Ir::LlvmIr => db
@@ -179,7 +179,7 @@ impl IrFeatures {
             Err(error) => Self::build_rich_ir_for_module_error(builder, module, error),
         })
     }
-    fn rich_ir_for_mir(module: &Module, mir: MirResult, tracing_config: &TracingConfig) -> RichIr {
+    fn rich_ir_for_mir(module: &Module, mir: MirResult, tracing_config: TracingConfig) -> RichIr {
         Self::rich_ir_for("MIR", module, tracing_config, |builder| match mir {
             Ok((mir, _)) => mir.build_rich_ir(builder),
             Err(error) => Self::build_rich_ir_for_module_error(builder, module, error),
@@ -188,7 +188,7 @@ impl IrFeatures {
     fn rich_ir_for_optimized_mir(
         module: &Module,
         mir: OptimizedMirResult,
-        tracing_config: &TracingConfig,
+        tracing_config: TracingConfig,
     ) -> RichIr {
         Self::rich_ir_for(
             "Optimized MIR",
@@ -200,7 +200,7 @@ impl IrFeatures {
             },
         )
     }
-    fn rich_ir_for_lir(module: &Module, lir: &LirResult, tracing_config: &TracingConfig) -> RichIr {
+    fn rich_ir_for_lir(module: &Module, lir: &LirResult, tracing_config: TracingConfig) -> RichIr {
         Self::rich_ir_for("LIR", module, tracing_config, |builder| match lir {
             Ok((lir, _)) => lir.build_rich_ir(builder),
             Err(error) => Self::build_rich_ir_for_module_error(builder, module, *error),
@@ -209,7 +209,7 @@ impl IrFeatures {
     fn rich_ir_for_optimized_lir(
         module: &Module,
         lir: LirResult,
-        tracing_config: &TracingConfig,
+        tracing_config: TracingConfig,
     ) -> RichIr {
         Self::rich_ir_for(
             "Optimized LIR",
@@ -224,7 +224,7 @@ impl IrFeatures {
     fn rich_ir_for_vm_byte_code(
         module: &Module,
         byte_code: &candy_vm::byte_code::ByteCode,
-        tracing_config: &TracingConfig,
+        tracing_config: TracingConfig,
     ) -> RichIr {
         Self::rich_ir_for("VM Byte Code", module, tracing_config, |builder| {
             byte_code.build_rich_ir(builder);
@@ -233,7 +233,7 @@ impl IrFeatures {
     fn rich_ir_for(
         ir_name: &str,
         module: &Module,
-        tracing_config: impl Into<Option<&TracingConfig>>,
+        tracing_config: impl Into<Option<TracingConfig>>,
         build_rich_ir: impl FnOnce(&mut RichIrBuilder),
     ) -> RichIr {
         let mut builder = RichIrBuilder::default();
@@ -409,14 +409,14 @@ pub enum Ir {
     LlvmIr,
 }
 impl Ir {
-    const fn tracing_config(&self) -> Option<&TracingConfig> {
+    const fn tracing_config(&self) -> Option<TracingConfig> {
         match self {
             Self::Rcst | Self::Ast | Self::Hir => None,
             Self::Mir(tracing_config)
             | Self::OptimizedMir(tracing_config)
             | Self::Lir(tracing_config)
             | Self::OptimizedLir(tracing_config)
-            | Self::VmByteCode(tracing_config) => Some(tracing_config),
+            | Self::VmByteCode(tracing_config) => Some(*tracing_config),
             #[cfg(feature = "inkwell")]
             Self::LlvmIr => None,
         }
@@ -527,7 +527,6 @@ impl LanguageFeatures for IrFeatures {
                         config
                             .ir
                             .tracing_config()
-                            .cloned()
                             .unwrap_or_else(TracingConfig::off),
                     ),
                 };
@@ -542,7 +541,6 @@ impl LanguageFeatures for IrFeatures {
                         config
                             .ir
                             .tracing_config()
-                            .cloned()
                             .unwrap_or_else(TracingConfig::off),
                     ),
                 };

--- a/compiler/vm/benches/utils.rs
+++ b/compiler/vm/benches/utils.rs
@@ -86,12 +86,7 @@ pub fn setup() -> Database {
     db.module_provider.add_str(&MODULE, r#"_ = use "Core""#);
 
     // Load `Core` into the cache.
-    let errors = compile_byte_code(
-        &db,
-        ExecutionTarget::Module(MODULE.clone()),
-        TRACING.clone(),
-    )
-    .1;
+    let errors = compile_byte_code(&db, ExecutionTarget::Module(MODULE.clone()), TRACING).1;
     if !errors.is_empty() {
         for error in errors.iter() {
             warn!("{}", error.to_string_with_location(&db));
@@ -104,12 +99,7 @@ pub fn setup() -> Database {
 
 pub fn compile(db: &mut Database, source_code: &str) -> ByteCode {
     db.did_open_module(&MODULE, source_code.as_bytes().to_owned());
-    compile_byte_code(
-        db,
-        ExecutionTarget::MainFunction(MODULE.clone()),
-        TRACING.clone(),
-    )
-    .0
+    compile_byte_code(db, ExecutionTarget::MainFunction(MODULE.clone()), TRACING).0
 }
 
 pub fn run(byte_code: impl Borrow<ByteCode>) -> (Heap, InlineObject) {

--- a/compiler/vm/fuzz/fuzz_targets/vm.rs
+++ b/compiler/vm/fuzz/fuzz_targets/vm.rs
@@ -70,12 +70,8 @@ fuzz_target!(|data: &[u8]| {
     db.module_provider.load_package_from_file_system("Builtins");
     db.module_provider.add(&MODULE, data.to_vec());
 
-    let byte_code = compile_byte_code(
-        &db,
-        ExecutionTarget::MainFunction(MODULE.clone()),
-        TRACING.clone(),
-    )
-    .0;
+    let byte_code =
+        compile_byte_code(&db, ExecutionTarget::MainFunction(MODULE.clone()), TRACING).0;
 
     let mut heap = Heap::default();
     let environment = Struct::create(&mut heap, true, &Default::default());

--- a/compiler/vm/src/byte_code.rs
+++ b/compiler/vm/src/byte_code.rs
@@ -423,7 +423,7 @@ pub impl RichIrForByteCode for RichIr {
     fn for_byte_code(
         module: &Module,
         byte_code: &ByteCode,
-        tracing_config: &TracingConfig,
+        tracing_config: TracingConfig,
     ) -> RichIr {
         let mut builder = RichIrBuilder::default();
         builder.push(


### PR DESCRIPTION
<!-- Please enter the corresponding issue ID: -->


<!-- Please summarize your changes: -->
```sh
jw@mars:~/Documents/GitHub/candy-lang/candy$ cargo run -- debug optimized-lir --help
Optimized Low-Level Intermediate Representation

Usage: candy debug optimized-lir [OPTIONS] <PATH>

Arguments:
  <PATH>
          

Options:
      --execution-target <EXECUTION_TARGET>
          [default: module]
          [possible values: module, main-function]

      --register-fuzzables[=<REGISTER_FUZZABLES>]
          [default: off]

          Possible values:
          - off
          - only-current: Traces the module that's the root of the compilation and no child modules
          - all

      --trace-calls[=<TRACE_CALLS>]
          [default: off]

          Possible values:
          - off
          - only-current: Traces the module that's the root of the compilation and no child modules
          - all

      --trace-evaluated-expressions[=<TRACE_EVALUATED_EXPRESSIONS>]
          [default: off]

          Possible values:
          - off
          - only-current: Traces the module that's the root of the compilation and no child modules
          - all

  -h, --help
          Print help (see a summary with '-h')
```


### Checklist
<!-- Please check if your PR fulfills the following requirements: -->

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
