### PR TITLE
Fix enum creation lowering

### DIFF
--- a/compiler_v4/src/ast_to_hir.rs
+++ b/compiler_v4/src/ast_to_hir.rs
@@ -7,10 +7,10 @@ use crate::{
     },
     error::CompilerError,
     hir::{
-        self, Assignment, Body, BodyOrBuiltin, BuiltinFunction, Expression, ExpressionKind,
-        Function, FunctionSignature, Hir, Id, Impl, NamedType, Parameter, ParameterType,
-        SliceOfTypeParameter, SwitchCase, Trait, TraitDefinition, TraitFunction, Type,
-        TypeDeclaration, TypeDeclarationKind, TypeParameter,
+        self, Assignment, Body, BodyOrBuiltin, BuiltinFunction, ContainsError, Expression,
+        ExpressionKind, Function, FunctionSignature, Hir, Id, Impl, NamedType, Parameter,
+        ParameterType, SliceOfTypeParameter, SwitchCase, Trait, TraitDefinition, TraitFunction,
+        Type, TypeDeclaration, TypeDeclarationKind, TypeParameter,
     },
     id::IdGenerator,
     position::Offset,
@@ -1836,6 +1836,10 @@ impl<'c, 'a> BodyBuilder<'c, 'a> {
             .iter()
             .map(|(_, type_)| type_.clone())
             .collect::<Box<_>>();
+
+        if argument_types.iter().any(ContainsError::contains_error) {
+            return LoweredExpression::Error;
+        }
 
         let (mut matches, mismatches): (Vec<_>, Vec<_>) = matches
             .into_iter()

--- a/compiler_v4/src/hir.rs
+++ b/compiler_v4/src/hir.rs
@@ -301,6 +301,8 @@ impl ToText for TypeParameter {
     }
 }
 
+// Type
+
 #[derive(Clone, Debug, Eq, From, Hash, PartialEq)]
 pub enum Type {
     // TODO: encode ADT, trait, or builtin type here
@@ -449,6 +451,27 @@ impl Display for NamedType {
             write!(f, "[{}]", self.type_arguments.iter().join(", "))?;
         }
         std::result::Result::Ok(())
+    }
+}
+
+pub trait ContainsError {
+    fn contains_error(&self) -> bool;
+}
+impl ContainsError for Type {
+    fn contains_error(&self) -> bool {
+        match self {
+            Self::Named(named_type) => named_type.contains_error(),
+            Self::Parameter(_) => false,
+            Self::Self_ { base_type } => base_type.contains_error(),
+            Self::Error => true,
+        }
+    }
+}
+impl ContainsError for NamedType {
+    fn contains_error(&self) -> bool {
+        self.type_arguments
+            .iter()
+            .any(ContainsError::contains_error)
     }
 }
 

--- a/compiler_v4/src/hir.rs
+++ b/compiler_v4/src/hir.rs
@@ -582,7 +582,7 @@ pub enum ExpressionKind {
         field: Box<str>,
     },
     CreateEnum {
-        enum_: Type,
+        enum_: NamedType,
         variant: Box<str>,
         value: Option<Id>,
     },

--- a/compiler_v4/src/mono_to_c.rs
+++ b/compiler_v4/src/mono_to_c.rs
@@ -332,7 +332,7 @@ impl<'h> Context<'h> {
                 ));
                 self.push(format!("{id}->variant = {enum_}_{variant};"));
                 if let Some(value) = value {
-                    self.push(format!("\n{id}->value = {value}"));
+                    self.push(format!("\n{id}->value.{variant} = {value};"));
                 }
             }
             // ExpressionKind::Lambda(lambda) => {

--- a/compiler_v4/src/string_to_ast/declarations.rs
+++ b/compiler_v4/src/string_to_ast/declarations.rs
@@ -15,7 +15,9 @@ use super::{
     word::raw_identifier,
 };
 use crate::ast::{
-    AstAssignment, AstDeclaration, AstEnum, AstEnumVariant, AstError, AstFunction, AstImpl, AstParameter, AstParameters, AstString, AstStruct, AstStructField, AstStructKind, AstTrait, AstTypeParameter, AstTypeParameters
+    AstAssignment, AstDeclaration, AstEnum, AstEnumVariant, AstError, AstFunction, AstImpl,
+    AstParameter, AstParameters, AstString, AstStruct, AstStructField, AstStructKind, AstTrait,
+    AstTypeParameter, AstTypeParameters,
 };
 use tracing::instrument;
 
@@ -329,7 +331,8 @@ fn function<'a>(parser: Parser) -> Option<(Parser, AstFunction)> {
     let display_span = name.value().map_or(fun_keyword_span, |it| it.span.clone());
 
     let (parser, type_parameters) = type_parameters(parser).optional(parser);
-    let (parser, parameters) = parameters(parser).unwrap_or_ast_error(parser, "Expected parameters");
+    let (parser, parameters) =
+        parameters(parser).unwrap_or_ast_error(parser, "Expected parameters");
     let (parser, return_type) = type_(parser).optional(parser).and_trailing_whitespace();
     let (parser, body) = body(parser).optional(parser);
 
@@ -347,13 +350,13 @@ fn function<'a>(parser: Parser) -> Option<(Parser, AstFunction)> {
 }
 #[instrument(level = "trace")]
 pub fn parameters<'a>(parser: Parser) -> Option<(Parser, AstParameters)> {
-    let mut parser = opening_parenthesis(parser)?
-        .and_trailing_whitespace();
+    let mut parser = opening_parenthesis(parser)?.and_trailing_whitespace();
 
     let mut parameters: Vec<AstParameter> = vec![];
     // TODO: error on duplicate parameter names
     let mut parser_for_missing_comma_error: Option<Parser> = None;
-    while let Some((new_parser, parameter, new_parser_for_missing_comma_error)) = parameter(parser) {
+    while let Some((new_parser, parameter, new_parser_for_missing_comma_error)) = parameter(parser)
+    {
         if let Some(parser_for_missing_comma_error) = parser_for_missing_comma_error {
             parameters.last_mut().unwrap().comma_error = Some(
                 parser_for_missing_comma_error
@@ -368,9 +371,18 @@ pub fn parameters<'a>(parser: Parser) -> Option<(Parser, AstParameters)> {
 
     let (parser, closing_parenthesis_error) = closing_parenthesis(parser)
         .and_trailing_whitespace()
-        .unwrap_or_ast_error(parser, "This parameter list is missing a closing parenthesis.");
+        .unwrap_or_ast_error(
+            parser,
+            "This parameter list is missing a closing parenthesis.",
+        );
 
-    Some((parser, AstParameters { parameters, closing_parenthesis_error }))
+    Some((
+        parser,
+        AstParameters {
+            parameters,
+            closing_parenthesis_error,
+        },
+    ))
 }
 #[instrument(level = "trace")]
 fn parameter<'a>(parser: Parser) -> Option<(Parser, AstParameter, Option<Parser>)> {

--- a/compiler_v4/src/string_to_ast/declarations.rs
+++ b/compiler_v4/src/string_to_ast/declarations.rs
@@ -138,7 +138,9 @@ fn enum_<'a>(parser: Parser) -> Option<(Parser, AstEnum)> {
         .and_trailing_whitespace()
         .unwrap_or_ast_error_result(parser, "This enum is missing a name.");
 
-    let (parser, type_parameters) = type_parameters(parser).optional(parser);
+    let (parser, type_parameters) = type_parameters(parser)
+        .and_trailing_whitespace()
+        .optional(parser);
 
     let (mut parser, opening_curly_brace_error) = opening_curly_brace(parser)
         .and_trailing_whitespace()

--- a/packages_v5/example.candy
+++ b/packages_v5/example.candy
@@ -129,6 +129,25 @@ impl Bool: ToText {
   }
 }
 
+enum Maybe[T] {
+  some: T,
+  none,
+}
+fun some[T](value: T) Maybe[T] {
+  Maybe.some(value)
+}
+fun none[T]() Maybe[T] {
+  Maybe.none[T]()
+}
+# impl[T] Maybe[T]: ToText {
+#   fun toText(self: Maybe[T]) Text {
+#     switch self {
+#       some(value) => "some({value.toText()})",
+#       none => "none()",
+#     }
+#   }
+# }
+
 enum MyEnum {
   foo: Int,
   bar,

--- a/packages_v5/example.candy
+++ b/packages_v5/example.candy
@@ -118,8 +118,8 @@ struct MyStruct {
 }
 
 enum Bool { true, false }
-let true: Bool = Bool.true
-let false: Bool = Bool.false
+let true: Bool = Bool.true()
+let false: Bool = Bool.false()
 impl Bool: ToText {
   fun toText(self: Bool) Text {
     switch self {
@@ -196,7 +196,7 @@ fun main() Int {
 #
 #  theAnswer
   print("fibonacci(20) = {fibonacci(20).toText()}")
-  print(Ordering.less)
+  print(Ordering.less())
   print(true)
   print(false)
   0

--- a/packages_v5/example.candy
+++ b/packages_v5/example.candy
@@ -190,7 +190,7 @@ let valueWithoutExplicitType = 42
 #}
 
 fun fibonacci(n: Int) Int {
-  switch isLessThan(n, 2) {
+  switch n.isLessThan(2) {
     true => n,
     false => fibonacci(n.subtract(1)).add(fibonacci(n.subtract(2))),
   }


### PR DESCRIPTION
Similar to #1058, but for enums. We now have `Maybe[T]` and can instantiate it