### PR TITLE
Log optimizations

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,3 +89,14 @@ We already have a language server that provides some tooling.
 
 If you are working on the Rust code itself, you might want to disable the release mode for quicker compilation:
 In the VS Code settings (JSON), add the following: `"candy.languageServerCommand": "cargo run --manifest-path <path-to-the-candy-folder>/compiler/cli/Cargo.toml -- lsp"`.
+
+## Environment Variables for Debugging the Compiler
+
+```sh
+# Don't normalize IDs (number them sequentially) after optimizing the MIR.
+CANDY_MIR_NORMALIZE_IDS=false
+
+# Generate a _large_ Markdown file that lists every single optimization step
+# performed on the MIR.
+CANDY_MIR_OPTIMIZATION_LOG=target/optimization-log.md
+```

--- a/compiler/frontend/src/hir_to_mir.rs
+++ b/compiler/frontend/src/hir_to_mir.rs
@@ -16,7 +16,10 @@ use crate::{
 use itertools::Itertools;
 use linked_hash_map::LinkedHashMap;
 use rustc_hash::{FxHashMap, FxHashSet};
-use std::{fmt::{self, Display, Formatter}, sync::Arc};
+use std::{
+    fmt::{self, Display, Formatter},
+    sync::Arc,
+};
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub enum ExecutionTarget {
@@ -36,8 +39,8 @@ impl ExecutionTarget {
 impl Display for ExecutionTarget {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         match self {
-            Self::Module(module) => write!(f, "module `{}`", module),
-            Self::MainFunction(module) => write!(f, "main function of module `{}`", module),
+            Self::Module(module) => write!(f, "module `{module}`"),
+            Self::MainFunction(module) => write!(f, "main function of module `{module}`"),
         }
     }
 }

--- a/compiler/frontend/src/hir_to_mir.rs
+++ b/compiler/frontend/src/hir_to_mir.rs
@@ -16,7 +16,7 @@ use crate::{
 use itertools::Itertools;
 use linked_hash_map::LinkedHashMap;
 use rustc_hash::{FxHashMap, FxHashSet};
-use std::sync::Arc;
+use std::{fmt::{self, Display, Formatter}, sync::Arc};
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub enum ExecutionTarget {
@@ -29,6 +29,15 @@ impl ExecutionTarget {
         match &self {
             Self::Module(module) => module,
             Self::MainFunction(module) => module,
+        }
+    }
+}
+
+impl Display for ExecutionTarget {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        match self {
+            Self::Module(module) => write!(f, "module `{}`", module),
+            Self::MainFunction(module) => write!(f, "main function of module `{}`", module),
         }
     }
 }

--- a/compiler/frontend/src/mir_optimize/common_subtree_elimination.rs
+++ b/compiler/frontend/src/mir_optimize/common_subtree_elimination.rs
@@ -36,6 +36,8 @@ use std::{
     mem,
 };
 
+const NAME: &str = "Common Subtree Elimination";
+
 pub fn eliminate_common_subtrees(body: &mut Body, pureness: &mut PurenessInsights) {
     // Previously, this was a more intuitive `FxHashMap<Id, Expression>`.
     // However, we had to clone _every_ expression for this, which was quite
@@ -109,8 +111,11 @@ pub fn eliminate_common_subtrees(body: &mut Body, pureness: &mut PurenessInsight
                 let (canonical_id, _) = body.expressions[*canonical_index];
 
                 let mut current_expression = CurrentExpression::new(body, index);
-                let old_expression =
-                    current_expression.replace_with(Expression::Reference(canonical_id), pureness);
+                let old_expression = current_expression.replace_with(
+                    NAME,
+                    Expression::Reference(canonical_id),
+                    pureness,
+                );
                 replaced.insert(id, canonical_id);
 
                 if let Expression::Function {

--- a/compiler/frontend/src/mir_optimize/constant_folding.rs
+++ b/compiler/frontend/src/mir_optimize/constant_folding.rs
@@ -50,6 +50,8 @@ use std::{
 use tracing::warn;
 use unicode_segmentation::UnicodeSegmentation;
 
+const NAME: &str = "Constant Folding";
+
 pub fn fold_constants(context: &mut Context, expression: &mut CurrentExpression) {
     let Expression::Call {
         function,
@@ -66,6 +68,7 @@ pub fn fold_constants(context: &mut Context, expression: &mut CurrentExpression)
             value: None,
         } if arguments.len() == 1 => {
             expression.replace_with(
+                NAME,
                 Expression::Tag {
                     symbol: symbol.clone(),
                     value: Some(arguments[0]),
@@ -87,7 +90,7 @@ pub fn fold_constants(context: &mut Context, expression: &mut CurrentExpression)
             ) else {
                 return;
             };
-            expression.replace_with(result, context.pureness);
+            expression.replace_with(NAME, result, context.pureness);
         }
         _ => {}
     }
@@ -261,7 +264,7 @@ fn run_builtin(
                 Err(err) => Err(body.push_with_new_id(id_generator, err.to_string())),
             };
             body.push_with_new_id(id_generator, result);
-            expression.replace_with_multiple(body, pureness);
+            expression.replace_with_multiple(NAME, body, pureness);
             return None;
         }
         BuiltinFunction::IntRemainder => {
@@ -472,7 +475,7 @@ fn run_builtin(
                 .map(|it| body.push_with_new_id(id_generator, it))
                 .collect_vec();
             body.push_with_new_id(id_generator, characters);
-            expression.replace_with_multiple(body, pureness);
+            expression.replace_with_multiple(NAME, body, pureness);
             return None;
         }
         BuiltinFunction::TextConcatenate => {
@@ -546,7 +549,7 @@ fn run_builtin(
                 .map(|it| body.push_with_new_id(id_generator, it))
                 .map_err(|_| body.push_with_new_id(id_generator, "Invalid UTF-8."));
             body.push_with_new_id(id_generator, result);
-            expression.replace_with_multiple(body, pureness);
+            expression.replace_with_multiple(NAME, body, pureness);
             return None;
         }
         BuiltinFunction::TextGetRange => {

--- a/compiler/frontend/src/mir_optimize/constant_lifting.rs
+++ b/compiler/frontend/src/mir_optimize/constant_lifting.rs
@@ -39,6 +39,8 @@ use super::current_expression::{Context, CurrentExpression};
 use crate::mir::Expression;
 use itertools::Itertools;
 
+const NAME: &str = "Constant Lifting";
+
 pub fn lift_constants(context: &mut Context, expression: &mut CurrentExpression) {
     let Expression::Function { body, .. } = expression.get_mut_carefully() else {
         return;
@@ -80,5 +82,5 @@ pub fn lift_constants(context: &mut Context, expression: &mut CurrentExpression)
         );
     }
 
-    expression.prepend_optimized(context.visible, constants);
+    expression.prepend_optimized(NAME, context.visible, constants);
 }

--- a/compiler/frontend/src/mir_optimize/current_expression.rs
+++ b/compiler/frontend/src/mir_optimize/current_expression.rs
@@ -3,6 +3,7 @@ use crate::{
     error::CompilerError,
     id::IdGenerator,
     mir::{Body, Expression, Id, VisibleExpressions},
+    mir_optimize::log::OptimizationLogger,
     TracingConfig,
 };
 use rustc_hash::FxHashSet;
@@ -38,47 +39,89 @@ impl<'a> CurrentExpression<'a> {
     pub fn get_mut_carefully(&mut self) -> &mut Expression {
         &mut self.body.expressions[self.index].1
     }
-    pub fn replace_id_references(&mut self, replacer: &mut impl FnMut(&mut Id)) {
+    pub fn replace_id_references(
+        &mut self,
+        optimization_name: &str,
+        replacer: &mut impl FnMut(&mut Id),
+    ) {
         self.get_mut_carefully().replace_id_references(replacer);
+        OptimizationLogger::log_replace_id_references(optimization_name, self.id());
     }
     pub fn prepend_optimized(
         &mut self,
+        optimization_name: &str,
         visible: &mut VisibleExpressions,
         optimized_expressions: impl IntoIterator<Item = (Id, Expression)>,
     ) {
+        let mut new_formatted = OptimizationLogger::is_enabled().then(String::new);
         self.body.expressions.splice(
             self.index..self.index,
             optimized_expressions.into_iter().map(|(id, expression)| {
+                if let Some(new_formatted) = &mut new_formatted {
+                    *new_formatted += &format!("{id} = {expression}\n");
+                }
                 visible.insert(id, expression);
                 self.index += 1;
                 (id, Expression::Parameter)
             }),
         );
+
+        if let Some(new_formatted) = new_formatted {
+            OptimizationLogger::log_prepend_optimized(
+                optimization_name,
+                self.id(),
+                new_formatted.strip_suffix('\n').unwrap_or_default(),
+            );
+        }
     }
     pub fn replace_with(
         &mut self,
+        optimization_name: &str,
         expression: Expression,
         pureness: &mut PurenessInsights,
     ) -> Expression {
         let id = self.body.expressions[self.index].0;
-        self.replace_with_multiple([(id, expression)], pureness)
+        self.replace_with_multiple(optimization_name, [(id, expression)], pureness)
     }
     pub fn replace_with_multiple<I: DoubleEndedIterator<Item = (Id, Expression)>>(
         &mut self,
+        optimization_name: &str,
         expressions: impl IntoIterator<Item = (Id, Expression), IntoIter = I>,
         pureness: &mut PurenessInsights,
     ) -> Expression {
+        let mut new_formatted = OptimizationLogger::is_enabled().then(String::new);
         let mut expressions = expressions.into_iter();
+        let id = self.id();
         let (_, last_expression) = expressions.next_back().unwrap();
         let mut removed = self.body.expressions.splice(
             self.index..=self.index,
-            expressions.chain([(self.id(), last_expression)]),
+            expressions
+                .chain([(id, last_expression)])
+                .map(|(id, expression)| {
+                    if let Some(new_formatted) = &mut new_formatted {
+                        *new_formatted += &format!("{id} = {expression}\n");
+                    }
+                    (id, expression)
+                }),
         );
+
         let (_, removed_expression) = removed.next().unwrap();
         assert!(removed.next().is_none());
+        drop(removed);
         for id in removed_expression.defined_ids() {
             pureness.on_remove(id);
         }
+
+        if let Some(new_formatted) = new_formatted {
+            OptimizationLogger::log_replace_with(
+                optimization_name,
+                &format!("{id} = {removed_expression}"),
+                // There's at least one new expression, so there's always a
+                // trailing newline we have to remove.
+                &new_formatted[..new_formatted.len() - 1],
+            );
+        }
+
         removed_expression
     }
 }

--- a/compiler/frontend/src/mir_optimize/inlining.rs
+++ b/compiler/frontend/src/mir_optimize/inlining.rs
@@ -45,6 +45,8 @@ use crate::{
 };
 use rustc_hash::FxHashMap;
 
+const NAME: &str = "Inlining";
+
 pub fn inline_tiny_functions(context: &mut Context, expression: &mut CurrentExpression) {
     inline_functions_of_maximum_complexity(
         context,
@@ -155,6 +157,7 @@ impl Context<'_> {
             .collect();
 
         expression.replace_with_multiple(
+            NAME,
             body.iter().map(|(id, expression)| {
                 let mut expression = expression.clone();
                 expression.replace_ids(&mut |id| {

--- a/compiler/frontend/src/mir_optimize/log.rs
+++ b/compiler/frontend/src/mir_optimize/log.rs
@@ -1,0 +1,106 @@
+use crate::mir::Id;
+use std::{
+    env,
+    fs::File,
+    io::{BufWriter, Write},
+    sync::{Mutex, OnceLock},
+};
+
+static LOGGER: OnceLock<Option<Mutex<OptimizationLogger>>> = OnceLock::new();
+
+#[derive(Debug)]
+pub struct OptimizationLogger {
+    file: BufWriter<File>,
+    indentation: usize,
+}
+impl OptimizationLogger {
+    // We specify Python for code blocks to get some syntax highlighting of
+    // comments and expressions.
+
+    pub fn log_replace_id_references(optimization_name: &str, id: Id) {
+        Self::run(|logger| {
+            logger.write_line(&format!(
+                "1. {optimization_name} calls `replace_id_references({id}, …)`",
+            ));
+        });
+    }
+    pub fn log_prepend_optimized(optimization_name: &str, following_id: Id, new: &str) {
+        Self::run(|logger| {
+            logger.write_line(&format!(
+                "1. {optimization_name} calls `prepend_optimized(…)`:",
+            ));
+            logger.indent();
+            logger.write_newline();
+            logger.write_line("```python");
+            logger.write_line(&format!("# Inserts before {following_id}:"));
+            logger.write_lines(new);
+            logger.write_line("```");
+            logger.write_newline();
+            logger.dedent();
+        });
+    }
+    pub fn log_replace_with(optimization_name: &str, old: &str, new: &str) {
+        Self::run(|logger| {
+            logger.write_line(&format!(
+                "1. {optimization_name} calls `replace_with(…)`/`replace_with_multiple(…)`:",
+            ));
+            logger.indent();
+            logger.write_newline();
+            logger.write_line("```python");
+            logger.write_line("# Before:");
+            logger.write_lines(old);
+            logger.write_newline();
+            logger.write_line("# After:");
+            logger.write_lines(new);
+            logger.write_line("```");
+            logger.write_newline();
+            logger.dedent();
+        });
+    }
+
+    pub fn is_enabled() -> bool {
+        Self::get().is_some()
+    }
+    fn get() -> &'static Option<Mutex<Self>> {
+        LOGGER.get_or_init(|| {
+            env::var("CANDY_MIR_OPTIMIZATION_LOG").ok().map(|path| {
+                let mut file = BufWriter::new(File::create(path).unwrap());
+                writeln!(file, "# Candy MIR Optimization Log").unwrap();
+                writeln!(file).unwrap();
+
+                Mutex::new(Self {
+                    file,
+                    indentation: 0,
+                })
+            })
+        })
+    }
+    fn run(run: impl FnOnce(&mut Self)) {
+        if let Some(logger) = Self::get() {
+            let mut logger = logger.lock().unwrap();
+            run(&mut logger);
+            logger.file.flush().unwrap();
+        }
+    }
+    fn write_lines(&mut self, text: &str) {
+        for line in text.lines() {
+            self.write_line(line);
+        }
+    }
+    fn write_line(&mut self, line: &str) {
+        self.write_indentation();
+        writeln!(self.file, "{line}").unwrap();
+    }
+    fn write_newline(&mut self) {
+        writeln!(self.file).unwrap();
+    }
+    fn indent(&mut self) {
+        self.indentation += 1;
+    }
+    fn dedent(&mut self) {
+        self.indentation -= 1;
+    }
+    fn write_indentation(&mut self) {
+        write!(self.file, "{}", "    ".repeat(self.indentation)).unwrap();
+    }
+}

--- a/compiler/frontend/src/mir_optimize/log.rs
+++ b/compiler/frontend/src/mir_optimize/log.rs
@@ -1,4 +1,5 @@
-use crate::mir::Id;
+use super::complexity::Complexity;
+use crate::{hir_to_mir::ExecutionTarget, mir::Id, rich_ir::RichIrBuilder, tracing::TracingConfig};
 use std::{
     env,
     fs::File,
@@ -17,6 +18,34 @@ impl OptimizationLogger {
     // We specify Python for code blocks to get some syntax highlighting of
     // comments and expressions.
 
+    pub fn log_optimized_mir_without_tail_calls_start(
+        target: &ExecutionTarget,
+        tracing: TracingConfig,
+    ) {
+        Self::run(|logger| {
+            logger.write_line(&format!("1. `optimized_mir_without_tail_calls(…)`",));
+            logger.indent();
+            logger.write_newline();
+            logger.write_line(&format!("Execution target: {target}"));
+            logger.write_newline();
+            logger.write_line("```python");
+            let mut builder = RichIrBuilder::default();
+            builder.push_tracing_config(tracing);
+            let tracing = builder.finish(false).text;
+            logger.write_lines(&tracing);
+            logger.write_line("```");
+        });
+    }
+    pub fn log_optimized_mir_without_tail_calls_end(
+        complexity_before: Complexity,
+        complexity_after: Complexity,
+    ) {
+        Self::run(|logger| {
+            logger.dedent();
+            logger.write_line(&format!("Complexity before: {complexity_before}"));
+            logger.write_line(&format!("Complexity after: {complexity_after}"));
+        });
+    }
     pub fn log_replace_id_references(optimization_name: &str, id: Id) {
         Self::run(|logger| {
             logger.write_line(&format!(

--- a/compiler/frontend/src/mir_optimize/log.rs
+++ b/compiler/frontend/src/mir_optimize/log.rs
@@ -1,5 +1,10 @@
-use super::complexity::Complexity;
-use crate::{hir_to_mir::ExecutionTarget, mir::Id, rich_ir::RichIrBuilder, tracing::TracingConfig};
+use super::{complexity::Complexity, current_expression::CurrentExpression};
+use crate::{
+    hir_to_mir::ExecutionTarget,
+    mir::{Body, Id},
+    rich_ir::RichIrBuilder,
+    tracing::TracingConfig,
+};
 use std::{
     env,
     fs::File,
@@ -23,7 +28,7 @@ impl OptimizationLogger {
         tracing: TracingConfig,
     ) {
         Self::run(|logger| {
-            logger.write_line(&format!("1. `optimized_mir_without_tail_calls(…)`",));
+            logger.write_line("1. `optimized_mir_without_tail_calls(…)`");
             logger.indent();
             logger.write_newline();
             logger.write_line(&format!("Execution target: {target}"));
@@ -46,6 +51,39 @@ impl OptimizationLogger {
             logger.write_line(&format!("Complexity after: {complexity_after}"));
         });
     }
+
+    pub fn log_optimize_body_start(body: &Body) {
+        Self::run(|logger| {
+            logger.write_line("1. `optimize_body(…)`");
+            logger.indent();
+            logger.write_newline();
+            logger.write_line("```python");
+            logger.write_lines(&body.to_string());
+            logger.write_line("```");
+        });
+    }
+    pub fn log_optimize_body_end() {
+        Self::run(|logger| {
+            logger.dedent();
+        });
+    }
+
+    pub fn log_optimize_expression_start(expression: &CurrentExpression) {
+        Self::run(|logger| {
+            logger.write_line(&format!("1. `optimize_expression({})`", expression.id()));
+            logger.indent();
+            logger.write_newline();
+            logger.write_line("```python");
+            logger.write_lines(&(*expression).to_string());
+            logger.write_line("```");
+        });
+    }
+    pub fn log_optimize_expression_end() {
+        Self::run(|logger| {
+            logger.dedent();
+        });
+    }
+
     pub fn log_replace_id_references(optimization_name: &str, id: Id) {
         Self::run(|logger| {
             logger.write_line(&format!(

--- a/compiler/frontend/src/mir_optimize/mod.rs
+++ b/compiler/frontend/src/mir_optimize/mod.rs
@@ -67,6 +67,7 @@ mod constant_folding;
 mod constant_lifting;
 mod current_expression;
 mod inlining;
+mod log;
 mod module_folding;
 mod pure;
 mod reference_following;

--- a/compiler/frontend/src/mir_optimize/mod.rs
+++ b/compiler/frontend/src/mir_optimize/mod.rs
@@ -168,6 +168,7 @@ impl Context<'_> {
     fn optimize_body(&mut self, body: &mut Body) {
         // Even though `self.visible` is mutable, this function guarantees that
         // the value is the same after returning.
+        OptimizationLogger::log_optimize_body_start(&body);
         let mut index = 0;
         while index < body.expressions.len() {
             // Thoroughly optimize the expression.
@@ -217,9 +218,11 @@ impl Context<'_> {
         call_tracing::remove_unnecessary_call_tracing(body, self.pureness, self.tracing.calls);
         tree_shaking::tree_shake(body, self.pureness);
         reference_following::remove_redundant_return_references(body, self.pureness);
+        OptimizationLogger::log_optimize_body_end();
     }
 
     fn optimize_expression(&mut self, expression: &mut CurrentExpression) {
+        OptimizationLogger::log_optimize_expression_start(expression);
         'outer: loop {
             if let Expression::Function {
                 parameters,
@@ -269,6 +272,7 @@ impl Context<'_> {
                 }
             }
         }
+        OptimizationLogger::log_optimize_expression_end();
     }
 }
 

--- a/compiler/frontend/src/mir_optimize/mod.rs
+++ b/compiler/frontend/src/mir_optimize/mod.rs
@@ -44,6 +44,7 @@
 
 use self::{
     current_expression::{Context, CurrentExpression},
+    log::OptimizationLogger,
     pure::PurenessInsights,
 };
 use super::{hir, hir_to_mir::HirToMir, mir::Mir, tracing::TracingConfig};
@@ -121,6 +122,7 @@ fn optimized_mir_without_tail_calls(
 ) -> OptimizedMirWithoutTailCallsResult {
     let module = target.module();
     debug!("{module}: Compiling.");
+    OptimizationLogger::log_optimized_mir_without_tail_calls_start(&target, tracing);
     let (mir, errors) = db.mir(target.clone(), tracing)?;
     let mut mir = (*mir).clone();
     let mut pureness = PurenessInsights::default();
@@ -131,6 +133,10 @@ fn optimized_mir_without_tail_calls(
     let complexity_after = mir.complexity();
 
     debug!("{module}: Done. Optimized from {complexity_before} to {complexity_after}");
+    OptimizationLogger::log_optimized_mir_without_tail_calls_end(
+        complexity_before,
+        complexity_after,
+    );
     Ok((Arc::new(mir), Arc::new(pureness), Arc::new(errors)))
 }
 

--- a/compiler/frontend/src/mir_optimize/mod.rs
+++ b/compiler/frontend/src/mir_optimize/mod.rs
@@ -168,7 +168,7 @@ impl Context<'_> {
     fn optimize_body(&mut self, body: &mut Body) {
         // Even though `self.visible` is mutable, this function guarantees that
         // the value is the same after returning.
-        OptimizationLogger::log_optimize_body_start(&body);
+        OptimizationLogger::log_optimize_body_start(body);
         let mut index = 0;
         while index < body.expressions.len() {
             // Thoroughly optimize the expression.

--- a/compiler/frontend/src/mir_optimize/module_folding.rs
+++ b/compiler/frontend/src/mir_optimize/module_folding.rs
@@ -38,6 +38,8 @@ use crate::{
 use rustc_hash::FxHashMap;
 use std::mem;
 
+const NAME: &str = "Module Folding";
+
 pub fn apply(context: &mut Context, expression: &mut CurrentExpression) {
     let Expression::UseModule {
         current_module,
@@ -68,6 +70,7 @@ pub fn apply(context: &mut Context, expression: &mut CurrentExpression) {
                 },
             );
             expression.replace_with_multiple(
+                NAME,
                 panicking_expression(context.id_generator, error.payload.to_string(), responsible),
                 context.pureness,
             );
@@ -76,6 +79,7 @@ pub fn apply(context: &mut Context, expression: &mut CurrentExpression) {
         }
         _ => {
             expression.replace_with_multiple(
+                NAME,
                 panicking_expression(
                     context.id_generator,
                     "`use` expects a text as a path.".to_string(),
@@ -92,6 +96,7 @@ pub fn apply(context: &mut Context, expression: &mut CurrentExpression) {
         Err(error) => {
             let error = CompilerError::for_whole_module(current_module.clone(), error);
             expression.replace_with_multiple(
+                NAME,
                 panicking_expression(context.id_generator, error.payload.to_string(), responsible),
                 context.pureness,
             );
@@ -116,6 +121,7 @@ pub fn apply(context: &mut Context, expression: &mut CurrentExpression) {
 
             context.pureness.include(other_pureness.as_ref(), &mapping);
             expression.prepend_optimized(
+                NAME,
                 context.visible,
                 mir.body.iter().map(|(id, expression)| {
                     let mut expression = expression.clone();
@@ -128,6 +134,7 @@ pub fn apply(context: &mut Context, expression: &mut CurrentExpression) {
                 }),
             );
             expression.replace_with(
+                NAME,
                 Expression::Reference(mapping[&mir.body.return_value()]),
                 context.pureness,
             );
@@ -145,7 +152,7 @@ pub fn apply(context: &mut Context, expression: &mut CurrentExpression) {
 
             let (inner_id_generator, body) = builder.finish();
             *context.id_generator = inner_id_generator;
-            expression.replace_with_multiple(body, context.pureness);
+            expression.replace_with_multiple(NAME, body, context.pureness);
         }
     };
 }

--- a/compiler/frontend/src/mir_optimize/reference_following.rs
+++ b/compiler/frontend/src/mir_optimize/reference_following.rs
@@ -22,8 +22,10 @@ use super::{
 };
 use crate::mir::{Body, Expression};
 
+const NAME: &str = "Reference Following";
+
 pub fn follow_references(context: &mut Context, expression: &mut CurrentExpression) {
-    expression.replace_id_references(&mut |id| {
+    expression.replace_id_references(NAME, &mut |id| {
         if context.visible.contains(*id)
             && let Expression::Reference(referenced) = context.visible.get(*id)
         {


### PR DESCRIPTION
<!-- Please enter the corresponding issue ID: -->


<!-- Please summarize your changes: -->
You can now run:

```sh
CANDY_MIR_OPTIMIZATION_LOG=target/optimization-log.md cargo run --manifest-path compiler/cli/Cargo.toml --release -- run packages/Examples/minimal.candy
```

This will generate a Markdown file containing a list of optimization steps that were performed.

> [!CAUTION]
> The generated files are _large_. For `minimal.candy`, it's around 30 MB, but for `fibonacci.candy` (which imports `Core`), it's 1.1 GB!


### Checklist
<!-- Please check if your PR fulfills the following requirements: -->

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
