### PR TITLE
Fix panic in Chrono.duration.toText

### DIFF
--- a/packages/Chrono/duration.candy
+++ b/packages/Chrono/duration.candy
@@ -195,5 +195,9 @@ toText duration :=
   mm = duration | minutes | toDebugText | text.padStart 2 "0"
   ss = duration | seconds | toDebugText | text.padStart 2 "0"
   f = duration | subSecondComponent | tag.getValue | fixedDecimal.toText
-  f = f | text.getRange 0 (f | text.firstIndexOf ".") | text.padEnd 9 "0"
+  dot = text.firstIndexOf f "." %
+    FoundAt index -> index
+    NotFound -> 0
+  f = text.getRange f 0 dot
+  f = text.padEnd f 9 "0"
   "{sign}{d}:{hh}:{mm}:{ss}.{f}"


### PR DESCRIPTION
There are three mistakes in Chrono.duration.toText:
1. incorrect argument order for text.getRange
2. incorrect argument order for text.firstIndexOf
3. assuming text.firstIndexOf returns in int rather than FoundAt index or NotFound

These three bugs caused packages/Examples/clock.candy to panic.

```
2024-02-25T22:32:38.353578Z DEBUG candy::run: Running Examples:clock.
2024-02-25T22:32:39.753290Z DEBUG candy::run: Compilation took 1399 ms.
2024-02-25T22:32:39.753301Z DEBUG candy::run: Running program.
2024-02-25T22:32:39.762745Z ERROR candy::run: The program panicked: `endExclusive | typeIs Int` was not satisfied
2024-02-25T22:32:39.762747Z ERROR candy::run: Chrono:duration:toText:121 is responsible.
2024-02-25T22:32:39.762889Z ERROR candy::run: This is the stack trace:
packages/Builtins/_.candy:570:3 – 570:36            needs False "`endExclusive | typeIs Int` was not satisfied" Chrono:duration:toText:121
packages/Chrono/duration.candy:198:7 – 198:55       {…} "0." 0 (FoundAt 1)
packages/Examples/clock.candy:9:23 – 9:73           {…} (Duration (FixedDecimal [MinorUnits: 1708900359, Scale: 0]))
tooling:user::                                      {…} [Arguments: (,), FileSystem: [File: [Close: { … }, Open: { … }, ReadToEnd: { … }]], GetRandomBytes: { … }, HttpServer: { … }, Stdin: { … }, Stdout: { … }, SystemClock: { … }]
2024-02-25T22:32:39.762892Z DEBUG candy::run: Execution took 9 ms.
```
### Checklist
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
