### PR TITLE
Fix stack trace formatting of needs' HIR ID

### DIFF
--- a/compiler/vm/src/tracer/stack_trace.rs
+++ b/compiler/vm/src/tracer/stack_trace.rs
@@ -1,5 +1,5 @@
 use super::Tracer;
-use crate::heap::{Heap, HirId, InlineObject, ToDebugText};
+use crate::heap::{Data, Heap, HirId, InlineObject, ToDebugText};
 use candy_frontend::{
     ast_to_hir::AstToHir,
     cst::CstKind,
@@ -184,7 +184,14 @@ impl StackTracer {
                 .unwrap_or_else(|| callee.to_string()),
             arguments
                 .iter()
-                .map(|it| it.to_debug_text(Precedence::High, MaxLength::Unlimited))
+                .map(|it| {
+                    if let Data::HirId(id) = (*it).into() {
+                        // Only occurs for `needs` calls.
+                        id.to_string()
+                    } else {
+                        it.to_debug_text(Precedence::High, MaxLength::Unlimited)
+                    }
+                })
                 .join(" "),
         );
         (caller_location_string, call_string)


### PR DESCRIPTION
<!-- Please enter the corresponding issue ID: -->


<!-- Please summarize your changes: -->
Now that we trace calls to `needs`, a stack trace can contain a HIR ID as an argument which we need to format. `to_debug_text` doesn't support HIR IDs since they can't be accessed in user code.

Example stack trace (first stack trace line was added in a different PR from today and caused a crash):

```log
2024-01-18T22:35:06.948445Z DEBUG candy::run: Running Examples:helloWorld.
2024-01-18T22:35:06.995519Z DEBUG candy::run: Compilation took 47 ms.
2024-01-18T22:35:06.995558Z DEBUG candy::run: Running program.
2024-01-18T22:35:06.995655Z ERROR candy::run: The program panicked: `struct | ✨.structHasKey key` was not satisfied
2024-01-18T22:35:06.995683Z ERROR candy::run: Examples:helloWorld:2:5 is responsible.
2024-01-18T22:35:06.996020Z ERROR candy::run: This is the stack trace:
packages/Builtins/_.candy:435:3 – 435:38            needs False "`struct | ✨.structHasKey key` was not satisfied" Examples:helloWorld:2:5
packages/Examples/helloWorld.candy:4:3 – 4:22       {…} [Arguments: (,), GetRandomBytes: { … }, HttpServer: { … }, Stdin: { … }, Stdout: { … }, SystemClock: { … }] Stdouta
tooling:user::                                      {…} [Arguments: (,), GetRandomBytes: { … }, HttpServer: { … }, Stdin: { … }, Stdout: { … }, SystemClock: { … }]
2024-01-18T22:35:06.996039Z DEBUG candy::run: Execution took 521 µs.
Error: CodePanicked
```


### Checklist
<!-- Please check if your PR fulfills the following requirements: -->

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
