### PR TITLE
1016 leading whitespaces after indentation are not parsed correctly

### DIFF
--- a/compiler/frontend/src/string_to_rcst/text.rs
+++ b/compiler/frontend/src/string_to_rcst/text.rs
@@ -20,8 +20,6 @@ pub fn text(input: &str, indentation: usize) -> Option<(&str, Rcst)> {
     let (new_input, mut opening_whitespace) =
         whitespaces_and_newlines(input, indentation + 1, false);
 
-    dbg!(&opening_whitespace);
-
     // If the string does not contain any newlines, parse the whitespace in
     // front of the string as part of the string and not as trailing whitespace.
     // This fixes https://github.com/candy-lang/candy/issues/896.
@@ -63,8 +61,6 @@ pub fn text(input: &str, indentation: usize) -> Option<(&str, Rcst)> {
                 whitespaces_and_newlines(input, indentation + 1, false);
             input = input_after_whitespace;
 
-            dbg!(input);
-
             let mut whitespace_before_closing_quote = if let Some(last_newline_index) = whitespace
                 .iter()
                 .enumerate()
@@ -80,15 +76,12 @@ pub fn text(input: &str, indentation: usize) -> Option<(&str, Rcst)> {
                 whitespace
             };
 
-            dbg!(&whitespace_before_closing_quote);
-
             // Allow closing quotes to have the same indentation level as the opening quotes
             let (input_after_whitespace, whitespace) = if newline(input).is_some() {
                 whitespaces_and_newlines(input, indentation, false)
             } else {
                 (input, Vec::new())
             };
-            dbg!(input_after_whitespace);
             let closing_quote = if let Some((input_after_double_quote, closing_double_quote)) =
                 double_quote(input_after_whitespace)
                 && let Some((input_after_single_quotes, closing_single_quotes)) = parse_multiple(
@@ -318,7 +311,10 @@ mod test {
               child: TextNewline "\n"
               whitespace:
                 Whitespace "  "
-            TextPart "  bar"
+            TrailingWhitespace:
+              child: TextPart "  bar"
+              whitespace:
+                Newline "\n"
           closing: ClosingText:
             closing_double_quote: DoubleQuote
             closing_single_quotes:
@@ -335,7 +331,10 @@ mod test {
               Newline "\n"
               Whitespace "  "
           parts:
-            TextPart "  text"
+            TrailingWhitespace:
+              child: TextPart "  text"
+              whitespace:
+                Newline "\n"
           closing: ClosingText:
             closing_double_quote: DoubleQuote
             closing_single_quotes:

--- a/compiler/frontend/src/string_to_rcst/whitespace.rs
+++ b/compiler/frontend/src/string_to_rcst/whitespace.rs
@@ -122,10 +122,7 @@ pub fn whitespaces_and_newlines(
     let mut new_input = input;
     let mut new_parts = vec![];
     let mut is_sufficiently_indented = true;
-    let mut current_indendation_level = 0;
-    println!("\ncalled with {input:?}, {indentation}\n");
     loop {
-        println!("indent: {current_indendation_level}/{indentation}");
         let new_input_from_iteration_start = new_input;
 
         if also_comments
@@ -140,27 +137,22 @@ pub fn whitespaces_and_newlines(
         }
 
         if let Some((new_new_input, newline)) = newline(new_input) {
-            current_indendation_level = 0;
             new_input = new_new_input;
             new_parts.push(newline);
             is_sufficiently_indented = false;
         }
-        if current_indendation_level < indentation
-            && let Some((new_new_input, whitespace)) = leading_indentation(new_input, indentation)
-        {
-            current_indendation_level += 1;
+        if let Some((new_new_input, whitespace)) = leading_indentation(new_input, indentation) {
             new_input = new_new_input;
             new_parts.push(whitespace);
 
             input = new_input;
             parts.append(&mut new_parts);
             is_sufficiently_indented = true;
-        } else if let Some((new_new_input, whitespace)) = single_line_whitespace(new_input) {
+        }
+        if let Some((new_new_input, whitespace)) = single_line_whitespace(new_input) {
             new_input = new_new_input;
             new_parts.push(whitespace);
         }
-
-        println!("new input after iter: {new_input:?}\n");
 
         if new_input == new_input_from_iteration_start {
             break;
@@ -239,16 +231,18 @@ mod test {
         assert_rich_ir_snapshot!(
             whitespaces_and_newlines("\n  foo", 0, true),
             @r###"
-        Remaining input: "  foo"
+        Remaining input: "foo"
         Parsed: Newline "\n"
+        Whitespace "  "
         "###
         );
         assert_rich_ir_snapshot!(
             whitespaces_and_newlines(" \n  foo", 0, true),
             @r###"
-        Remaining input: "  foo"
+        Remaining input: "foo"
         Parsed: Whitespace " "
         Newline "\n"
+        Whitespace "  "
         "###
         );
         assert_rich_ir_snapshot!(

--- a/compiler/frontend/src/string_to_rcst/whitespace.rs
+++ b/compiler/frontend/src/string_to_rcst/whitespace.rs
@@ -122,7 +122,10 @@ pub fn whitespaces_and_newlines(
     let mut new_input = input;
     let mut new_parts = vec![];
     let mut is_sufficiently_indented = true;
+    let mut current_indendation_level = 0;
+    println!("\ncalled with {input:?}, {indentation}\n");
     loop {
+        println!("indent: {current_indendation_level}/{indentation}");
         let new_input_from_iteration_start = new_input;
 
         if also_comments
@@ -137,12 +140,15 @@ pub fn whitespaces_and_newlines(
         }
 
         if let Some((new_new_input, newline)) = newline(new_input) {
+            current_indendation_level = 0;
             new_input = new_new_input;
             new_parts.push(newline);
             is_sufficiently_indented = false;
         }
-
-        if let Some((new_new_input, whitespace)) = leading_indentation(new_input, indentation) {
+        if current_indendation_level < indentation
+            && let Some((new_new_input, whitespace)) = leading_indentation(new_input, indentation)
+        {
+            current_indendation_level += 1;
             new_input = new_new_input;
             new_parts.push(whitespace);
 
@@ -153,6 +159,8 @@ pub fn whitespaces_and_newlines(
             new_input = new_new_input;
             new_parts.push(whitespace);
         }
+
+        println!("new input after iter: {new_input:?}\n");
 
         if new_input == new_input_from_iteration_start {
             break;


### PR DESCRIPTION
<!-- Please enter the corresponding issue ID: -->
Closes: #1016 

<!-- Please summarize your changes: -->
The problem was, that after parsing indentation whitespace-parsing was postponed. When the whitespaces consisted of two spaces, we first checked if you could parse indentation from the remaining input. Because of the two spaces you could, so more indentation was parsed. The solution was to not postpone whitespace-parsing and instead do it immediately after parsing indentation.

I am more or less sure the test cases look okay. If I were to choose, however, I would pick less. So, I would appreciate feedback.


### Checklist
<!-- Please check if your PR fulfills the following requirements: -->

- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
