### PR TITLE
Fix programming language benchmark

### DIFF
--- a/.github/workflows/compiler.yaml
+++ b/.github/workflows/compiler.yaml
@@ -177,10 +177,11 @@ jobs:
 
       - name: Run benchmark
         working-directory: compiler/vm/
+        # TODO(JonasWanke): Fix output format error
         # Explicitly specify Bash since it also includes `-o pipefail`. Without
         # it, this step succeeds even if the benchmark execution itself fails.
         # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#exit-codes-and-error-action-preference
-        shell: bash
+        # shell: bash
         run: cargo bench -- --output-format bencher | tee benchmark_output.txt
 
       - name: Store benchmark result

--- a/.github/workflows/compiler.yaml
+++ b/.github/workflows/compiler.yaml
@@ -177,6 +177,10 @@ jobs:
 
       - name: Run benchmark
         working-directory: compiler/vm/
+        # Explicitly specify Bash since it also includes `-o pipefail`. Without
+        # it, this step succeeds even if the benchmark execution itself fails.
+        # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#exit-codes-and-error-action-preference
+        shell: bash
         run: cargo bench -- --output-format bencher | tee benchmark_output.txt
 
       - name: Store benchmark result

--- a/compiler/vm/benches/benchmark.rs
+++ b/compiler/vm/benches/benchmark.rs
@@ -75,7 +75,7 @@ main _ := fib {n}"#,
 fn create_binary_trees_code(n: usize) -> String {
     format!(
         r#"
-[equals, if, ifElse, int, iterable, recursive, result, struct, text] = use "Core"
+[equals, if, ifElse, int, iterator, recursive, result, struct, text] = use "Core"
 
 createTree n :=
   needs (int.is n)
@@ -110,7 +110,7 @@ main _ :=
   recursive minDepth {{ recurse depth ->
     if (depth | int.isLessThanOrEqualTo maxDepth) {{
       iterations = 1 | int.shiftLeft (maxDepth | int.subtract depth | int.add minDepth)
-      check = iterable.generate iterations {{ _ -> createTree depth | checkTree }} | iterable.sum
+      check = iterator.generate iterations {{ _ -> createTree depth | checkTree }} | iterator.sum
       recurse (depth | int.add 2)
     }}
   }}


### PR DESCRIPTION
<!-- Please enter the corresponding issue ID: -->


<!-- Please summarize your changes: -->
Turns out the Programming Language benchmark was missing recent results from our benchmarking graphs because it still referenced the old `iterable` (instead of the renamed `iterator`). And because GitHub Actions' default shell doesn't set `pipefail` (https://github.com/actions/runner-images/issues/4459), our CI still succeeded.


### Checklist
<!-- Please check if your PR fulfills the following requirements: -->

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
