### PR TITLE
Remove debug info from release builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,3 @@ members = [
 [workspace.package]
 edition = "2021"
 rust-version = "1.78.0"
-
-[profile.release]
-# https://github.com/flamegraph-rs/flamegraph#usage-with-benchmarks
-debug = true

--- a/compiler/cli/README.md
+++ b/compiler/cli/README.md
@@ -5,9 +5,9 @@
 Create a [flamegraph](https://github.com/flamegraph-rs/flamegraph#readme):
 
 ```bash
-cargo flamegraph --bin=candy --deterministic --output=<output file name> -- run <candy file>
+CARGO_PROFILE_RELEASE_DEBUG=true cargo flamegraph --bin=candy --deterministic --output=<output file name> -- run <candy file>
 # For example:
-cargo flamegraph --bin=candy --deterministic --output=flamegraph.svg -- run packages/Examples/fibonacci.candy
+CARGO_PROFILE_RELEASE_DEBUG=true cargo flamegraph --bin=candy --deterministic --output=flamegraph.svg -- run packages/Examples/fibonacci.candy
 ```
 
 Use [hyperfine](https://github.com/sharkdp/hyperfine#readme):


### PR DESCRIPTION
<!-- Please enter the corresponding issue ID: -->


<!-- Please summarize your changes: -->
This reduces the release size from 177.4 MB to 14.2 MB for me and also speeds up compile times:

```text
# time cargo build --release

# Before:
real    0m6,217s
user    0m32,679s
sys     0m1,407s

# After:
real    0m4,735s
user    0m22,096s
sys     0m0,528s
```

AFAIK, the debug info was only there for flamegraphs, but we can still enable it specifically for generating flamegraphs.

### Checklist
<!-- Please check if your PR fulfills the following requirements: -->

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
