### PR TITLE
Fix struct creation lowering

### DIFF
--- a/compiler_v4/src/ast_to_hir.rs
+++ b/compiler_v4/src/ast_to_hir.rs
@@ -1,9 +1,9 @@
 use crate::{
     ast::{
         Ast, AstArguments, AstAssignment, AstBody, AstCall, AstDeclaration, AstEnum, AstExpression,
-        AstExpressionKind, AstFunction, AstImpl, AstLambda, AstParameter, AstParameters, AstResult,
-        AstStatement, AstString, AstStruct, AstStructKind, AstSwitch, AstTextPart, AstTrait,
-        AstType, AstTypeParameter, AstTypeParameters,
+        AstExpressionKind, AstFunction, AstImpl, AstLambda, AstParameters, AstResult, AstStatement,
+        AstString, AstStruct, AstStructKind, AstSwitch, AstTextPart, AstTrait, AstType,
+        AstTypeParameter, AstTypeParameters,
     },
     error::CompilerError,
     hir::{
@@ -1107,7 +1107,7 @@ impl<'a> Context<'a> {
             .parameters
             .value()
             .map(|it| self.lower_parameters(&all_type_parameters, self_type, it))
-            .unwrap_or(Box::default());
+            .unwrap_or_default();
         let return_type = function.return_type.as_ref().map_or_else(
             || NamedType::nothing().into(),
             |it| self.lower_type(&all_type_parameters, self_type, it),
@@ -1685,7 +1685,7 @@ impl<'c, 'a> BodyBuilder<'c, 'a> {
                     LoweredExpression::Error => LoweredExpression::Error,
                 }
             }
-            AstExpressionKind::Lambda(AstLambda { parameters, .. }) => {
+            AstExpressionKind::Lambda(AstLambda { .. }) => {
                 todo!()
             }
             AstExpressionKind::Body(AstBody { statements, .. }) => {

--- a/compiler_v4/src/ast_to_hir.rs
+++ b/compiler_v4/src/ast_to_hir.rs
@@ -164,7 +164,13 @@ impl<'a> FunctionDeclaration<'a> {
             } else {
                 format!(
                     "[{}]",
-                    self.type_parameters.iter().map(|it| &it.name).join(", ")
+                    self.type_parameters
+                        .iter()
+                        .map(|it| it.upper_bound.as_ref().map_or_else(
+                            || it.name.to_string(),
+                            |upper_bound| format!("{}: {upper_bound}", it.name)
+                        ))
+                        .join(", ")
                 )
             },
             self.parameters

--- a/compiler_v4/src/ast_to_hir.rs
+++ b/compiler_v4/src/ast_to_hir.rs
@@ -2026,13 +2026,13 @@ impl<'c, 'a> BodyBuilder<'c, 'a> {
             }
         };
 
-        let struct_type = Type::Named(NamedType::new(
+        let struct_type = NamedType::new(
             type_,
             type_parameters
                 .iter()
                 .map(|it| substitutions[&it.type_()].clone())
                 .collect_vec(),
-        ));
+        );
         self.push_lowered(
             None,
             ExpressionKind::CreateStruct {
@@ -2228,7 +2228,7 @@ impl<'c, 'a> BodyBuilder<'c, 'a> {
         self.push(
             None,
             ExpressionKind::CreateStruct {
-                struct_: Type::nothing(),
+                struct_: NamedType::nothing(),
                 fields: [].into(),
             },
             Type::nothing(),

--- a/compiler_v4/src/ast_to_hir.rs
+++ b/compiler_v4/src/ast_to_hir.rs
@@ -26,7 +26,13 @@ use petgraph::{
     graph::{DiGraph, NodeIndex},
 };
 use rustc_hash::{FxHashMap, FxHashSet};
-use std::{collections::hash_map::Entry, iter, mem, ops::Range, path::Path};
+use std::{
+    collections::hash_map::Entry,
+    fmt::{self, Display, Formatter},
+    iter, mem,
+    ops::Range,
+    path::Path,
+};
 use strum::VariantArray;
 
 pub fn ast_to_hir(path: &Path, ast: &Ast) -> (Hir, Vec<CompilerError>) {
@@ -68,11 +74,13 @@ impl<'a> TraitDeclaration<'a> {
             .iter()
             .find(|(_, trait_function)| {
                 impl_function.name == trait_function.name
-                    && impl_function.type_parameters.len() == trait_function.type_parameters.len()
+                    && impl_function.signature.type_parameters.len()
+                        == trait_function.signature.type_parameters.len()
                     && impl_function
+                        .signature
                         .type_parameters
                         .iter()
-                        .zip(trait_function.type_parameters.iter())
+                        .zip(trait_function.signature.type_parameters.iter())
                         .all(|(function, signature)| {
                             function.upper_bound
                                 == signature
@@ -80,16 +88,21 @@ impl<'a> TraitDeclaration<'a> {
                                     .as_ref()
                                     .map(|it| it.as_ref().map(|it| it.substitute(substitutions)))
                         })
-                    && impl_function.parameters.len() == trait_function.parameters.len()
+                    && impl_function.signature.parameters.len()
+                        == trait_function.signature.parameters.len()
                     && impl_function
+                        .signature
                         .parameters
                         .iter()
-                        .zip(trait_function.parameters.iter())
+                        .zip(trait_function.signature.parameters.iter())
                         .all(|(function, signature)| {
                             function.type_ == signature.type_.substitute(substitutions)
                         })
-                    && impl_function.return_type
-                        == trait_function.return_type.substitute(substitutions)
+                    && impl_function.signature.return_type
+                        == trait_function
+                            .signature
+                            .return_type
+                            .substitute(substitutions)
             })
             .map(|(id, _)| *id)
     }
@@ -149,35 +162,12 @@ struct FunctionDeclaration<'a> {
     ast: Option<&'a AstFunction>,
     name: Box<str>,
     name_span: Option<Range<Offset>>,
-    type_parameters: Box<[TypeParameter]>,
-    parameters: Box<[Parameter]>,
-    return_type: Type,
+    signature: Signature,
     body: Option<BodyOrBuiltin>,
 }
 impl<'a> FunctionDeclaration<'a> {
     fn signature_to_string(&self) -> String {
-        format!(
-            "{}{}({})",
-            self.name,
-            if self.type_parameters.is_empty() {
-                String::new()
-            } else {
-                format!(
-                    "[{}]",
-                    self.type_parameters
-                        .iter()
-                        .map(|it| it.upper_bound.as_ref().map_or_else(
-                            || it.name.to_string(),
-                            |upper_bound| format!("{}: {upper_bound}", it.name)
-                        ))
-                        .join(", ")
-                )
-            },
-            self.parameters
-                .iter()
-                .map(|it| format!("{}: {}", it.name, it.type_))
-                .join(", "),
-        )
+        format!("{}{}", self.name, self.signature)
     }
 
     fn call_signature_to_string(function_name: &str, argument_types: &[Type]) -> String {
@@ -207,10 +197,42 @@ impl<'a> FunctionDeclaration<'a> {
     fn into_function_signature(self) -> FunctionSignature {
         FunctionSignature {
             name: self.name,
-            type_parameters: self.type_parameters,
-            parameters: self.parameters,
-            return_type: self.return_type,
+            type_parameters: self.signature.type_parameters,
+            parameters: self.signature.parameters,
+            return_type: self.signature.return_type,
         }
+    }
+}
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Signature {
+    pub type_parameters: Box<[TypeParameter]>,
+    pub parameters: Box<[Parameter]>,
+    pub return_type: Type,
+}
+impl Display for Signature {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "{}({})",
+            if self.type_parameters.is_empty() {
+                String::new()
+            } else {
+                format!(
+                    "[{}]",
+                    self.type_parameters
+                        .iter()
+                        .map(|it| it.upper_bound.as_ref().map_or_else(
+                            || it.name.to_string(),
+                            |upper_bound| format!("{}: {upper_bound}", it.name)
+                        ))
+                        .join(", ")
+                )
+            },
+            self.parameters
+                .iter()
+                .map(|it| format!("{}: {}", it.name, it.type_))
+                .join(", "),
+        )
     }
 }
 
@@ -326,14 +348,14 @@ impl<'a> Context<'a> {
                             "Main function may not be overloaded",
                         );
                         None
-                    } else if !function.parameters.is_empty() {
+                    } else if !function.signature.parameters.is_empty() {
                         self.add_error(
                             function.ast.unwrap().name.value().unwrap().span.clone(),
                             "Main function must not have parameters",
                         );
                         None
-                    } else if function.return_type != Type::Error
-                        && function.return_type != NamedType::int().into()
+                    } else if function.signature.return_type != Type::Error
+                        && function.signature.return_type != NamedType::int().into()
                     {
                         self.add_error(
                             function.ast.unwrap().name.value().unwrap().span.clone(),
@@ -380,9 +402,11 @@ impl<'a> Context<'a> {
                     ast: None,
                     name: signature.name.clone(),
                     name_span: None,
-                    type_parameters,
-                    parameters,
-                    return_type: signature.return_type,
+                    signature: Signature {
+                        type_parameters,
+                        parameters,
+                        return_type: signature.return_type,
+                    },
                     body: Some(BodyOrBuiltin::Builtin(*builtin_function)),
                 },
             );
@@ -1087,9 +1111,11 @@ impl<'a> Context<'a> {
             ast: Some(function),
             name: name.string.clone(),
             name_span: Some(name.span.clone()),
-            type_parameters,
-            parameters,
-            return_type,
+            signature: Signature {
+                type_parameters,
+                parameters,
+                return_type,
+            },
             body: None,
         })
     }
@@ -1133,14 +1159,17 @@ impl<'a> Context<'a> {
             return;
         }
 
-        let (hir_body, _) =
-            BodyBuilder::build(self, &function.type_parameters, self_type, |builder| {
-                for parameter in function.parameters.iter() {
+        let (hir_body, _) = BodyBuilder::build(
+            self,
+            &function.signature.type_parameters,
+            self_type,
+            |builder| {
+                for parameter in function.signature.parameters.iter() {
                     builder.push_parameter(parameter.clone());
                 }
 
                 if let Some(body) = function.ast.unwrap().body.as_ref() {
-                    builder.lower_statements(&body.body, Some(&function.return_type));
+                    builder.lower_statements(&body.body, Some(&function.signature.return_type));
                 } else {
                     builder.context.add_error(
                         function.ast.unwrap().display_span.clone(),
@@ -1148,7 +1177,8 @@ impl<'a> Context<'a> {
                     );
                     builder.push_panic("No function body provided");
                 }
-            });
+            },
+        );
 
         function.body = Some(BodyOrBuiltin::Body(hir_body));
     }
@@ -1916,6 +1946,7 @@ impl<'c, 'a> BodyBuilder<'c, 'a> {
                 (id, function.clone(), trait_.cloned())
             })
             .collect_vec();
+
         if matches.is_empty() {
             self.context.add_error(
                 name.span.clone(),
@@ -1924,261 +1955,206 @@ impl<'c, 'a> BodyBuilder<'c, 'a> {
             return LoweredExpression::Error;
         }
 
-        // Check type parameter count
-        let matches = if let Some((type_arguments, type_arguments_span)) = &type_arguments {
-            let (matches, mismatches) = matches.into_iter().partition::<Vec<_>, _>(|(_, it, _)| {
-                it.type_parameters.len() == type_arguments.len()
-            });
-            if matches.is_empty() {
-                self.context.add_error(
-                    type_arguments_span.clone(),
-                    format!(
-                        "No overload accepts exactly {} {}:\n{}",
-                        arguments.len(),
-                        if arguments.len() == 1 {
-                            "type argument"
-                        } else {
-                            "type arguments"
-                        },
-                        mismatches
-                            .iter()
-                            .map(|(_, it, _)| it.signature_to_string())
-                            .join("\n"),
-                    ),
-                );
-                return LoweredExpression::Error;
-            }
-            matches
-        } else {
-            matches
-        };
-
-        // TODO: show mismatches from previous steps
-
-        // Check parameter count
-        let matches = {
-            let (matches, mismatches) = matches
-                .into_iter()
-                .partition::<Vec<_>, _>(|(_, it, _)| it.parameters.len() == arguments.len());
-            if matches.is_empty() {
-                self.context.add_error(
-                    name.span.clone(),
-                    format!(
-                        "No overload accepts exactly {} {}:\n{}",
-                        arguments.len(),
-                        if arguments.len() == 1 {
-                            "argument"
-                        } else {
-                            "arguments"
-                        },
-                        mismatches
-                            .iter()
-                            .map(|(_, it, _)| it.signature_to_string())
-                            .join("\n"),
-                    ),
-                );
-                return LoweredExpression::Error;
-            }
-            matches
-        };
-
-        // Check argument types
         let argument_types = arguments
             .iter()
             .map(|(_, type_)| type_.clone())
             .collect::<Box<_>>();
-        let old_matches = matches;
-        let mut matches = vec![];
-        let mut mismatches = vec![];
-        'outer: for (id, function, solver_rule) in old_matches {
-            let mut unifier = TypeUnifier::new(&function.type_parameters);
-            // Type arguments
-            if let Some((type_arguments, _)) = &type_arguments {
-                for (type_argument, type_parameter) in type_arguments
-                    .iter()
-                    .zip_eq(function.type_parameters.iter())
-                {
-                    match unifier.unify(type_argument, &type_parameter.type_().into()) {
-                        Ok(true) => {}
-                        Ok(false) => unreachable!(),
-                        Err(reason) => {
-                            mismatches.push((id, function, Some(reason)));
-                            continue 'outer;
-                        }
-                    };
+
+        let (mut matches, mismatches): (Vec<_>, Vec<_>) = matches
+            .into_iter()
+            .map(|(id, function, trait_)| {
+                let result = self.match_signature(
+                    trait_
+                        .as_ref()
+                        .map(|it| (&it.solver_goal, it.solver_subgoals.as_ref())),
+                    &function.signature,
+                    type_arguments.as_ref().map(|(box it, _)| it),
+                    &argument_types,
+                );
+                match result {
+                    Ok(substitutions) => Ok((id, function, substitutions)),
+                    Err(error) => Err((function, error)),
                 }
-            }
-
-            // Arguments
-            for (argument_type, parameter) in
-                argument_types.iter().zip_eq(function.parameters.iter())
-            {
-                match unifier.unify(argument_type, &parameter.type_) {
-                    Ok(true) => {}
-                    Ok(false) => {
-                        mismatches.push((id, function, None));
-                        continue 'outer;
-                    }
-                    Err(reason) => {
-                        mismatches.push((id, function, Some(reason)));
-                        continue 'outer;
-                    }
-                };
-            }
-
-            match unifier.finish() {
-                Ok(substitutions) => matches.push((id, function, solver_rule, substitutions)),
-                Err(error) => mismatches.push((id, function, Some(error))),
-            }
-        }
+            })
+            .partition_result();
 
         if matches.is_empty() {
             self.context.add_error(
                 name.span.clone(),
                 format!(
                     "No matching function found for:\n  {}\n{}:{}",
-                    FunctionDeclaration::call_signature_to_string(
-                        mismatches.first().unwrap().1.name.as_ref(),
-                        argument_types.as_ref()
-                    ),
+                    FunctionDeclaration::call_signature_to_string(&name.string, &argument_types),
                     if mismatches.len() == 1 {
                         "This is the candidate function"
                     } else {
                         "These are candidate functions"
                     },
                     mismatches
-                        .iter()
-                        .map(|(_, it, reason)| format!(
-                            "\n• {}{}",
-                            it.signature_to_string(),
-                            reason
-                                .as_ref()
-                                .map_or_else(String::new, |reason| format!(" ({reason})")),
+                        .into_iter()
+                        .map(|(function, error)| format!(
+                            "\n• {}: {}",
+                            function.signature_to_string(),
+                            match error {
+                                CallLikeLoweringError::TypeArgumentCount =>
+                                    "Wrong number of type arguments".to_string(),
+                                CallLikeLoweringError::ArgumentCount =>
+                                    "Wrong number of arguments".to_string(),
+                                CallLikeLoweringError::Unification(Some(error)) =>
+                                    error.into_string(),
+                                CallLikeLoweringError::Unification(None) =>
+                                    "Mismatching types".to_string(),
+                                CallLikeLoweringError::FunctionReachableViaMultipleImpls =>
+                                    "Function is reachable via multiple impls".to_string(),
+                                // TODO: more specific error message
+                                CallLikeLoweringError::TypeArgumentMismatch =>
+                                    "Type arguments are not assignable".to_string(),
+                            },
                         ))
+                        .join(""),
+                ),
+            );
+            return LoweredExpression::Error;
+        } else if matches.len() > 1 {
+            self.context.add_error(
+                name.span.clone(),
+                format!(
+                    "Multiple matching function found for:\n  {}\nThese are candidate functions:{}",
+                    FunctionDeclaration::call_signature_to_string(&name.string, &argument_types),
+                    matches
+                        .iter()
+                        .map(|(_, function, _)| format!("\n• {}", function.signature_to_string()))
                         .join(""),
                 ),
             );
             return LoweredExpression::Error;
         }
 
-        // Solve traits
-        let mut matches = {
-            let old_matches = matches;
-            let mut matches = vec![];
-            let mut mismatches = vec![];
-            for (id, function, trait_, substitutions) in old_matches {
-                let self_goal =
-                    substitutions
-                        .get(&ParameterType::self_type())
-                        .map(|self_type| {
-                            trait_.as_ref().unwrap().solver_goal.substitute_all(
-                                &FxHashMap::from_iter([(
-                                    SolverVariable::self_(),
-                                    self_type.clone().try_into().unwrap(),
-                                )]),
-                            )
-                        });
-
-                let type_parameter_subgoals = function
-                    .type_parameters
-                    .iter()
-                    .filter_map(|it| it.clone().try_into().ok())
-                    .collect_vec();
-
-                let solver_substitutions = substitutions
-                    .iter()
-                    .filter_map(|(parameter_type, type_)| try {
-                        (
-                            SolverVariable::new(parameter_type.clone()),
-                            type_.clone().try_into().ok()?,
-                        )
-                    })
-                    .collect();
-
-                let used_rule = self_goal
-                    .iter()
-                    .chain(trait_.iter().flat_map(|it| it.solver_subgoals.iter()))
-                    .chain(type_parameter_subgoals.iter())
-                    .map(|subgoal| {
-                        let solution = self.context.environment.solve(
-                            &subgoal.substitute_all(&solver_substitutions),
-                            &self
-                                .type_parameters
-                                .iter()
-                                .filter_map(|it| it.clone().try_into().ok())
-                                .collect::<Box<[SolverGoal]>>(),
-                        );
-                        match solution {
-                            SolverSolution::Unique(solution) => Some(solution.used_rule),
-                            SolverSolution::Ambiguous => {
-                                // TODO: Add syntax to disambiguate trait function call on parameter types.
-                                self.context.add_error(
-                                    name.span.clone(),
-                                    format!(
-                                        "Function is reachable via multiple impls:\n{}",
-                                        function.signature_to_string(),
-                                    ),
-                                );
-                                None
-                            }
-                            SolverSolution::Impossible => None,
-                        }
-                    })
-                    .collect::<Option<Vec<_>>>();
-                if used_rule.is_some() {
-                    matches.push((id, function, substitutions));
-                } else {
-                    mismatches.push(function);
-                }
-            }
-            if matches.is_empty() {
-                // TODO: hide this error when there's an ambiguous solution
-                self.context.add_error(
-                    name.span.clone(),
-                    format!(
-                        "No function matches this signature:\n  {}\nThese are candidate functions:{}",
-                        FunctionDeclaration::call_signature_to_string(
-                            name.string.as_ref(),
-                            argument_types.as_ref()
-                        ),
-                        mismatches
-                            .iter()
-                            .map(|it| format!("\n• {}", it.signature_to_string()))
-                            .join(""),
-                    ),
-                );
-                return LoweredExpression::Error;
-            } else if matches.len() > 1 {
-                self.context.add_error(
-                    name.span.clone(),
-                    format!(
-                        "Multiple matching function found for:\n  {}\nThese are candidate functions:{}",
-                        FunctionDeclaration::call_signature_to_string(
-                            name.string.as_ref(),
-                            argument_types.as_ref()
-                        ),
-                        matches
-                            .iter()
-                            .map(|(_, it, _)| format!("\n• {}", it.signature_to_string()))
-                            .join(""),
-                    ),
-                );
-                return LoweredExpression::Error;
-            }
-            matches
-        };
-
-        let (function, signature, substitutions) = matches.pop().unwrap();
-        let return_type = signature.return_type.substitute(&substitutions);
+        let (id, function, substitutions) = matches.pop().unwrap();
+        let return_type = function.signature.return_type.substitute(&substitutions);
         self.push_lowered(
             None,
             ExpressionKind::Call {
-                function,
+                function: id,
                 substitutions,
                 arguments: arguments.iter().map(|(id, _)| *id).collect(),
             },
             return_type,
         )
+    }
+    fn match_signature(
+        &mut self,
+        trait_goal_and_subgoals: Option<(&SolverGoal, &[SolverGoal])>,
+        signature: &Signature,
+        type_arguments: Option<&[Type]>,
+        argument_types: &[Type],
+    ) -> Result<FxHashMap<ParameterType, Type>, CallLikeLoweringError> {
+        // Check type argument count
+        if let Some(type_arguments) = type_arguments
+            && type_arguments.len() != signature.type_parameters.len()
+        {
+            return Err(CallLikeLoweringError::TypeArgumentCount);
+        }
+
+        // Check argument count
+        if argument_types.len() != signature.parameters.len() {
+            return Err(CallLikeLoweringError::ArgumentCount);
+        }
+
+        // Check argument types
+        let substitutions = {
+            let mut unifier = TypeUnifier::new(&signature.type_parameters);
+            // Type arguments
+            if let Some(type_arguments) = type_arguments {
+                for (type_argument, type_parameter) in type_arguments
+                    .iter()
+                    .zip_eq(signature.type_parameters.iter())
+                {
+                    match unifier.unify(type_argument, &type_parameter.type_().into()) {
+                        Ok(true) => {}
+                        Ok(false) => unreachable!(),
+                        Err(reason) => {
+                            return Err(CallLikeLoweringError::Unification(Some(reason)))
+                        }
+                    }
+                }
+            }
+
+            // Arguments
+            for (argument_type, parameter) in
+                argument_types.iter().zip_eq(signature.parameters.iter())
+            {
+                match unifier.unify(argument_type, &parameter.type_) {
+                    Ok(true) => {}
+                    Ok(false) => return Err(CallLikeLoweringError::Unification(None)),
+                    Err(reason) => return Err(CallLikeLoweringError::Unification(Some(reason))),
+                }
+            }
+
+            match unifier.finish() {
+                Ok(substitutions) => substitutions,
+                Err(error) => return Err(CallLikeLoweringError::Unification(Some(error))),
+            }
+        };
+
+        // Solve traits
+        {
+            let self_goal = substitutions
+                .get(&ParameterType::self_type())
+                .map(|self_type| {
+                    trait_goal_and_subgoals
+                        .unwrap()
+                        .0
+                        .substitute_all(&FxHashMap::from_iter([(
+                            SolverVariable::self_(),
+                            self_type.clone().try_into().unwrap(),
+                        )]))
+                });
+
+            let type_parameter_subgoals = signature
+                .type_parameters
+                .iter()
+                .filter_map(|it| it.clone().try_into().ok())
+                .collect_vec();
+
+            let solver_substitutions = substitutions
+                .iter()
+                .filter_map(|(parameter_type, type_)| try {
+                    (
+                        SolverVariable::new(parameter_type.clone()),
+                        type_.clone().try_into().ok()?,
+                    )
+                })
+                .collect();
+
+            let error = self_goal
+                .iter()
+                .chain(trait_goal_and_subgoals.iter().flat_map(|it| it.1.iter()))
+                .chain(type_parameter_subgoals.iter())
+                .find_map(|subgoal| {
+                    let solution = self.context.environment.solve(
+                        &subgoal.substitute_all(&solver_substitutions),
+                        &self
+                            .type_parameters
+                            .iter()
+                            .filter_map(|it| it.clone().try_into().ok())
+                            .collect::<Box<[SolverGoal]>>(),
+                    );
+                    match solution {
+                        SolverSolution::Unique(_) => None,
+                        SolverSolution::Ambiguous => {
+                            Some(CallLikeLoweringError::FunctionReachableViaMultipleImpls)
+                        }
+                        SolverSolution::Impossible => {
+                            Some(CallLikeLoweringError::TypeArgumentMismatch)
+                        }
+                    }
+                });
+            if let Some(error) = error {
+                return Err(error);
+            }
+        }
+
+        Ok(substitutions)
     }
 
     fn push_panic(&mut self, message: impl Into<Box<str>>) {
@@ -2271,6 +2247,14 @@ enum LoweredExpression {
 //     Error,
 // }
 
+enum CallLikeLoweringError {
+    TypeArgumentCount,
+    ArgumentCount,
+    Unification(Option<Box<str>>),
+    FunctionReachableViaMultipleImpls,
+    TypeArgumentMismatch,
+}
+
 pub struct TypeUnifier<'h> {
     type_parameters: &'h [TypeParameter],
     substitutions: FxHashMap<ParameterType, Type>,
@@ -2302,6 +2286,7 @@ impl<'h> TypeUnifier<'h> {
                 Ok(true)
             }
             (Type::Named(argument), Type::Named(parameter)) => {
+                // TODO: change `Ok(false)` to and `Err`
                 if argument.name != parameter.name
                     || argument.type_arguments.len() != parameter.type_arguments.len()
                 {

--- a/compiler_v4/src/ast_to_hir.rs
+++ b/compiler_v4/src/ast_to_hir.rs
@@ -180,7 +180,10 @@ impl<'a> FunctionDeclaration<'a> {
 
     #[must_use]
     fn into_trait_function(mut self) -> TraitFunction {
-        let body = mem::take(&mut self.body);
+        let body = mem::take(&mut self.body).map(|it| match it {
+            BodyOrBuiltin::Body(body) => body,
+            BodyOrBuiltin::Builtin(_) => panic!("Trait functions may not be built-in"),
+        });
         TraitFunction {
             signature: self.into_function_signature(),
             body,

--- a/compiler_v4/src/hir.rs
+++ b/compiler_v4/src/hir.rs
@@ -216,7 +216,7 @@ impl Display for Trait {
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct TraitFunction {
     pub signature: FunctionSignature,
-    pub body: Option<BodyOrBuiltin>,
+    pub body: Option<Body>,
 }
 impl ToText for (&Id, &TraitFunction) {
     fn build_text(&self, builder: &mut TextBuilder) {
@@ -224,12 +224,7 @@ impl ToText for (&Id, &TraitFunction) {
         self.1.signature.build_text(builder);
         if let Some(body) = &self.1.body {
             builder.push(" ");
-            match body {
-                BodyOrBuiltin::Body(body) => body.build_text(builder),
-                BodyOrBuiltin::Builtin(builtin_function) => {
-                    builder.push(format!("= {builtin_function:?}"));
-                }
-            }
+            body.build_text(builder);
         }
     }
 }

--- a/compiler_v4/src/hir.rs
+++ b/compiler_v4/src/hir.rs
@@ -67,21 +67,6 @@ pub struct Hir {
     pub functions: FxHashMap<Id, Function>,
     pub main_function_id: Id,
 }
-impl Hir {
-    pub fn get_function(&self, id: Id) -> (&FunctionSignature, Option<&BodyOrBuiltin>) {
-        self.functions
-            .get(&id)
-            .or_else(|| self.impls.iter().find_map(|it| it.functions.get(&id)))
-            .map(|it| (&it.signature, Some(&it.body)))
-            .or_else(|| {
-                self.traits
-                    .values()
-                    .find_map(|it| it.functions.get(&id))
-                    .map(|it| (&it.signature, it.body.as_ref()))
-            })
-            .unwrap()
-    }
-}
 impl ToText for Hir {
     fn build_text(&self, builder: &mut TextBuilder) {
         for (name, declaration) in self

--- a/compiler_v4/src/hir.rs
+++ b/compiler_v4/src/hir.rs
@@ -561,7 +561,7 @@ impl Expression {
     pub fn nothing() -> Self {
         Self {
             kind: ExpressionKind::CreateStruct {
-                struct_: Type::nothing(),
+                struct_: NamedType::nothing(),
                 fields: [].into(),
             },
             type_: Type::nothing(),
@@ -574,7 +574,7 @@ pub enum ExpressionKind {
     Int(i64),
     Text(Box<str>),
     CreateStruct {
-        struct_: Type,
+        struct_: NamedType,
         fields: Box<[Id]>,
     },
     StructAccess {

--- a/compiler_v4/src/hir_to_mono.rs
+++ b/compiler_v4/src/hir_to_mono.rs
@@ -399,7 +399,7 @@ impl<'c, 'h> BodyBuilder<'c, 'h> {
                 );
             }
             hir::ExpressionKind::CreateStruct { struct_, fields } => {
-                let struct_ = self.context.lower_type(struct_);
+                let struct_ = self.context.lower_type(&struct_.clone().into());
                 let fields = self.lower_ids(fields);
                 self.push(
                     id,

--- a/compiler_v4/src/mono_to_c.rs
+++ b/compiler_v4/src/mono_to_c.rs
@@ -30,6 +30,10 @@ impl<'h> Context<'h> {
         self.push("#include <stdlib.h>\n");
         self.push("#include <string.h>\n\n");
 
+        self.push("/// Type Forward Declarations\n\n");
+        self.lower_type_forward_declarations();
+        self.push("\n");
+
         self.push("/// Type Declarations\n\n");
         self.lower_type_declarations();
         self.push("\n");
@@ -59,6 +63,11 @@ impl<'h> Context<'h> {
         ));
     }
 
+    fn lower_type_forward_declarations(&mut self) {
+        for name in self.mono.type_declarations.keys() {
+            self.push(format!("typedef struct {name} {name};\n"));
+        }
+    }
     fn lower_type_declarations(&mut self) {
         for (name, declaration) in &self.mono.type_declarations {
             self.push(format!("struct {name} {{\n"));
@@ -109,7 +118,6 @@ impl<'h> Context<'h> {
                     self.push("} value;\n};\n");
                 }
             }
-            self.push(format!("typedef struct {name} {name};\n"));
         }
     }
 

--- a/compiler_v4/src/string_to_ast/expression.rs
+++ b/compiler_v4/src/string_to_ast/expression.rs
@@ -44,7 +44,7 @@ pub fn expression(parser: Parser) -> Option<(Parser, AstExpression)> {
         .or_else(|| body(parser).map(|(parser, it)| (parser, AstExpressionKind::Body(it))))
         .or_else(|| switch(parser).map(|(parser, it)| (parser, AstExpressionKind::Switch(it))))?;
     let span = start_offset..parser.offset();
-    let mut result = AstExpression { kind, span };
+    let mut result = AstExpression { span, kind };
 
     loop {
         fn parse_suffix<'a>(

--- a/packages_v5/example.candy
+++ b/packages_v5/example.candy
@@ -161,14 +161,6 @@ let valueWithoutExplicitType = 42
 # }
 # aDate.add(Duration(days: 1)) # is equivalent to `add(aDate, Duration(days: 1))`
 
-fun isLessThan(a: Int, b: Int) Bool {
-  switch a.compareTo(b) {
-    less => true,
-    equal => false,
-    greater => false,
-  }
-}
-
 # fun twar() Int {
 #  foo
 #     bar

--- a/packages_v5/minimal.candy
+++ b/packages_v5/minimal.candy
@@ -3,19 +3,7 @@ enum Never {}
 struct Int = builtin
 struct Text = builtin
 
-trait ToText {
-  fun toText(self: Self) Text
-}
-impl Int: ToText {
-  fun toText(self: Int) Text {
-    builtinIntToText(self)
-  }
-}
-fun print[T: ToText](t: T) {
-  builtinPrint(t.toText())
-}
-
 fun main() Int {
-  print(42)
+  builtinPrint(42.builtinIntToText())
   0
 }

--- a/packages_v5/minimal.candy
+++ b/packages_v5/minimal.candy
@@ -1,36 +1,21 @@
+struct Nothing {}
+enum Never {}
+struct Int = builtin
+struct Text = builtin
+
 trait ToText {
   fun toText(self: Self) Text
 }
-
-fun printToText[T: ToText](t: T) {
-  print(t.toText())
-}
-
-struct Nothing {}
-enum Never {}
-
-enum Bool { true, false }
-impl Bool: ToText {
-  fun toText(self: Bool) Text {
-    switch self {
-      true => "true",
-      false => "false",
-    }
+impl Int: ToText {
+  fun toText(self: Int) Text {
+    builtinIntToText(self)
   }
 }
-
-enum Ordering { less, equal, greater }
-impl Ordering: ToText {
-  fun toText(self: Ordering) Text {
-    switch self {
-      less => "less",
-      equal => "equal",
-      greater => "greater",
-    }
-  }
+fun print[T: ToText](t: T) {
+  builtinPrint(t.toText())
 }
 
 fun main() Int {
-  printToText(Bool.true)
+  print(42)
   0
 }


### PR DESCRIPTION
The following now compiles and works as expected:

```candy
struct Tuple2[T, U: ToText] {
  first: T,
  second: U,
}

fun main() Int {
  Tuple2(42, "foo")
  0
}
```